### PR TITLE
fix: default font size

### DIFF
--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -3,7 +3,7 @@
 }
 
 .Cboard__FontSize__Standard {
-  font-size: 14px;
+  font-size: 16px;
 }
 
 .Cboard__FontSize__Large {


### PR DESCRIPTION
Finally, this had been for two years.

Change default font-size from 14px back to 16px.
16px IS the default font size for browsers.. optimized for readability.
When it was changed to 14px 2 years ago, it made the tooltip font-size not legible for me, and I have 20/20 eye sight.