### PR TITLE
fix(translation): Fallback to en-US if the user language has not be translated

### DIFF
--- a/src/components/LanguageProvider/LanguageProvider.container.js
+++ b/src/components/LanguageProvider/LanguageProvider.container.js
@@ -74,7 +74,7 @@ export class LanguageProvider extends Component {
         this.setState({ messages });
       })
       .catch(() => {
-        changeLang('en-US');
+        changeLang(DEFAULT_LANG);
         showNotification(`A ${lang} translation was not found, so the language was set to English (en-US).
           Go to Settings if you want to change it.`);
       });

--- a/src/components/LanguageProvider/LanguageProvider.container.js
+++ b/src/components/LanguageProvider/LanguageProvider.container.js
@@ -5,6 +5,7 @@ import { IntlProvider } from 'react-intl';
 
 import { APP_LANGS, DEFAULT_LANG } from '../App/App.constants';
 import { changeLang, setLangs } from './LanguageProvider.actions';
+import { showNotification } from '../Notifications/Notifications.actions';
 import { importTranslation } from '../../i18n';
 
 export class LanguageProvider extends Component {
@@ -64,11 +65,19 @@ export class LanguageProvider extends Component {
   }
 
   fetchMessages(lang) {
+    const { changeLang, showNotification } = this.props;
+
     this.setState({ messages: null });
 
-    importTranslation(lang).then(messages => {
-      this.setState({ messages });
-    });
+    importTranslation(lang)
+      .then(messages => {
+        this.setState({ messages });
+      })
+      .catch(() => {
+        changeLang('en-US');
+        showNotification(`A ${lang} translation was not found, so the language was set to English (en-US).
+          Go to Settings if you want to change it.`);
+      });
   }
 
   render() {
@@ -98,6 +107,9 @@ const mapDispatchToProps = dispatch => ({
   },
   changeLang: lang => {
     dispatch(changeLang(lang));
+  },
+  showNotification: text => {
+    dispatch(showNotification(text));
   }
 });
 


### PR DESCRIPTION
Hi, @shayc.

When I first tried to run the project, I saw the error below because my language (pt-BR) has not be translated yet (I'll do it soon in Crowdin).

To fix it, I added a catch to the translation import, so when the language isn't found, it fallbacks to en-US and the user is notified.

Let me know if you want to do this different, if you want to change the notification or anything.

**Print of the error:**
![image](https://user-images.githubusercontent.com/13774309/33843080-7db103c8-de83-11e7-9419-745c6cafb262.png)