### PR TITLE
remove: google-plus from share

### DIFF
--- a/src/components/Board/BoardShare/BoardShare.component.js
+++ b/src/components/Board/BoardShare/BoardShare.component.js
@@ -14,8 +14,6 @@ import {
   FacebookIcon,
   TwitterShareButton,
   TwitterIcon,
-  GooglePlusShareButton,
-  GooglePlusIcon,
   EmailShareButton,
   EmailIcon
 } from 'react-share';
@@ -66,16 +64,15 @@ const BoardShare = ({
       <DialogContent className="ShareDialog__content">
         <div className="ShareDialog__Subtitle">
           <FormattedMessage {...messages.shareALink} />
-          {isOwnBoard &&
-            !isPublic && (
-              <Button
-                color="primary"
-                className="ShareDialog__ToggleStatusButton"
-                onClick={publishBoard}
-              >
-                <FormattedMessage {...messages.publishBoard} />
-              </Button>
-            )}
+          {isOwnBoard && !isPublic && (
+            <Button
+              color="primary"
+              className="ShareDialog__ToggleStatusButton"
+              onClick={publishBoard}
+            >
+              <FormattedMessage {...messages.publishBoard} />
+            </Button>
+          )}
         </div>
 
         <div className="ShareDialog__socialIcons">
@@ -107,12 +104,6 @@ const BoardShare = ({
                 <TwitterIcon round />
                 <FormattedMessage {...messages.twitter} />
               </TwitterShareButton>
-            </Button>
-            <Button disabled={!isPublic}>
-              <GooglePlusShareButton url={url}>
-                <GooglePlusIcon round />
-                <FormattedMessage {...messages.googlePlus} />
-              </GooglePlusShareButton>
             </Button>
           </div>
         </div>

--- a/src/components/Board/BoardShare/BoardShare.messages.js
+++ b/src/components/Board/BoardShare/BoardShare.messages.js
@@ -32,9 +32,5 @@ export default defineMessages({
   email: {
     id: 'cboard.components.BoardShare.email',
     defaultMessage: 'Email'
-  },
-  googlePlus: {
-    id: 'cboard.components.BoardShare.googlePlus',
-    defaultMessage: 'Google+'
   }
 });

--- a/src/translations/ar-SA.json
+++ b/src/translations/ar-SA.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "فيس بوك",
   "cboard.components.BoardShare.twitter": "تغريد",
   "cboard.components.BoardShare.email": "البريد الإلكتروني",
-  "cboard.components.BoardShare.googlePlus": "في + Google",
   "cboard.components.About.resources": "مصادر",
   "cboard.components.About.about": "حول كبوارد",
   "cboard.components.About.intro": "كبوارد هو تطبيق ويب الاتصالات المعززة والبديلة (آك)، مما يسمح للأشخاص ذوي الإعاقة الكلام واللغة على التواصل عن طريق الرموز والنص إلى كلام.",

--- a/src/translations/be-BY.json
+++ b/src/translations/be-BY.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "facebook",
   "cboard.components.BoardShare.twitter": "шчэбет",
   "cboard.components.BoardShare.email": "E-mail",
-  "cboard.components.BoardShare.googlePlus": "Google+",
   "cboard.components.About.resources": "рэсурсы",
   "cboard.components.About.about": "Аб Cboard",
   "cboard.components.About.intro": "Cboard гэта вэб-дадатак, якое ўзмацняе і альтэрнатыўныя спосабы зносін (AAC), што дазваляе людзям з маўленчымі і моўнымі парушэннямі мець зносіны з дапамогай знакаў і тэксту ў размова.",

--- a/src/translations/bn-BD.json
+++ b/src/translations/bn-BD.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "ফেসবুক",
   "cboard.components.BoardShare.twitter": "টুইটার",
   "cboard.components.BoardShare.email": "ইমেইল",
-  "cboard.components.BoardShare.googlePlus": "Google+ এ",
   "cboard.components.About.resources": "সম্পদ",
   "cboard.components.About.about": "সিবোর্ড সম্পর্কে",
   "cboard.components.About.intro": "Cboard একটি বর্ধনকারক এবং বিকল্প যোগাযোগ (এএসি) ওয়েব অ্যাপ্লিকেশন, বক্তৃতা এবং ভাষা ইন্দ্রিয়গুলোর ক্ষতি মানুষের প্রতীক এবং টেক্সট থেকে ভাষ্য সাহায্যে যোগাযোগ করতে সক্ষম হবেন হয়।",

--- a/src/translations/cs-CZ.json
+++ b/src/translations/cs-CZ.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "Facebook",
   "cboard.components.BoardShare.twitter": "Cvrlikání",
   "cboard.components.BoardShare.email": "E-mailem",
-  "cboard.components.BoardShare.googlePlus": "Google+",
   "cboard.components.About.resources": "Zdroje",
   "cboard.components.About.about": "O Kartě",
   "cboard.components.About.intro": "Cboard je webová aplikace augmentativní a alternativní komunikace (AAC), která umožňuje lidem s poruchami řeči a jazyka komunikovat pomocí symbolů a textů k řeči.",

--- a/src/translations/da-DK.json
+++ b/src/translations/da-DK.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "Facebook",
   "cboard.components.BoardShare.twitter": "Twitter",
   "cboard.components.BoardShare.email": "E-mail",
-  "cboard.components.BoardShare.googlePlus": "Google+",
   "cboard.components.About.resources": "Ressourcer",
   "cboard.components.About.about": "Om Cboard",
   "cboard.components.About.intro": "Cboard er en forstørrende og alternativ kommunikation (AAC) webapplikation, der gør det muligt for folk med tale- og sprogkrænkelser at kommunikere med symboler og tekst til tale.",

--- a/src/translations/de-DE.json
+++ b/src/translations/de-DE.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "Facebook",
   "cboard.components.BoardShare.twitter": "Twitter",
   "cboard.components.BoardShare.email": "Email",
-  "cboard.components.BoardShare.googlePlus": "Google+",
   "cboard.components.About.resources": "Ressourcen",
   "cboard.components.About.about": "Über Cboard",
   "cboard.components.About.intro": "Cboard ist eine augmentative und alternative Kommunikation (AAC) Web-Anwendung, mit welcher Menschen mit Sprach-und Sprachbeeinträchtigungen durch Symbole und Text-to-Speech zu kommunizieren.",

--- a/src/translations/el-GR.json
+++ b/src/translations/el-GR.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "Facebook",
   "cboard.components.BoardShare.twitter": "Κελάδημα",
   "cboard.components.BoardShare.email": "ΗΛΕΚΤΡΟΝΙΚΗ ΔΙΕΥΘΥΝΣΗ",
-  "cboard.components.BoardShare.googlePlus": "Google+",
   "cboard.components.About.resources": "Πόροι",
   "cboard.components.About.about": "Σχετικά με το Cboard",
   "cboard.components.About.intro": "Το Cboard είναι μια διαδικτυακή εφαρμογή επεκτατικής και εναλλακτικής επικοινωνίας (AAC), η οποία επιτρέπει στα άτομα με προβλήματα ομιλίας και γλώσσας να επικοινωνούν με σύμβολα και κείμενο σε ομιλία.",

--- a/src/translations/en-GB.json
+++ b/src/translations/en-GB.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "Facebook",
   "cboard.components.BoardShare.twitter": "Twitter",
   "cboard.components.BoardShare.email": "Email",
-  "cboard.components.BoardShare.googlePlus": "Google+",
   "cboard.components.About.resources": "Resources",
   "cboard.components.About.about": "About Cboard",
   "cboard.components.About.intro": "Cboard is an augmentative and alternative communication (AAC) web application, allowing people with speech and language impairments to communicate by symbols and text-to-speech.",

--- a/src/translations/en-US.json
+++ b/src/translations/en-US.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "Facebook",
   "cboard.components.BoardShare.twitter": "Twitter",
   "cboard.components.BoardShare.email": "Email",
-  "cboard.components.BoardShare.googlePlus": "Google+",
   "cboard.components.About.resources": "Resources",
   "cboard.components.About.about": "About Cboard",
   "cboard.components.About.intro": "Cboard is an augmentative and alternative communication (AAC) web application, allowing people with speech and language impairments to communicate by symbols and text-to-speech.",

--- a/src/translations/es-ES.json
+++ b/src/translations/es-ES.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "Facebook",
   "cboard.components.BoardShare.twitter": "Twitter",
   "cboard.components.BoardShare.email": "Email",
-  "cboard.components.BoardShare.googlePlus": "Google+",
   "cboard.components.About.resources": "Recursos",
   "cboard.components.About.about": "Acerca de Cboard",
   "cboard.components.About.intro": "Cboard es una aplicación web de comunicación aumentativa y alternativa (AAC), que permite a las personas con impedimentos del habla y del lenguaje comunicarse mediante símbolos y texto a voz.",

--- a/src/translations/fi-FI.json
+++ b/src/translations/fi-FI.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "Facebook",
   "cboard.components.BoardShare.twitter": "Viserrys",
   "cboard.components.BoardShare.email": "Sähköposti",
-  "cboard.components.BoardShare.googlePlus": "Google+",
   "cboard.components.About.resources": "voimavarat",
   "cboard.components.About.about": "Tietoja sementistä",
   "cboard.components.About.intro": "Cboard on puhetta tukeva ja korvaava kommunikaatio (AAC) web-sovellus, jonka avulla ihmiset puheen ja kielen häiriöt kommunikoimaan symbolien ja tekstin puheeksi.",

--- a/src/translations/fr-FR.json
+++ b/src/translations/fr-FR.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "Facebook",
   "cboard.components.BoardShare.twitter": "Gazouillement",
   "cboard.components.BoardShare.email": "Email",
-  "cboard.components.BoardShare.googlePlus": "Google+",
   "cboard.components.About.resources": "Ressources",
   "cboard.components.About.about": "À propos de Cboard",
   "cboard.components.About.intro": "Cboard est une application web de communication améliorée et alternative (CAA) permettant aux personnes ayant des troubles de la parole et du langage de communiquer par des symboles et de la synthèse vocale.",

--- a/src/translations/he-IL.json
+++ b/src/translations/he-IL.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "פייסבוק",
   "cboard.components.BoardShare.twitter": "טוויטר",
   "cboard.components.BoardShare.email": "אֶלֶקטרוֹנִי",
-  "cboard.components.BoardShare.googlePlus": "Google+",
   "cboard.components.About.resources": "משאבים",
   "cboard.components.About.about": "אודות Cboard",
   "cboard.components.About.intro": "Cboard הוא יישום אינטרנט תקשורת תומכת וחליפית (תת\"ח), המאפשר לאנשים עם ליקויי דיבור ושפה לתקשר באמצעות סמלים ודיבור סינטטי.",

--- a/src/translations/hi-IN.json
+++ b/src/translations/hi-IN.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "फेसबुक",
   "cboard.components.BoardShare.twitter": "ट्विटर",
   "cboard.components.BoardShare.email": "ईमेल",
-  "cboard.components.BoardShare.googlePlus": "गूगल +",
   "cboard.components.About.resources": "साधन",
   "cboard.components.About.about": "बोर्ड के बारे में",
   "cboard.components.About.intro": "बोर्ड एक संवर्धित और वैकल्पिक संचार (एएसी) वेब अनुप्रयोग है, जो लोगों को भाषण और भाषा के विकारों के साथ प्रतीकों और पाठ-से-भाषण द्वारा संवाद करने की इजाजत देता है।",

--- a/src/translations/hr-HR.json
+++ b/src/translations/hr-HR.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "Facebook",
   "cboard.components.BoardShare.twitter": "Cvrkut",
   "cboard.components.BoardShare.email": "E-mail",
-  "cboard.components.BoardShare.googlePlus": "Google+",
   "cboard.components.About.resources": "Resursi",
   "cboard.components.About.about": "O smeću",
   "cboard.components.About.intro": "Cboard je web aplikacija za augmentativnu i alternativnu komunikaciju (AAC), koja omogućuje ljudima s oštećenjem govora i jezika da komuniciraju simboli i tekstualno-govornih.",

--- a/src/translations/hu-HU.json
+++ b/src/translations/hu-HU.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "Facebook",
   "cboard.components.BoardShare.twitter": "Twitter",
   "cboard.components.BoardShare.email": "Email",
-  "cboard.components.BoardShare.googlePlus": "Google+",
   "cboard.components.About.resources": "Erőforrások",
   "cboard.components.About.about": "A Cboard-ról",
   "cboard.components.About.intro": "Cboard egy alternatív és augmentatív kommunikáció (AAC) webes alkalmazás, amely lehetővé teszi az emberek beszéd és nyelvi zavarok kommunikálni a szimbólumok és a text-to-speech.",

--- a/src/translations/id-ID.json
+++ b/src/translations/id-ID.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "Facebook",
   "cboard.components.BoardShare.twitter": "Kericau",
   "cboard.components.BoardShare.email": "E-mail",
-  "cboard.components.BoardShare.googlePlus": "Google+",
   "cboard.components.About.resources": "Sumber",
   "cboard.components.About.about": "Tentang Cboard",
   "cboard.components.About.intro": "Cboard adalah aplikasi web augmentative and alternative communication (AAC), yang memungkinkan orang-orang dengan gangguan bahasa dan bahasa untuk berkomunikasi dengan simbol dan teks-to-speech.",

--- a/src/translations/it-IT.json
+++ b/src/translations/it-IT.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "Facebook",
   "cboard.components.BoardShare.twitter": "cinguettio",
   "cboard.components.BoardShare.email": "E-mail",
-  "cboard.components.BoardShare.googlePlus": "Google+",
   "cboard.components.About.resources": "risorse",
   "cboard.components.About.about": "Informazioni su Cboard",
   "cboard.components.About.intro": "Cboard è un'applicazione web ausiliaria e alternativa (AAC), che consente alle persone con problemi di parola e linguaggio di comunicare con simboli e testo-a-voce.",

--- a/src/translations/ja-JP.json
+++ b/src/translations/ja-JP.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "フェイスブック",
   "cboard.components.BoardShare.twitter": "Twitter",
   "cboard.components.BoardShare.email": "Eメール",
-  "cboard.components.BoardShare.googlePlus": "Google+",
   "cboard.components.About.resources": "リソース",
   "cboard.components.About.about": "Cboardについて",
   "cboard.components.About.intro": "CboardはAAC（Augmentative and Alternative Communication）Webアプリケーションで、構音障害や言語障害のあるを方がシンボルやテキストを音声に変換する機能を用いてコミュニケーションできます。",

--- a/src/translations/km-KH.json
+++ b/src/translations/km-KH.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "Facebook",
   "cboard.components.BoardShare.twitter": "Twitter",
   "cboard.components.BoardShare.email": "អ៊ីមែល",
-  "cboard.components.BoardShare.googlePlus": "Google+",
   "cboard.components.About.resources": "ធនធាន",
   "cboard.components.About.about": "អំពីក្តារបន្ទះ",
   "cboard.components.About.intro": "Cboard គឺជាកម្មវិធីបណ្តាញទំនាក់ទំនងដែលស្ទាបនិងជំនួស (AAC) ដែលអនុញ្ញាតឱ្យមនុស្សដែលមានការនិយាយនិងភាសាដែលពុំសូវក្នុងការប្រាស្រ័យទាក់ទងដោយនិមិត្តសញ្ញានិងអត្ថបទទៅការនិយាយ។",

--- a/src/translations/ko-KR.json
+++ b/src/translations/ko-KR.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "페이스 북",
   "cboard.components.BoardShare.twitter": "지저귀다",
   "cboard.components.BoardShare.email": "이메일",
-  "cboard.components.BoardShare.googlePlus": "Google+",
   "cboard.components.About.resources": "자원",
   "cboard.components.About.about": "Cboard 정보",
   "cboard.components.About.intro": "Cboard는 음성 및 언어 장애가있는 사람들이 기호 및 TTS (text-to-speech)로 통신 할 수있게 해주는 AIG (Augmentative and Alternative Communication) 웹 응용 프로그램입니다.",

--- a/src/translations/ne-NP.json
+++ b/src/translations/ne-NP.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "फेसबुक",
   "cboard.components.BoardShare.twitter": "ट्विटर",
   "cboard.components.BoardShare.email": "ईमेल",
-  "cboard.components.BoardShare.googlePlus": "Google+",
   "cboard.components.About.resources": "स्रोतहरू",
   "cboard.components.About.about": "केबोर्डको बारेमा",
   "cboard.components.About.intro": "Cboard एक augmentative र वैकल्पिक संचार (AAC) वेब अनुप्रयोग बोली र भाषा impairments मानिसहरूलाई प्रतीक र पाठ वाचक द्वारा कुराकानी गर्न अनुमति छ।",

--- a/src/translations/nl-NL.json
+++ b/src/translations/nl-NL.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "Facebook",
   "cboard.components.BoardShare.twitter": "tjilpen",
   "cboard.components.BoardShare.email": "E-mail",
-  "cboard.components.BoardShare.googlePlus": "Google+",
   "cboard.components.About.resources": "Middelen",
   "cboard.components.About.about": "Over Cboard",
   "cboard.components.About.intro": "Cboard is een aanvullende en alternatieve communicatie (AAC) webapplicatie waarmee mensen met spraak- en taalgebreken kunnen communiceren met symbolen en tekst-naar-spraak.",

--- a/src/translations/no-NO.json
+++ b/src/translations/no-NO.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "Facebook",
   "cboard.components.BoardShare.twitter": "Twitter",
   "cboard.components.BoardShare.email": "e-post",
-  "cboard.components.BoardShare.googlePlus": "Google+",
   "cboard.components.About.resources": "ressurser",
   "cboard.components.About.about": "Om Cboard",
   "cboard.components.About.intro": "Cboard er en forsterkende og alternativ kommunikasjon (AAC) webapplikasjon, slik at folk med tale- og språknedsettelser kan kommunisere med symboler og tekst-til-tale.",

--- a/src/translations/pl-PL.json
+++ b/src/translations/pl-PL.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "Facebook",
   "cboard.components.BoardShare.twitter": "Świergot",
   "cboard.components.BoardShare.email": "E-mail",
-  "cboard.components.BoardShare.googlePlus": "Google+",
   "cboard.components.About.resources": "Zasoby",
   "cboard.components.About.about": "O tablicach",
   "cboard.components.About.intro": "Cboard jest aplikacją internetową AUG (Aupment and Alternative Communication), umożliwiającą komunikowanie się przez osoby z zaburzeniami mowy i języka poprzez symbole i tekst na mowę.",

--- a/src/translations/pt-BR.json
+++ b/src/translations/pt-BR.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "Facebook",
   "cboard.components.BoardShare.twitter": "Twitter",
   "cboard.components.BoardShare.email": "Email",
-  "cboard.components.BoardShare.googlePlus": "Google+",
   "cboard.components.About.resources": "Recursos",
   "cboard.components.About.about": "Sobre o Cboard",
   "cboard.components.About.intro": "O Cboard é um aplicativo web de comunicação alternativa (AAC) e aumentativa, que permite que pessoas com deficiências de fala e linguagem se comuniquem por símbolos e texto a fala.",

--- a/src/translations/pt-PT.json
+++ b/src/translations/pt-PT.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "Facebook",
   "cboard.components.BoardShare.twitter": "Twitter",
   "cboard.components.BoardShare.email": "O email",
-  "cboard.components.BoardShare.googlePlus": "Google+",
   "cboard.components.About.resources": "Recursos",
   "cboard.components.About.about": "Sobre o Cboard",
   "cboard.components.About.intro": "O Cboard é um aplicativo web de comunicação alternativa (AAC) e aumentativa, que permite que pessoas com deficiências de fala e linguagem se comuniquem por símbolos e texto a fala.",

--- a/src/translations/ro-RO.json
+++ b/src/translations/ro-RO.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "Facebook",
   "cboard.components.BoardShare.twitter": "Stare de nervozitate",
   "cboard.components.BoardShare.email": "E-mail",
-  "cboard.components.BoardShare.googlePlus": "Google+",
   "cboard.components.About.resources": "Resurse",
   "cboard.components.About.about": "Despre Cboard",
   "cboard.components.About.intro": "Cboard este o aplicație web augmentativă și alternativă de comunicare (AAC), care permite persoanelor cu discursuri și limbaj comunicații să comunice prin simboluri și text-to-speech.",

--- a/src/translations/ru-MD.json
+++ b/src/translations/ru-MD.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "Facebook",
   "cboard.components.BoardShare.twitter": "Twitter",
   "cboard.components.BoardShare.email": "Email",
-  "cboard.components.BoardShare.googlePlus": "Google+",
   "cboard.components.About.resources": "Resources",
   "cboard.components.About.about": "About Cboard",
   "cboard.components.About.intro": "Cboard is an augmentative and alternative communication (AAC) web application, allowing people with speech and language impairments to communicate by symbols and text-to-speech.",

--- a/src/translations/ru-RU.json
+++ b/src/translations/ru-RU.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "facebook",
   "cboard.components.BoardShare.twitter": "щебет",
   "cboard.components.BoardShare.email": "Эл. адрес",
-  "cboard.components.BoardShare.googlePlus": "Google+",
   "cboard.components.About.resources": "Ресурсы",
   "cboard.components.About.about": "О компании",
   "cboard.components.About.intro": "Cboard - это приложение для расширения и альтернативной коммуникации (AAC), позволяющее людям с речевыми и языковыми нарушениями общаться по символам и текста в речь.",

--- a/src/translations/si-LK.json
+++ b/src/translations/si-LK.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "ෆේස්බුක්",
   "cboard.components.BoardShare.twitter": "ට්විටර්",
   "cboard.components.BoardShare.email": "විද්යුත් තැපෑල",
-  "cboard.components.BoardShare.googlePlus": "ගූගල් +",
   "cboard.components.About.resources": "සම්පත්",
   "cboard.components.About.about": "මණ්ඩපය ගැන",
   "cboard.components.About.intro": "Cboard කතාව සහ භාෂාව ශ්රවණාබාධ සහිත ජනතාව සංකේත සහ පෙළ-කිරීමට කතාව විසින් අදහස් හුවමාරු කර ගැනීමට, ඉතා augmentative සහ විකල්ප සන්නිවේදන (AAC) වෙබ් යෙදුම වේ.",

--- a/src/translations/sk-SK.json
+++ b/src/translations/sk-SK.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "Facebook",
   "cboard.components.BoardShare.twitter": "cvrlikání",
   "cboard.components.BoardShare.email": "e-mail",
-  "cboard.components.BoardShare.googlePlus": "Google+",
   "cboard.components.About.resources": "zdroje",
   "cboard.components.About.about": "O spoločnosti Cboard",
   "cboard.components.About.intro": "Kart je rozšírená a alternatívna webová aplikácia (AAC), ktorá umožňuje ľuďom s poruchami reči a jazyka komunikovať pomocou symbolov a text-to-speech.",

--- a/src/translations/sr-SP.json
+++ b/src/translations/sr-SP.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "Фацебоок",
   "cboard.components.BoardShare.twitter": "Твиттер",
   "cboard.components.BoardShare.email": "Емаил",
-  "cboard.components.BoardShare.googlePlus": "Гоогле+",
   "cboard.components.About.resources": "Ресурси",
   "cboard.components.About.about": "О плочи",
   "cboard.components.About.intro": "Канцеларија је аугментативна и алтернативна комуникација (ААЦ) веб апликација, која омогућава људима са поремећајима говора и језика да комуницирају симболима и текстом у говору.",

--- a/src/translations/src/cboard.json
+++ b/src/translations/src/cboard.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "Facebook",
   "cboard.components.BoardShare.twitter": "Twitter",
   "cboard.components.BoardShare.email": "Email",
-  "cboard.components.BoardShare.googlePlus": "Google+",
   "cboard.components.About.resources": "Resources",
   "cboard.components.About.about": "About Cboard",
   "cboard.components.About.intro": "Cboard is an augmentative and alternative communication (AAC) web application, allowing people with speech and language impairments to communicate by symbols and text-to-speech.",

--- a/src/translations/sv-SE.json
+++ b/src/translations/sv-SE.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "Facebook",
   "cboard.components.BoardShare.twitter": "Twitter",
   "cboard.components.BoardShare.email": "E-post",
-  "cboard.components.BoardShare.googlePlus": "Google+",
   "cboard.components.About.resources": "Medel",
   "cboard.components.About.about": "Om Cboard",
   "cboard.components.About.intro": "Cboard är en kompletterande och alternativ kommunikation (AAC) webbapplikation, så att personer med tal och språkfel kan kommunicera med symboler och text-till-tal.",

--- a/src/translations/th-TH.json
+++ b/src/translations/th-TH.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "Facebook",
   "cboard.components.BoardShare.twitter": "พูดเบาและรวดเร็ว",
   "cboard.components.BoardShare.email": "อีเมล์",
-  "cboard.components.BoardShare.googlePlus": "Google+",
   "cboard.components.About.resources": "ทรัพยากร",
   "cboard.components.About.about": "เกี่ยวกับ Cboard",
   "cboard.components.About.intro": "Cboard คือแอพพลิเคชันเว็บแอ็พพลิเคชันการสื่อสารแบบ Augment และ Alternative (AAC) ทำให้ผู้ที่มีความบกพร่องทางการพูดและภาษาสามารถสื่อสารด้วยสัญลักษณ์และข้อความเป็นคำพูด",

--- a/src/translations/tr-TR.json
+++ b/src/translations/tr-TR.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "Facebook",
   "cboard.components.BoardShare.twitter": "heyecan",
   "cboard.components.BoardShare.email": "E-posta",
-  "cboard.components.BoardShare.googlePlus": "Google+",
   "cboard.components.About.resources": "kaynaklar",
   "cboard.components.About.about": "Cboard Hakkında",
   "cboard.components.About.intro": "Cboard, konuşma ve dil yetersizliği olan kişilerin semboller ve konuşma metni ile iletişim kurmalarına olanak tanıyan arttırıcı ve alternatif iletişim (AAC) web uygulamasıdır.",

--- a/src/translations/uk-UA.json
+++ b/src/translations/uk-UA.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "Facebook",
   "cboard.components.BoardShare.twitter": "Twitter",
   "cboard.components.BoardShare.email": "Електронна пошта",
-  "cboard.components.BoardShare.googlePlus": "Google+",
   "cboard.components.About.resources": "Ресурси",
   "cboard.components.About.about": "Про Cboard",
   "cboard.components.About.intro": "Cboard це веб-додаток, що підсилює і альтернативні способи спілкування (AAC), що дозволяє людям з мовними і мовними порушеннями спілкуватися за допомогою символів і тексту в мову.",

--- a/src/translations/ur-PK.json
+++ b/src/translations/ur-PK.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "فیس بک",
   "cboard.components.BoardShare.twitter": "ٹویٹر",
   "cboard.components.BoardShare.email": "ای میل",
-  "cboard.components.BoardShare.googlePlus": "Google+",
   "cboard.components.About.resources": "وسائل",
   "cboard.components.About.about": "کی بورڈ کے بارے میں",
   "cboard.components.About.intro": "کی بورڈ ایک اضافی اور متبادل مواصلات (اے اے سی) کی ویب ایپلی کیشن ہے، جو لوگوں کو تقریر اور زبان کی خرابیوں سے علامتوں اور متن سے بات کرنے کے ذریعے بات چیت کرنے کی اجازت دیتا ہے.",

--- a/src/translations/vi-VN.json
+++ b/src/translations/vi-VN.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "Facebook",
   "cboard.components.BoardShare.twitter": "Twitter",
   "cboard.components.BoardShare.email": "E-mail",
-  "cboard.components.BoardShare.googlePlus": "Google+",
   "cboard.components.About.resources": "Tài nguyên",
   "cboard.components.About.about": "Giới thiệu về Cboard",
   "cboard.components.About.intro": "Cboard là một ứng dụng web truyền tải bổ sung (AAC), cho phép những người có ngôn ngữ và ngôn ngữ khiếm khuyết để giao tiếp bằng các ký hiệu và chuyển văn bản thành giọng nói.",

--- a/src/translations/zh-CN.json
+++ b/src/translations/zh-CN.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "脸书",
   "cboard.components.BoardShare.twitter": "推特",
   "cboard.components.BoardShare.email": "电子邮件",
-  "cboard.components.BoardShare.googlePlus": "Google+",
   "cboard.components.About.resources": "资源",
   "cboard.components.About.about": "关于Cboard",
   "cboard.components.About.intro": "Cboard是一种增强和替代沟通（AAC）网络应用程序，允许具有口语和语言障碍的人通过符号和文本到语音的转换进行沟通。",

--- a/src/translations/zu-ZA.json
+++ b/src/translations/zu-ZA.json
@@ -71,7 +71,6 @@
   "cboard.components.BoardShare.facebook": "crwdns50061:0crwdne50061:0",
   "cboard.components.BoardShare.twitter": "crwdns50063:0crwdne50063:0",
   "cboard.components.BoardShare.email": "crwdns50065:0crwdne50065:0",
-  "cboard.components.BoardShare.googlePlus": "crwdns50067:0crwdne50067:0",
   "cboard.components.About.resources": "crwdns49887:0crwdne49887:0",
   "cboard.components.About.about": "crwdns49882:0crwdne49882:0",
   "cboard.components.About.intro": "crwdns49821:0crwdne49821:0",


### PR DESCRIPTION
Google+ was shutdown, removed Google+ share button.

"On April 2, 2019 we are shutting down the consumer (personal) version of Google+, a social network by Google."

https://support.google.com/plus/answer/9217723?hl=en


