### PR TITLE
Add loading Circular progress when clicking LOAD MORE buttton 

### DIFF
--- a/src/components/Communicator/CommunicatorDialog/CommunicatorDialog.component.js
+++ b/src/components/Communicator/CommunicatorDialog/CommunicatorDialog.component.js
@@ -22,6 +22,7 @@ const CommunicatorDialog = ({
   intl,
   selectedTab,
   loading,
+  nextPageLoading,
   boards,
   total,
   limit,
@@ -138,6 +139,14 @@ const CommunicatorDialog = ({
                     <FormattedMessage {...messages.loadNextPage} />
                   </Button>
                 )}
+
+                {nextPageLoading && (
+                  <CircularProgress
+                    size={35}
+                    className="CommunicatorDialog__spinner"
+                    thickness={7}
+                  />
+                )}
               </div>
             </React.Fragment>
           )}
@@ -158,6 +167,7 @@ const CommunicatorDialog = ({
 CommunicatorDialog.defaultProps = {
   open: false,
   loading: false,
+  nextPageLoading: false,
   userData: null,
   limit: 10,
   page: 1,

--- a/src/components/Communicator/CommunicatorDialog/CommunicatorDialog.container.js
+++ b/src/components/Communicator/CommunicatorDialog/CommunicatorDialog.container.js
@@ -91,6 +91,7 @@ class CommunicatorDialogContainer extends React.Component {
   }
 
   async loadNextPage() {
+    this.setState({ nextPageLoading: true });
     const page = this.state.page + 1;
     const selectedTab = this.state.selectedTab;
     const tabData = await this.doSearch('', page, selectedTab);
@@ -100,7 +101,8 @@ class CommunicatorDialogContainer extends React.Component {
       page: page,
       search: '',
       isSearchOpen: false,
-      loading: false
+      loading: false,
+      nextPageLoading: false
     });
   }
 


### PR DESCRIPTION
Fixes #621 

Added a new a progress loader bar when clicking "LOAD MORE". The loader is centered and disappears once the new data is set in the state.

I've attached a screenshot and tested it with a setTimeout() function to simulate loading times. All removed before committing.

![Screenshot (315)](https://user-images.githubusercontent.com/39199348/73579525-47228480-4448-11ea-8bc4-63cdc16e28a1.png)
