### PR TITLE
Add option to read folder name out loud when clicked

### DIFF
--- a/src/components/App/App.reducer.js
+++ b/src/components/App/App.reducer.js
@@ -25,7 +25,8 @@ const initialState = {
     active: false,
     caBackButtonActive: false,
     quickUnlockActive: false,
-    removeOutputActive: false
+    removeOutputActive: false,
+    vocalizeFolders: false
   },
   userData: {}
 };

--- a/src/components/Board/Board.container.js
+++ b/src/components/Board/Board.container.js
@@ -533,32 +533,12 @@ export class BoardContainer extends Component {
       speak,
       intl,
       boards,
-      showNotification
+      showNotification,
+      navigationSettings
     } = this.props;
     const hasAction = tile.action && tile.action.startsWith('+');
 
-    if (tile.loadBoard) {
-      try {
-        const boardExists = boards.find(b => b.id === tile.loadBoard);
-        if (boardExists) {
-          changeBoard(tile.loadBoard);
-          this.props.history.push(tile.loadBoard);
-        } else {
-          const rboardExists = boards.find(b => b.name === tile.label);
-          if (rboardExists) {
-            changeBoard(rboardExists.id);
-            this.props.history.push(rboardExists.id);
-          } else {
-            showNotification(intl.formatMessage(messages.boardMissed));
-          }
-        }
-      } catch (error) {
-        console.log(error.message);
-        showNotification(intl.formatMessage(messages.boardMissed));
-      }
-    } else {
-      changeOutput([...this.props.output, tile]);
-      clickSymbol(tile.label);
+    const say = () => {
       if (tile.sound) {
         this.playAudio(tile.sound);
       } else {
@@ -567,6 +547,28 @@ export class BoardContainer extends Component {
           speak(toSpeak);
         }
       }
+    };
+
+    if (tile.loadBoard) {
+      const nextBoard = (
+        boards.find(b => b.id === tile.loadBoard) ||
+        // If the board id is invalid, try falling back to a board
+        // with the right name.
+        boards.find(b => b.name === tile.label)
+      );
+      if (nextBoard) {
+        changeBoard(nextBoard.id);
+        this.props.history.push(nextBoard.id);
+        if (navigationSettings.vocalizeFolders) {
+          say();
+        }
+      } else {
+        showNotification(intl.formatMessage(messages.boardMissed));
+      }
+    } else {
+      changeOutput([...this.props.output, tile]);
+      clickSymbol(tile.label);
+      say();
     }
   };
 

--- a/src/components/Settings/Navigation/Navigation.component.js
+++ b/src/components/Settings/Navigation/Navigation.component.js
@@ -48,6 +48,12 @@ class Navigation extends React.Component {
     });
   };
 
+  toggleVocalizeFolders = () => {
+    this.setState({
+      vocalizeFolders: !this.state.vocalizeFolders
+    });
+  };
+
   onSubmit = () => {
     this.props.updateNavigationSettings(this.state);
   };
@@ -106,6 +112,22 @@ class Navigation extends React.Component {
                     disabled={true}
                     checked={this.state.quickUnlockActive}
                     onChange={this.toggleQuickUnlock}
+                    value="active"
+                    color="secondary"
+                  />
+                </ListItemSecondaryAction>
+              </ListItem>
+              <ListItem>
+                <ListItemText
+                  primary={<FormattedMessage {...messages.vocalizeFolders} />}
+                  secondary={
+                    <FormattedMessage {...messages.vocalizeFoldersSecondary} />
+                  }
+                />
+                <ListItemSecondaryAction>
+                  <Switch
+                    checked={this.state.vocalizeFolders}
+                    onChange={this.toggleVocalizeFolders}
                     value="active"
                     color="secondary"
                   />

--- a/src/components/Settings/Navigation/Navigation.messages.js
+++ b/src/components/Settings/Navigation/Navigation.messages.js
@@ -28,5 +28,13 @@ export default defineMessages({
   outputRemoveSecondary: {
     id: 'cboard.components.Settings.Navigation.outputRemoveSecondary',
     defaultMessage: 'Shows a "x" buttton on each symbol in order to remove it'
+  },
+  vocalizeFolders: {
+    id: 'cboard.components.Settings.Navigation.vocalizeFolders',
+    defaultMessage: 'Enable folder vocalization'
+  },
+  vocalizeFoldersSecondary: {
+    id: 'cboard.components.Settings.Navigation.vocalizeFoldersSecondary',
+    defaultMessage: 'Reads a folder\'s name out loud when clicked'
   }
 });

--- a/src/translations/fr-FR.json
+++ b/src/translations/fr-FR.json
@@ -235,6 +235,8 @@
   "cboard.components.Settings.Navigation.outputRemoveSecondary": "Affiche un bouton \"x\" sur chaque symbole afin de le supprimer",
   "cboard.components.Settings.Navigation.outputHide": "Masquer la barre de sortie",
   "cboard.components.Settings.Navigation.outputHideSecondary": "Masque la barre blanche en haut où vous créez une phrase.",
+  "cboard.components.Settings.Navigation.vocalizeFolders": "Activer la vocalisation de dossiers",
+  "cboard.components.Settings.Navigation.vocalizeFoldersSecondary": "Lit à voix haute le nom d'un dossier lorsque cliqué",
   "cboard.components.Settings.Export.export": "Exportation",
   "cboard.components.Settings.Export.exportSingleSecondary": "Cette option exportera une seule carte que vous avez à partir d'une liste de cartes. Vous pouvez choisir les formats {cboardLink}, {link} ou PDF.",
   "cboard.components.Settings.Export.exportAll": "Exporter toutes les cartes",


### PR DESCRIPTION
This PR implements an optional "folder vocalization" feature, which reads folder names out loud when switching boards. It also adds a toggle to the Navigation settings page.

A few notes:
- The feature is disabled by default to keep the current behaviour.
- We only read the folder name if we find a valid board to switch to. Should we do it even when there's no valid board?

![image](https://user-images.githubusercontent.com/46613478/79694137-7de48b80-823c-11ea-9c33-43c05ad7c062.png)

Close #611 