### PR TITLE
Added speech settings for pitch and rate.

### DIFF
--- a/src/containers/Settings/Speech/Speech.js
+++ b/src/containers/Settings/Speech/Speech.js
@@ -1,23 +1,60 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import compose from 'recompose/compose';
+import { withStyles } from 'material-ui/styles';
 import { injectIntl, FormattedMessage } from 'react-intl';
-import List, {
-  ListItem,
-  ListItemText,
-  ListItemSecondaryAction
-} from 'material-ui/List';
+import Button from 'material-ui/Button';
+import List, { ListItem, ListItemText } from 'material-ui/List';
 import Menu, { MenuItem } from 'material-ui/Menu';
-import IconButton from 'material-ui/IconButton';
-import AddIcon from 'material-ui-icons/Add';
-import RemoveIcon from 'material-ui-icons/Remove';
+import { LinearProgress } from 'material-ui/Progress';
 
-import messages from './messages';
+// Icons
+import ArrowDownwardIcon from 'material-ui-icons/ArrowDownward';
+import ArrowUpwardIcon from 'material-ui-icons/ArrowUpward';
+import FastForwardIcon from 'material-ui-icons/FastForward';
+import FastRewindIcon from 'material-ui-icons/FastRewind';
+
 import { changeVoice, changePitch, changeRate } from '../../../speech/actions';
 import speech from '../../../speech';
 import FullScreenDialog from '../../../components/FullScreenDialog';
