### PR TITLE
add: fallback values when conversion fails

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -42,7 +42,7 @@ export function standardizeLanguageCode(lang) {
   }
   let standardLang =
     splittedLang[0].length === 3
-      ? alpha3TToAlpha2(splittedLang[0])
+      ? alpha3TToAlpha2(splittedLang[0]) || splittedLang[0]
       : splittedLang[0];
 
   if (splittedLang.length === 1) {
@@ -51,7 +51,7 @@ export function standardizeLanguageCode(lang) {
 
   let standardCountry =
     splittedLang[1].length === 3
-      ? alpha3ToAlpha2(splittedLang[1])
+      ? alpha3ToAlpha2(splittedLang[1]) || splittedLang[1]
       : splittedLang[1];
 
   return `${standardLang}-${standardCountry}`;


### PR DESCRIPTION
add fallback values for when conversion of language code returns undefined (on Linux).
You can see in the list below there are some "weird" language codes: `en-029` returns `en-undefined` and `bpy` returns `undefined`

This PR fixes issue #700

Speech Synthesis voice languages on Ubuntu 20.04:
```
[
  "ca",
  "or",
  "bpy",
  "fa-LATN",
  "nci",
  "nl",
  "cmn",
  "hyw",
  "az",
  "ky",
  "shn",
  "yue",
  "vi",
  "am",
  "ga",
  "lv",
  "quc",
  "af",
  "vi-VN",
  "en-GB",
  "ms",
  "tt",
  "ne",
  "sr",
  "es-419",
  "ru-LV",
  "ar",
  "ia",
  "ur",
  "it",
  "an",
  "de",
  "eu",
  "bn",
  "pt-BR",
  "lt",
  "as",
  "da",
  "fr-FR",
  "pap",
  "en-GB",
  "bs",
  "gn",
  "mr",
  "tr",
  "en-US",
  "fa",
  "hi",
  "bg",
  "lfn",
  "is",
  "fr-BE",
  "mt",
  "ht",
  "eo",
  "ba",
  "pt",
  "es",
  "ku",
  "jbo",
  "cs",
  "en-029",
  "hu",
  "ta",
  "id",
  "en-GB",
  "my",
  "en-GB",
  "grc",
  "fr-CH",
  "hy",
  "kl",
  "nb",
  "mi",
  "kn",
  "pa",
  "hak",
  "ja",
  "ro",
  "gu",
  "la",
  "pl",
  "sl",
  "ml",
  "ru",
  "hr",
  "ko",
  "cy",
  "sk",
  "ka",
  "vi-VN",
  "sq",
  "uz",
  "sw",
  "fi",
  "el",
  "gd",
  "te",
  "kok",
  "sd",
  "et",
  "om",
  "en-GB",
  "sv",
  "mk",
  "tn",
  "si",
  "kk",
  "py"
]
```