### PR TITLE
Fix/imported boards switching

### DIFF
--- a/src/components/Grid/Grid.container.js
+++ b/src/components/Grid/Grid.container.js
@@ -103,7 +103,7 @@ export class GridContainer extends PureComponent {
     const tilesIds = currentLayout.map(gridTile => gridTile.i);
 
     const tiles = tilesIds.map(t => {
-      return board.tiles.find(tile => tile.id === t);
+      return board.tiles.find(tile => tile.id == t);
     });
 
     updateTiles(tiles);

--- a/src/components/Grid/Grid.container.js
+++ b/src/components/Grid/Grid.container.js
@@ -103,7 +103,9 @@ export class GridContainer extends PureComponent {
     const tilesIds = currentLayout.map(gridTile => gridTile.i);
 
     const tiles = tilesIds.map(t => {
-      return board.tiles.find(tile => tile.id == t);
+      return board.tiles.find(
+        tile => tile.id === t || Number(tile.id) === Number(t)
+      );
     });
 
     updateTiles(tiles);


### PR DESCRIPTION
Fixes imported board crashing the application when switching from the communicator.

The bug was actually in `Grid.container`