### PR TITLE
#638 Adds Display Setting to Position or Hide Label

### DIFF
--- a/src/components/App/App.reducer.js
+++ b/src/components/App/App.reducer.js
@@ -6,7 +6,10 @@ import {
   UPDATE_USER_DATA
 } from './App.constants';
 import { LOGIN_SUCCESS, LOGOUT } from '../Account/Login/Login.constants';
-import { DISPLAY_SIZE_STANDARD } from '../Settings/Display/Display.constants';
+import {
+  DISPLAY_SIZE_STANDARD,
+  LABEL_POSITION_BELOW
+} from '../Settings/Display/Display.constants';
 
 const initialState = {
   isConnected: true,
@@ -14,7 +17,8 @@ const initialState = {
   displaySettings: {
     uiSize: DISPLAY_SIZE_STANDARD,
     fontSize: DISPLAY_SIZE_STANDARD,
-    hideOutputActive: false
+    hideOutputActive: false,
+    labelPosition: LABEL_POSITION_BELOW
   },
   navigationSettings: {
     active: false,

--- a/src/components/Board/Board.component.js
+++ b/src/components/Board/Board.component.js
@@ -78,6 +78,7 @@ export class Board extends Component {
   static defaultProps = {
     displaySettings: {
       uiSize: 'Standard',
+      labelPosition: 'Below',
       hideOutputActive: false
     },
     navigationSettings: {},
@@ -162,7 +163,12 @@ export class Board extends Component {
   };
 
   renderTiles(tiles) {
-    const { isSelecting, isSaving, selectedTileIds } = this.props;
+    const {
+      isSelecting,
+      isSaving,
+      selectedTileIds,
+      displaySettings
+    } = this.props;
 
     return tiles.map(tile => {
       const isSelected = selectedTileIds.includes(tile.id);
@@ -181,7 +187,11 @@ export class Board extends Component {
               this.handleTileFocus(tile.id);
             }}
           >
-            <Symbol image={tile.image} label={tile.label} />
+            <Symbol
+              image={tile.image}
+              label={tile.label}
+              labelpos={displaySettings.labelPosition}
+            />
 
             {isSelecting && !isSaving && (
               <div className="CheckCircle">

--- a/src/components/Board/Output/SymbolOutput/SymbolOutput.js
+++ b/src/components/Board/Output/SymbolOutput/SymbolOutput.js
@@ -60,7 +60,7 @@ class SymbolOutput extends PureComponent {
         <Scroll {...other}>
           {symbols.map(({ image, label }, index) => (
             <div className="SymbolOutput__value" key={index}>
-              <Symbol image={image} label={label} />
+              <Symbol image={image} label={label} labelpos="Below" />
               <div className="SymbolOutput__value__IconButton">
                 <IconButton
                   size={'small'}

--- a/src/components/Board/Symbol/Symbol.js
+++ b/src/components/Board/Symbol/Symbol.js
@@ -29,12 +29,17 @@ function Symbol(props) {
 
   return (
     <div className={symbolClassName} {...other}>
+      {props.labelpos === 'Above' && props.labelpos !== 'Hidden' && (
+        <div className="Symbol__label">{label}</div>
+      )}
       {image && (
         <div className="Symbol__image-container">
           <img className="Symbol__image" src={image} alt="" />
         </div>
       )}
-      <div className="Symbol__label">{label}</div>
+      {props.labelpos === 'Below' && props.labelpos !== 'Hidden' && (
+        <div className="Symbol__label">{label}</div>
+      )}
     </div>
   );
 }

--- a/src/components/Settings/Display/Display.component.js
+++ b/src/components/Settings/Display/Display.component.js
@@ -17,7 +17,10 @@ import './Display.css';
 import {
   DISPLAY_SIZE_STANDARD,
   DISPLAY_SIZE_LARGE,
-  DISPLAY_SIZE_EXTRALARGE
+  DISPLAY_SIZE_EXTRALARGE,
+  LABEL_POSITION_ABOVE,
+  LABEL_POSITION_BELOW,
+  LABEL_POSITION_HIDDEN
 } from './Display.constants';
 
 const propTypes = {
@@ -62,22 +65,44 @@ class Display extends React.Component {
       >
         <FormControlLabel
           control={<Radio />}
-          label={this.props.intl.formatMessage(messages[DISPLAY_SIZE_STANDARD])}
-          value={DISPLAY_SIZE_STANDARD}
-          labelPlacement="start"
-        />
-        <FormControlLabel
-          control={<Radio />}
-          label={this.props.intl.formatMessage(messages[DISPLAY_SIZE_LARGE])}
-          value={DISPLAY_SIZE_LARGE}
+          label={this.props.intl.formatMessage(
+            name === 'labelPosition'
+              ? messages[LABEL_POSITION_ABOVE]
+              : messages[DISPLAY_SIZE_STANDARD]
+          )}
+          value={this.props.intl.formatMessage(
+            name === 'labelPosition'
+              ? messages[LABEL_POSITION_ABOVE]
+              : messages[DISPLAY_SIZE_STANDARD]
+          )}
           labelPlacement="start"
         />
         <FormControlLabel
           control={<Radio />}
           label={this.props.intl.formatMessage(
-            messages[DISPLAY_SIZE_EXTRALARGE]
+            name === 'labelPosition'
+              ? messages[LABEL_POSITION_BELOW]
+              : messages[DISPLAY_SIZE_LARGE]
           )}
-          value={DISPLAY_SIZE_EXTRALARGE}
+          value={this.props.intl.formatMessage(
+            name === 'labelPosition'
+              ? messages[LABEL_POSITION_BELOW]
+              : messages[DISPLAY_SIZE_LARGE]
+          )}
+          labelPlacement="start"
+        />
+        <FormControlLabel
+          control={<Radio />}
+          label={this.props.intl.formatMessage(
+            name === 'labelPosition'
+              ? messages[LABEL_POSITION_HIDDEN]
+              : messages[DISPLAY_SIZE_EXTRALARGE]
+          )}
+          value={this.props.intl.formatMessage(
+            name === 'labelPosition'
+              ? messages[LABEL_POSITION_HIDDEN]
+              : messages[DISPLAY_SIZE_EXTRALARGE]
+          )}
           labelPlacement="start"
         />
       </RadioGroup>
@@ -131,6 +156,17 @@ class Display extends React.Component {
                   value="active"
                   color="primary"
                 />
+              </ListItemSecondaryAction>
+            </ListItem>
+            <ListItem>
+              <ListItemText
+                primary={<FormattedMessage {...messages.labelPosition} />}
+                secondary={
+                  <FormattedMessage {...messages.labelPositionSecondary} />
+                }
+              />
+              <ListItemSecondaryAction className="Display__Options">
+                {this.renderRadioGroup('labelPosition')}
               </ListItemSecondaryAction>
             </ListItem>
           </List>

--- a/src/components/Settings/Display/Display.constants.js
+++ b/src/components/Settings/Display/Display.constants.js
@@ -3,8 +3,6 @@ export const DISPLAY_SIZE_LARGE = 'Large';
 export const DISPLAY_SIZE_EXTRALARGE = 'ExtraLarge';
 
 // Add label positioning options
-export const LABEL_POSITION = 'Label Position';
-export const LABEL_POSITION_SECONDARY = 'Below';
 export const LABEL_POSITION_ABOVE = 'Above';
 export const LABEL_POSITION_BELOW = 'Below';
 export const LABEL_POSITION_HIDDEN = 'Hidden';

--- a/src/components/Settings/Display/Display.constants.js
+++ b/src/components/Settings/Display/Display.constants.js
@@ -2,6 +2,13 @@ export const DISPLAY_SIZE_STANDARD = 'Standard';
 export const DISPLAY_SIZE_LARGE = 'Large';
 export const DISPLAY_SIZE_EXTRALARGE = 'ExtraLarge';
 
+// Add label positioning options
+export const LABEL_POSITION = 'Label Position';
+export const LABEL_POSITION_SECONDARY = 'Below';
+export const LABEL_POSITION_ABOVE = 'Above';
+export const LABEL_POSITION_BELOW = 'Below';
+export const LABEL_POSITION_HIDDEN = 'Hidden';
+
 export const DISPLAY_SIZE_GRID_COLS = {
   [DISPLAY_SIZE_STANDARD]: {
     lg: 6,

--- a/src/components/Settings/Display/Display.messages.js
+++ b/src/components/Settings/Display/Display.messages.js
@@ -2,7 +2,10 @@ import { defineMessages } from 'react-intl';
 import {
   DISPLAY_SIZE_STANDARD,
   DISPLAY_SIZE_LARGE,
-  DISPLAY_SIZE_EXTRALARGE
+  DISPLAY_SIZE_EXTRALARGE,
+  LABEL_POSITION_ABOVE,
+  LABEL_POSITION_BELOW,
+  LABEL_POSITION_HIDDEN
 } from './Display.constants';
 
 export default defineMessages({
@@ -22,6 +25,18 @@ export default defineMessages({
     id: 'cboard.components.Settings.Display.ExtraLargeSize',
     defaultMessage: 'Extra Large'
   },
+  [LABEL_POSITION_ABOVE]: {
+    id: 'cboard.components.Settings.Display.LabelPositionAbove',
+    defaultMessage: 'Above'
+  },
+  [LABEL_POSITION_BELOW]: {
+    id: 'cboard.components.Settings.Display.LabelPositionBelow',
+    defaultMessage: 'Below'
+  },
+  [LABEL_POSITION_HIDDEN]: {
+    id: 'cboard.components.Settings.Display.LabelPositionHidden',
+    defaultMessage: 'Hidden'
+  },
   uiSize: {
     id: 'cboard.components.Settings.Display.uiSize',
     defaultMessage: 'UI Size'
@@ -37,6 +52,15 @@ export default defineMessages({
   fontSizeSecondary: {
     id: 'cboard.components.Settings.Display.fontSizeSecondary',
     defaultMessage: 'App font size'
+  },
+  labelPosition: {
+    id: 'cboard.components.Settings.Display.labelPosition',
+    defaultMessage: 'Label Position'
+  },
+  labelPositionSecondary: {
+    id: 'cboard.components.Settings.Display.labelPositionSecondary',
+    defaultMessage:
+      'Whether labels on tiles should be visible, or positioned above or below'
   },
   outputHide: {
     id: 'cboard.components.Settings.Navigation.outputHide',


### PR DESCRIPTION
Resolves #638 

This PR includes updates to:

* src/components/Board/Board.component.js
* src/components/Board/Symbol/Symbol.js
* src/components/Settings/Display/Display.component.js
* src/components/Settings/Display/Display.constants.js
* src/components/Settings/Display/Display.messages.js


This PR includes:
1) Adds a radio option to /settings/display that lets users choose between positioning label on each tile as above, below or hidden
2) Adds subheaders to the UI at /settings/display, to improve overall readability with the new option
3) In Board.component.js, adds the new labelPosition option info to all tiles
4) In Symbol.component.js, use the labelPosition prop to control where label is rendered/whether it's rendered.

#### Adds a radio option to /settings/display that lets users choose between positioning label on each tile as above, below or hidden
#### Adds subheaders to the UI at /settings/display, to improve overall readability with the new option
<img width="823" alt="Screen Shot 2020-03-15 at 9 44 59 PM" src="https://user-images.githubusercontent.com/1507827/76721644-4b5be600-6706-11ea-85ef-a2ffafde36ee.png">

#### In Board.component.js, adds the new labelPosition option info to all tiles
#### In Symbol.component.js, use the labelPosition prop to control where label is rendered/whether it's rendered.

<img width="200" alt="Screen Shot 2020-03-15 at 6 40 34 PM" src="https://user-images.githubusercontent.com/1507827/76714420-7c2f2180-66ec-11ea-9106-9de5cf22ab25.png">
<img width="200" alt="Screen Shot 2020-03-15 at 6 40 17 PM" src="https://user-images.githubusercontent.com/1507827/76714421-7cc7b800-66ec-11ea-8da6-710c5e8a0e16.png">
<img width="200" alt="Screen Shot 2020-03-15 at 6 39 51 PM" src="https://user-images.githubusercontent.com/1507827/76714424-7d604e80-66ec-11ea-9611-71e02efc1cd4.png">
