### PR TITLE
Speak symbols 'text' property if provided instead of 'label'.

### DIFF
--- a/src/containers/Board/Board.js
+++ b/src/containers/Board/Board.js
@@ -109,7 +109,7 @@ export class Board extends Component {
       default:
         const { intl } = this.props;
         this.outputPush(symbol);
-        this.speak(intl.formatMessage({ id: symbol.label }));
+        this.speak(intl.formatMessage({ id: symbol.text || symbol.label }));
     }
   };
 


### PR DESCRIPTION
Fixes #33