### PR TITLE
Add Snapshots for SymbolSearch and LoadingIcon

### DIFF
--- a/src/components/LoadingIcon/LoadingIcon.test.js
+++ b/src/components/LoadingIcon/LoadingIcon.test.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { shallowMatchSnapshot } from '../../common/test_utils';
+import LoadingIcon from './LoadingIcon';
+
+describe('LoadingIcon tests', () => {
+  test('default renderer', () => {
+    shallowMatchSnapshot(<LoadingIcon />);
+  });
+});

--- a/src/components/LoadingIcon/__snapshots__/LoadingIcon.test.js.snap
+++ b/src/components/LoadingIcon/__snapshots__/LoadingIcon.test.js.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LoadingIcon tests default renderer 1`] = `
+<WithStyles(CircularProgress)
+  className="LoadingIcon"
+  size={14}
+/>
+`;

--- a/src/components/SymbolSearch/SymbolSearch.test.js
+++ b/src/components/SymbolSearch/SymbolSearch.test.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { shallowMatchSnapshot } from '../../common/test_utils';
+import SymbolSearch from './SymbolSearch';
+
+import { IntlProvider } from 'react-intl';
+
+describe('SymbolSearch tests', () => {
+  test('default renderer', () => {
+    shallowMatchSnapshot(
+      <IntlProvider locale="en">
+        <SymbolSearch />
+      </IntlProvider>
+    );
+  });
+});

--- a/src/components/SymbolSearch/__snapshots__/SymbolSearch.test.js.snap
+++ b/src/components/SymbolSearch/__snapshots__/SymbolSearch.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SymbolSearch tests default renderer 1`] = `<InjectIntl(SymbolSearch) />`;


### PR DESCRIPTION
Related to #158 
Please review the snapshot of `SymbolSearch`, I had to use `IntlProvider` (see https://github.com/yahoo/react-intl/issues/307) but I'm not sure about the result...
