### PR TITLE
chore: remove dead code

### DIFF
--- a/src/build-version.js
+++ b/src/build-version.js
@@ -1,1 +1,0 @@
-module.exports = '20';

--- a/src/store.js
+++ b/src/store.js
@@ -1,17 +1,16 @@
 import { createStore, applyMiddleware, compose } from 'redux';
 import thunk from 'redux-thunk';
 import { persistStore } from 'redux-persist';
-import storage from 'redux-persist/lib/storage';
 import { UPDATE_CONNECTIVITY } from './components/App/App.constants';
 import googleAnalytics from './analytics';
 import createReducer from './reducers';
-import buildVersion from './build-version';
 
 let store;
 
 export default function configureStore(initialState = {}) {
   const middlewares = [thunk, googleAnalytics];
   const enhancers = [applyMiddleware(...middlewares)];
+
   // If Redux DevTools Extension is installed use it, otherwise use Redux compose
   /* eslint-disable no-underscore-dangle */
   const composeEnhancers =
@@ -27,23 +26,6 @@ export default function configureStore(initialState = {}) {
     composeEnhancers(...enhancers)
   );
 
-  // Check to ensure latest build version
-  storage
-    .getItem('buildVersion')
-    .then(localVersion => {
-      if (localVersion !== buildVersion) {
-        // Purge store
-        persistStore(store).purge();
-        // Save the new build version in the local cache
-        storage.setItem('buildVersion', buildVersion);
-      } else {
-        persistStore(store);
-      }
-    })
-    .catch(() => {
-      persistStore(store);
-      storage.setItem('buildVersion', buildVersion);
-    });
   // TODO refactor not here
   window.addEventListener('offline', () => {
     store.dispatch({
@@ -51,13 +33,17 @@ export default function configureStore(initialState = {}) {
       payload: false
     });
   });
+
   window.addEventListener('online', () => {
     store.dispatch({
       type: UPDATE_CONNECTIVITY,
       payload: true
     });
   });
+
   const persistor = persistStore(store);
+
   return { persistor, store };
 }
+
 export const getStore = () => store;


### PR DESCRIPTION
This code was never updating the build version and was practically useless.
The original idea was to increment `buildVersion.js` at run-time so that each time we deploy it'll invalidate the user's `localStorage`.
But for 2 years this had been "stuck" on version 20. So was doing nothing at all.