### PR TITLE
Dockerize cboard

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,52 @@
+FROM node:8-alpine AS base
+
+# Make a directory for our source and build artifacts
+RUN mkdir -p /home/cboard/build
+WORKDIR /home/cboard
+
+# Copy only the package.json file so we can install and cache dependencies
+COPY package.json /home/cboard
+
+
+
+# --- Create "dependencies" intermediate stage
+
+FROM base AS dependencies
+RUN npm set progress=false
+
+# Install only modules listed in "dependencies" in package.json
+RUN npm install --only=production
+
+# Cache the runtime dependencies for later stage
+RUN cp -R node_modules prod_node_modules
+
+# Install all runtime and dev dependencies for building the code
+RUN npm install
+
+# --- End "dependencies" stage
+
+
+
+# --- Create the "build" intermediate stage
+
+FROM dependencies AS build
+COPY . .
+RUN npm run build
+
+# --- End "build" stage
+
+
+
+# --- Create the "release" image without devDependencies
+
+FROM base AS release
+COPY --from=dependencies /home/cboard/prod_node_modules ./node_modules
+COPY --from=build /home/cboard/build ./build
+
+RUN npm install -g serve
+
+EXPOSE 5000
+
+CMD ["serve", "-s", "build"]
+
+# --- End "release" stage

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+image:
+	docker build -t cboard .
+
+run:
+	docker run -p 5000:5000 cboard:latest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Crowdin](https://d322cqt584bo4o.cloudfront.net/cboard/localized.svg)](https://crowdin.com/project/cboard)
 [![Backers on Open Collective](https://opencollective.com/cboard/backers/badge.svg)](#backers)
- [![Sponsors on Open Collective](https://opencollective.com/cboard/sponsors/badge.svg)](#sponsors) 
+[![Sponsors on Open Collective](https://opencollective.com/cboard/sponsors/badge.svg)](#sponsors)
 
 # Cboard - AAC Communication Board for the Browser
 
@@ -27,6 +27,8 @@ Languages were machine translated and require proofreading, if you want to help 
 
 In order to pull the latest translations from CrowdIn into the codebase, you can run `yarn translations:pull`. This will update all language files such as `en.json` as well as the central `cboard.json` file. Please note that this requires the CrowdIn API key to be available in the `.private` config file. Refer to [Secrets Management](#secrets-management). After the script completes, changes to the translation files will need to be committed to the repo by the usual process.
 
+## Getting Started
+
 ### `npm start` or `yarn start`
 
 Runs the app in development mode.<br>
@@ -52,11 +54,19 @@ By default, it also [includes a service worker](https://github.com/facebookincub
 
 Cboard is ready to be deployed.
 
+### `make image`
+
+Creates a Docker image with cboard built for production. The image is tagged as cboard:latest.
+
+### `make run`
+
+Runs the cboard:latest Docker image on port 5000.
+
 ## Secrets Management
 
 Some external services have APIs we want to access, and these require API keys. To prevent open disclosure of these keys in the public repository, while still tracking them with the code, we encrypt some secrets into a GPG file. These files are `env/local-private.gpg` and `env/prod-private.gpg`.
 
-In order to access the secrets, you must request the `ENCRYPTION_KEY` from @shaycojo and then run the decrypt script: `ENCRYPTION_KEY={key-goes-here} yarn decrypt:local` (or `prod`), which will create the file `.private/local.js` with the secrets in plain text where the scripts can access them. **The files in `.private` should never be committed to the repository.** 
+In order to access the secrets, you must request the `ENCRYPTION_KEY` from @shaycojo and then run the decrypt script: `ENCRYPTION_KEY={key-goes-here} yarn decrypt:local` (or `prod`), which will create the file `.private/local.js` with the secrets in plain text where the scripts can access them. **The files in `.private` should never be committed to the repository.**
 
 If you need to add or change a secret, make the change to the `.private/local.js` file, and then run the encryption script: `ENCRYPTION_KEY={key-goes-here} yarn encrypt:local` (or `prod`).
 
@@ -64,26 +74,24 @@ _Note: These keys/secrets are *not* required to run or develop Cboard._ They are
 
 ## Thanks
 
-[Straight Street](http://straight-street.com/gallery.php) - for providing the symbols.  
-[Crowdin](https://crowdin.com/) - for providing the localization management platform.  
-[<img src="https://www.browserstack.com/images/mail/browserstack-logo-footer.png" width="120" alt="Live, web-based browser testing">](https://www.browserstack.com/)  
-Thank you to BrowserStack for providing the infrastructure to test Cboard in real browsers.  
+[Straight Street](http://straight-street.com/gallery.php) - for providing the symbols.
+[Crowdin](https://crowdin.com/) - for providing the localization management platform.
+[<img src="https://www.browserstack.com/images/mail/browserstack-logo-footer.png" width="120" alt="Live, web-based browser testing">](https://www.browserstack.com/)
+Thank you to BrowserStack for providing the infrastructure to test Cboard in real browsers.
 
-[<img src="https://cdn.auth0.com/oss/badges/a0-badge-light.png" width="150" height="50" alt="JWT Auth for open source projects">](https://auth0.com/?utm_source=oss&utm_medium=gp&utm_campaign=oss)  
-Thank you to Auth0 for providing the token based authentication.  
+[<img src="https://cdn.auth0.com/oss/badges/a0-badge-light.png" width="150" height="50" alt="JWT Auth for open source projects">](https://auth0.com/?utm_source=oss&utm_medium=gp&utm_campaign=oss)
+Thank you to Auth0 for providing the token based authentication.
 
 ## Contributors
 
 This project exists thanks to all the people who contribute. [[Contribute](CONTRIBUTING.md)].
 <a href="graphs/contributors"><img src="https://opencollective.com/cboard/contributors.svg?width=890&button=false" /></a>
 
-
 ## Backers
 
 Thank you to all our backers! 🙏 [[Become a backer](https://opencollective.com/cboard#backer)]
 
 <a href="https://opencollective.com/cboard#backers" target="_blank"><img src="https://opencollective.com/cboard/backers.svg?width=890"></a>
-
 
 ## Sponsors
 
@@ -100,9 +108,7 @@ Support this project by becoming a sponsor. Your logo will show up here with a l
 <a href="https://opencollective.com/cboard/sponsor/8/website" target="_blank"><img src="https://opencollective.com/cboard/sponsor/8/avatar.svg"></a>
 <a href="https://opencollective.com/cboard/sponsor/9/website" target="_blank"><img src="https://opencollective.com/cboard/sponsor/9/avatar.svg"></a>
 
-
-
 ## License
 
-Code - [GPLv3](https://github.com/shayc/cboard/blob/master/LICENSE)  
+Code - [GPLv3](https://github.com/shayc/cboard/blob/master/LICENSE)
 Symbols - [CC BY-SA](https://creativecommons.org/licenses/by-sa/2.0/uk/)


### PR DESCRIPTION
I'm using intermediate stages to reduce the image's file size down. Only the runtime dependencies and build artifacts from ﻿`npm run build` are included in the final release stage.

The README is updated with instructions on how to build and run the Docker image.

This is for Issue #157 