### PR TITLE
Removes debugger from main board component.

### DIFF
--- a/src/components/Board/Board.component.js
+++ b/src/components/Board/Board.component.js
@@ -93,7 +93,6 @@ export class Board extends Component {
   }
 
   componentDidMount() {
-    debugger;
     if (this.props.scannerSettings.active) {
       this.props.onScannerActive();
     }


### PR DESCRIPTION
Hi!

This is my first contribution, and it may be useless - I just found there was a debugger on line 96 of Board.component.js that crashed my local on first run. But this probably only matters if devtools is open, so if that's a deliberate choice, feel free to delete this PR. :)