+import messages from './messages';
+
+const MIN_PITCH = 0.0;
+const MAX_PITCH = 2.0;
+const INCREMENT_PITCH = 0.25;
+const MIN_RATE = 0.0;
+const MAX_RATE = 2.0;
+const INCREMENT_RATE = 0.25;
+
+const styles = theme => ({
+  container: {
+    flexGrow: 1,
+    display: 'flex',
+    position: 'relative',
+  },
+  icon: {
+    marginLeft: 3,
+    marginRight: 3,
+    width: 20,
+  },
+  progress: {
+    paddingLeft: 2,
+    paddingRight: 2,
+    maxWidth: '50%',
+    minWidth: '20%',
+    marginTop: 20,
+  },
+});
+
+const getProgressPercent = (value, min, max) => Math.round(((value - min)/(max - min))*100.0);
+const speakSampleMessage = (intl) => {
+  const text = intl.formatMessage(messages.sampleSentence);
+  speech.speak(text);
+};
 
 export class Speech extends PureComponent {
+
   constructor(props) {
     super(props);
 
@@ -34,9 +71,20 @@ export class Speech extends PureComponent {
   handleMenuItemClick = ({ voiceURI, lang }) => {
     const { changeVoice, intl } = this.props;
     changeVoice(voiceURI, lang);
-    const text = intl.formatMessage(messages.sampleSentence);
-    speech.speak(text);
+    speakSampleMessage(intl);
     this.setState({ voiceOpen: false });
+  };
+
+  handleChangePitch = (value) => {
+    const { changePitch, intl } = this.props;
+    changePitch(value);
+    speakSampleMessage(intl);
+  };
+
+  handleChangeRate = (value) => {
+    const { changeRate, intl } = this.props;
+    changeRate(value);
+    speakSampleMessage(intl);
   };
 
   handleVoiceRequestClose = () => {
@@ -44,7 +92,18 @@ export class Speech extends PureComponent {
   };
 
   render() {
-    const { open, locale, onCancel, speech: { voices, voiceURI } } = this.props;
+    const {
+      open,
+      locale,
+      onCancel,
+      speech: {
+        voices,
+        voiceURI,
+        pitch,
+        rate
+      },
+      classes,
+    } = this.props;
 
     const localeVoices = voices.filter(
       voice => voice.lang.slice(0, 2) === locale
@@ -68,16 +127,63 @@ export class Speech extends PureComponent {
             >
               <ListItemText primary="Voice" secondary={voiceURI} />
             </ListItem>
-            <ListItem button divider>
-              <ListItemText primary="Pitch" secondary="Change pitch" />
-              <ListItemSecondaryAction>
-                <IconButton>
-                  <RemoveIcon />
-                </IconButton>
-                <IconButton>
-                  <AddIcon />
-                </IconButton>
-              </ListItemSecondaryAction>
+            <ListItem
+              aria-label="Pitch"
+            >
+              <ListItemText primary="Pitch" secondary="Raise or lower the pitch for the voice" />
+              <div className={classes.container}>
+                <Button
+                  color="primary"
+                  aria-label="Lower Pitch"
+                  disabled={ pitch <= MIN_PITCH }                  
+                  onClick={() => this.handleChangePitch(pitch - INCREMENT_PITCH)}
+                >
+                  Lower <ArrowDownwardIcon className={classes.icon} />
+                </Button>
+                <div className={classes.progress}>
+                  <LinearProgress
+                    mode="determinate"
+                    value={getProgressPercent(pitch, MIN_PITCH, MAX_PITCH)}
+                  />
+                </div>
+                <Button
+                  color="primary"
+                  aria-label="Raise Pitch"
+                  disabled={ pitch >= MAX_PITCH }
+                  onClick={() => this.handleChangePitch(pitch + INCREMENT_PITCH)}                  
+                >
+                  <ArrowUpwardIcon className={classes.icon} /> Higher
+                </Button>
+              </div>
+            </ListItem>
+            <ListItem
+              aria-label="Rate"
+            >
+              <ListItemText primary="Rate" secondary="Make the voice speak faster or slower" />
+              <div className={classes.container}>
+                <Button
+                  color="primary"
+                  aria-label="Slower Rate"
+                  disabled={ rate <= MIN_RATE }                  
+                  onClick={() => this.handleChangeRate(rate - INCREMENT_RATE)}                  
+                >
+                  Slower <FastRewindIcon className={classes.icon} />
+                </Button>
+                <div className={classes.progress}>
+                  <LinearProgress
+                    mode="determinate"
+                    value={getProgressPercent(rate, MIN_RATE, MAX_RATE)}
+                  />
+                </div>
+                <Button
+                  color="primary"
+                  aria-label="Faster Rate"
+                  disabled={ rate >= MAX_RATE }
+                  onClick={() => this.handleChangeRate(rate + INCREMENT_RATE)}                  
+                >
+                  <FastForwardIcon className={classes.icon} /> Faster
+                </Button>
+              </div>
             </ListItem>
           </List>
           <Menu
@@ -104,13 +210,13 @@ export class Speech extends PureComponent {
 
 Speech.propTypes = {
   open: PropTypes.bool,
-  activeTextToSpeech: PropTypes.string,
   locale: PropTypes.string,
-  voices: PropTypes.array,
   speech: PropTypes.object,
+  voices: PropTypes.array,  
+  onCancel: PropTypes.func,
   changeVoice: PropTypes.func,
   changePitch: PropTypes.func,
-  changeRate: PropTypes.func
+  changeRate: PropTypes.func,
 };
 
 const mapStateToProps = state => {
@@ -126,13 +232,14 @@ export function mapDispatchToProps(dispatch) {
     changeVoice: (voiceURI, lang) => {
       dispatch(changeVoice(voiceURI, lang));
     },
-    changePitch: pitch => {
+    changePitch: (pitch) => {
       dispatch(changePitch(pitch));
     },
-    changeRate: rate => {
+    changeRate: (rate) => {
       dispatch(changeRate(rate));
-    }
+    },
   };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(injectIntl(Speech));
+const EnhancedSpeech = compose(injectIntl, withStyles(styles))(Speech);
+export default connect(mapStateToProps, mapDispatchToProps)(EnhancedSpeech);

--- a/src/speech/reducer.js
+++ b/src/speech/reducer.js
@@ -10,8 +10,8 @@ const initialState = {
   voices: [],
   voiceURI: null,
   lang: '',
-  pitch: 1,
-  rate: 1,
+  pitch: 1.0,
+  rate: 1.0,
   volume: 1
 };
 


### PR DESCRIPTION
This PR addresses Issue #23 by allowing a user to choose the pitch & rate of the selected voice, within the bounds of the fixed 0 to 2 range. Value is adjust in increments of 0.25 and displayed to usual with visual feedback using a progress bar.

On each change, the sample sentence is spoken in the new configuration so user can evaluate the desired pitch & rate.

TODO:

- [ ] Replace static text with i18n messages