### PR TITLE
Editorconfig and fomat on save

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,1 +1,3 @@
-{}
+{
+  "editor.formatOnSave": true
+}


### PR DESCRIPTION
An example editorconfig file which configures the editor. Often requires an editor extension eg for [VS code](  "editor.formatOnSave": true)

Also workspace config of format on save for VS code that with the [Prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) causes Prettier to run on file save. It mght be preferred to leave this as a user pref, given the lint-staged setting causes prettier to run on commit. However I think it has enough value to make it a project setting for code users