### PR TITLE
Moved overflow

### DIFF
--- a/src/components/WelcomeScreen/WelcomeScreen.css
+++ b/src/components/WelcomeScreen/WelcomeScreen.css
@@ -3,6 +3,7 @@
   padding: 1em;
   color: #eceff1;
   background: linear-gradient(to right, rgb(121, 22, 254), rgb(172, 47, 138));
+  overflow: auto;
 }
 
 .WelcomeScreen__container {
@@ -11,7 +12,6 @@
   flex-direction: column;
   max-width: 680px;
   margin: 0 auto;
-  overflow: auto;
 }
 
 .WelcomeScreen__content {


### PR DESCRIPTION
As you can see from the first screenshot the scroll bar appears in the middle of the screen which seems out of place.

![Image with scrollbar](https://i.imgur.com/mVGdq3t.png)

I solved this by moving the `overflow: auto` to the parent of the container it is currently on. 

![Image with new scroll bar](https://i.imgur.com/fHrfCaX.png)