### PR TITLE
Store images as data URIs when importing from OBF/OBZ

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "keycode": "^2.2.0",
     "lodash": "^4.17.16",
     "matx": "1.0.0",
+    "mime-types": "^2.1.27",
     "moment": "2.27.0",
     "opencollective": "^1.0.3",
     "pdfmake": "^0.1.66",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "matx": "1.0.0",
     "mime-types": "^2.1.27",
     "moment": "2.27.0",
+    "mongoose": "^5.9.25",
     "opencollective": "^1.0.3",
     "pdfmake": "^0.1.66",
     "prop-types": "^15.7.2",

--- a/src/components/Settings/Export/Export.helpers.js
+++ b/src/components/Settings/Export/Export.helpers.js
@@ -88,7 +88,7 @@ function getBase64Image(base64Str = '') {
   };
 }
 
-async function getDataUri(url) {
+export async function getDataUri(url) {
   try {
     const result = await axios({
       method: 'get',

--- a/src/components/Settings/Export/Export.helpers.js
+++ b/src/components/Settings/Export/Export.helpers.js
@@ -180,7 +180,7 @@ async function boardToOBF(boardsMap, board = {}, intl, { embed = false }) {
               // file, the path is unnecessary.
               path: embed ? undefined : path,
               data: embed ? imageResponse.data : undefined,
-              content_type: contentType,
+              content_type: imageResponse['content_type'],
               width: 300,
               height: 300
             };

--- a/src/components/Settings/Export/Export.helpers.js
+++ b/src/components/Settings/Export/Export.helpers.js
@@ -26,6 +26,7 @@ import {
 } from '../../../cordova-util';
 import { getStore } from '../../../store';
 import * as _ from 'lodash';
+import mime from 'mime-types';
 
 pdfMake.vfs = pdfFonts.pdfMake.vfs;
 
@@ -132,15 +133,14 @@ async function boardToOBF(boardsMap, board = {}, intl, { embed = false }) {
               : tile.image;
           let imageResponse = null;
           let path = '';
-          let contentType = '';
           let fetchedImageID = `custom/${board.name ||
             board.nameKey}/${tile.label || tile.labelKey || tile.id}`;
 
           if (image.startsWith('data:')) {
             imageResponse = getBase64Image(image);
-            contentType = imageResponse['content_type'];
-            const defaultExtension =
-              contentType.indexOf('/') >= 0 ? contentType.split('/')[1] : '';
+            const defaultExtension = mime.extension(
+              imageResponse['content_type']
+            );
             fetchedImageID = defaultExtension.length
               ? `${fetchedImageID}.${defaultExtension}`
               : fetchedImageID;

--- a/src/components/Settings/Export/Export.helpers.js
+++ b/src/components/Settings/Export/Export.helpers.js
@@ -27,6 +27,7 @@ import {
 import { getStore } from '../../../store';
 import * as _ from 'lodash';
 import mime from 'mime-types';
+import mongoose from 'mongoose';
 
 pdfMake.vfs = pdfFonts.pdfMake.vfs;
 
@@ -87,6 +88,30 @@ function getBase64Image(base64Str = '') {
   };
 }
 
+async function getDataUri(url) {
+  try {
+    const result = await axios({
+      method: 'get',
+      url,
+      responseType: 'arraybuffer'
+    });
+
+    // Convert the array buffer to a Base64-encoded string.
+    const encodedImage = btoa(
+      String.fromCharCode.apply(null, new Uint8Array(result.data))
+    );
+    const contentType = result.headers['content-type'];
+
+    return {
+      ab: result.data,
+      content_type: contentType,
+      data: `data:${contentType};base64,${encodedImage}`
+    };
+  } catch (e) {
+    console.error(`Failed to get image at ${url}.`);
+  }
+}
+
 /**
  * Generate the contents of an OBF file for a single board, and get the
  * associated images.
@@ -131,48 +156,32 @@ async function boardToOBF(boardsMap, board = {}, intl, { embed = false }) {
             isCordova() && tile.image && tile.image.search('/') === 0
               ? `.${tile.image}`
               : tile.image;
-          let imageResponse = null;
-          let path = '';
-          let fetchedImageID = `custom/${board.name ||
-            board.nameKey}/${tile.label || tile.labelKey || tile.id}`;
 
-          if (image.startsWith('data:')) {
-            imageResponse = getBase64Image(image);
-            const defaultExtension = mime.extension(
-              imageResponse['content_type']
-            );
-            fetchedImageID = defaultExtension.length
-              ? `${fetchedImageID}.${defaultExtension}`
-              : fetchedImageID;
-            path = `/${fetchedImageID}`;
-          } else {
-            if (!isCordova()) {
-              path = image.startsWith('/') ? image : `/${image}`;
-            }
-            fetchedImageID = image;
-            try {
-              const result = await axios({
-                method: 'get',
-                url: image,
-                responseType: 'arraybuffer'
-              });
+          const imageResponse = image.startsWith('data:')
+            ? getBase64Image(image)
+            : await getDataUri(image);
 
-              // Convert the array buffer to a Base64-encoded string.
-              const encodedImage = btoa(
-                String.fromCharCode.apply(null, new Uint8Array(result.data))
-              );
-              contentType = result.headers['content-type'];
-              imageResponse = {
-                ab: result.data,
-                content_type: contentType,
-                data: `data:${contentType};base64,${encodedImage}`
-              };
-            } catch (e) {}
-          }
+          const getCustomImagePath = () => {
+            const components = [
+              'custom',
+              board.name || board.nameKey,
+              tile.label || tile.labelKey || tile.id
+            ];
+            const extension = mime.extension(imageResponse['content_type']);
+            return `/${_.join(components, '/')}.${extension}`;
+          };
+
+          const path = image.startsWith('data:')
+            ? getCustomImagePath()
+            : isCordova()
+            ? ''
+            : image.startsWith('/')
+            ? image
+            : `/${image}`;
 
           if (imageResponse) {
-            const imageID = `${board.id}_${image}`;
-            fetchedImages[fetchedImageID] = imageResponse;
+            const imageID = new mongoose.Types.ObjectId().toString();
+            fetchedImages[imageID] = _.defaults({ path }, imageResponse);
             button['image_id'] = imageID;
             images[imageID] = {
               id: imageID,
@@ -501,8 +510,9 @@ export async function openboardExportManyAdapter(boards = [], intl) {
 
     const imagesKeys = Object.keys(images);
     imagesKeys.forEach(key => {
-      const imageFilename = `images/${key}`;
-      zip.file(imageFilename, images[key].ab);
+      const image = images[key];
+      const imageFilename = `images/${image.path}`;
+      zip.file(imageFilename, image.ab);
       imagesMap[key] = imageFilename;
     });
 

--- a/src/components/Settings/Import/Import.container.js
+++ b/src/components/Settings/Import/Import.container.js
@@ -89,13 +89,16 @@ export class ImportContainer extends PureComponent {
           if (typeof boardToCreate.name === 'undefined') {
             boardToCreate.name = 'unknow';
           }
-          const response = await API.createBoard(boardToCreate);
-
-          if (board.id) {
-            response.prevId = board.id;
+          try {
+            const response = await API.createBoard(boardToCreate);
+            if (board.id) {
+              response.prevId = board.id;
+            }
+            return response;
+          } catch (err) {
+            console.log(err.message);
+            return board
           }
-
-          return response;
         })
       );
     } else {
@@ -103,7 +106,6 @@ export class ImportContainer extends PureComponent {
         if (board.id) {
           board.prevId = board.id;
         }
-
         board.id = shortid.generate();
       });
     }
@@ -130,7 +132,11 @@ export class ImportContainer extends PureComponent {
     };
 
     if (userData && userData.authToken && userData.authToken.length) {
-      communicatorModified = await API.updateCommunicator(communicatorModified);
+      try {
+        communicatorModified = await API.updateCommunicator(communicatorModified);
+      } catch (err) {
+        console.log(err.message);
+      }
     }
 
     this.props.upsertCommunicator(communicatorModified);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2622,6 +2622,19 @@ bindings@^1.5.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
+bl@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-2.2.0.tgz#e1a574cdf528e4053019bb800b041c0ac88da493"
+  integrity sha512-wbgvOpqopSr7uq6fJrLH8EsvYMJf9gzfo2jCsL2eTy75qXPukA4pCgHamOQkZtY5vmfVtjB+P3LNlMHW5CEZXA==
+  dependencies:
+    readable-stream "^2.3.5"
+    safe-buffer "^5.1.1"
+
+bluebird@3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
+  integrity sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==
+
 bluebird@^3.5.5:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
@@ -2858,6 +2871,11 @@ bser@2.1.1:
   integrity sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==
   dependencies:
     node-int64 "^0.4.0"
+
+bson@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/bson/-/bson-1.1.4.tgz#f76870d799f15b854dffb7ee32f0a874797f7e89"
+  integrity sha512-S/yKGU1syOMzO86+dGpg2qGoDL0zvzcb262G+gqEy6TgP6rt6z6qxSFX/8X6vLC91P7G7C3nLs0+bvDzmvBA3Q==
 
 btoa@^1.2.1:
   version "1.2.1"
@@ -4096,7 +4114,7 @@ debug@2.6.9, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.
   dependencies:
     ms "2.0.0"
 
-debug@=3.1.0:
+debug@3.1.0, debug@=3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
@@ -4241,6 +4259,11 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
+
+denque@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-1.4.1.tgz#6744ff7641c148c3f8a69c307e51235c1f4a37cf"
+  integrity sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ==
 
 depd@^1.1.0, depd@~1.1.2:
   version "1.1.2"
@@ -8030,6 +8053,11 @@ jszip@^3.5.0:
     readable-stream "~2.3.6"
     set-immediate-shim "~1.0.1"
 
+kareem@2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/kareem/-/kareem-2.3.1.tgz#def12d9c941017fabfb00f873af95e9c99e1be87"
+  integrity sha512-l3hLhffs9zqoDe8zjmb/mAN4B8VT3L56EUvKNqLFVs9YlFA+zx7ke1DO8STAdDyYNkeSo1nKmjuvQeI12So8Xw==
+
 keycode@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/keycode/-/keycode-2.2.0.tgz#3d0af56dc7b8b8e5cba8d0a97f107204eec22b04"
@@ -8679,6 +8707,11 @@ memory-fs@^0.5.0:
     errno "^0.1.3"
     readable-stream "^2.0.1"
 
+memory-pager@^1.0.2:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/memory-pager/-/memory-pager-1.5.0.tgz#d8751655d22d384682741c972f2c3d6dfa3e66b5"
+  integrity sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==
+
 meow@^3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
@@ -8795,7 +8828,7 @@ mime-db@1.44.0, "mime-db@>= 1.43.0 < 2":
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.44.0.tgz#fa11c5eb0aca1334b4233cb4d52f10c5a6272f92"
   integrity sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==
 
-mime-types@^2.0.7, mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
+mime-types@^2.0.7, mime-types@^2.1.12, mime-types@^2.1.27, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
   version "2.1.27"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.27.tgz#47949f98e279ea53119f5722e0f34e529bec009f"
   integrity sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==
@@ -8954,6 +8987,41 @@ moment@2.27.0:
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.27.0.tgz#8bff4e3e26a236220dfe3e36de756b6ebaa0105d"
   integrity sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==
 
+mongodb@3.5.10:
+  version "3.5.10"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.5.10.tgz#ed414988d2935b529004cead6dfdd22681258887"
+  integrity sha512-p/C48UvTU/dr/PQEDKfb9DsCVDJWXGmdJNFC+u5FPmTQVtog69X6D8vrWHz+sJx1zJnd96sjdh9ueo7bx2ILTw==
+  dependencies:
+    bl "^2.2.0"
+    bson "^1.1.4"
+    denque "^1.4.1"
+    require_optional "^1.0.1"
+    safe-buffer "^5.1.2"
+  optionalDependencies:
+    saslprep "^1.0.0"
+
+mongoose-legacy-pluralize@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz#3ba9f91fa507b5186d399fb40854bff18fb563e4"
+  integrity sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ==
+
+mongoose@^5.9.25:
+  version "5.9.27"
+  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-5.9.27.tgz#914cbc2a454520934fbbf2c0e366d9c7d8076b3b"
+  integrity sha512-N8zj4pj9J2xJ2BnQ4NiIHEtmjPldtbmbEZOMz4phLTQr3KFWPR0T0I6EzQxNioHwmDbHD4VFzbEd755oD2SJxA==
+  dependencies:
+    bson "^1.1.4"
+    kareem "2.3.1"
+    mongodb "3.5.10"
+    mongoose-legacy-pluralize "1.0.2"
+    mpath "0.7.0"
+    mquery "3.2.2"
+    ms "2.1.2"
+    regexp-clone "1.0.0"
+    safe-buffer "5.2.1"
+    sift "7.0.1"
+    sliced "1.0.1"
+
 moo@^0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.1.tgz#7aae7f384b9b09f620b6abf6f74ebbcd1b65dbc4"
@@ -8971,6 +9039,22 @@ move-concurrently@^1.0.1:
     rimraf "^2.5.4"
     run-queue "^1.0.3"
 
+mpath@0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/mpath/-/mpath-0.7.0.tgz#20e8102e276b71709d6e07e9f8d4d0f641afbfb8"
+  integrity sha512-Aiq04hILxhz1L+f7sjGyn7IxYzWm1zLNNXcfhDtx04kZ2Gk7uvFdgZ8ts1cWa/6d0TQmag2yR8zSGZUmp0tFNg==
+
+mquery@3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/mquery/-/mquery-3.2.2.tgz#e1383a3951852ce23e37f619a9b350f1fb3664e7"
+  integrity sha512-XB52992COp0KP230I3qloVUbkLUxJIu328HBP2t2EsxSFtf4W1HPSOBWOXf1bqxK4Xbb66lfMJ+Bpfd9/yZE1Q==
+  dependencies:
+    bluebird "3.5.1"
+    debug "3.1.0"
+    regexp-clone "^1.0.0"
+    safe-buffer "5.1.2"
+    sliced "1.0.1"
+
 ms@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
@@ -8986,7 +9070,7 @@ ms@2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
-ms@^2.1.1:
+ms@2.1.2, ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
@@ -11487,7 +11571,7 @@ read-pkg@^4.0.1:
     parse-json "^4.0.0"
     pify "^3.0.0"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.3, readable-stream@~2.3.6:
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.3, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -11662,6 +11746,11 @@ regex-parser@2.2.10:
   version "2.2.10"
   resolved "https://registry.yarnpkg.com/regex-parser/-/regex-parser-2.2.10.tgz#9e66a8f73d89a107616e63b39d4deddfee912b37"
   integrity sha512-8t6074A68gHfU8Neftl0Le6KTDwfGAj7IyjPIMSfikI2wJUTHDMaIq42bUsfVnj8mhx0R+45rdUXHGpN164avA==
+
+regexp-clone@1.0.0, regexp-clone@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/regexp-clone/-/regexp-clone-1.0.0.tgz#222db967623277056260b992626354a04ce9bf63"
+  integrity sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw==
 
 regexp.prototype.flags@^1.2.0, regexp.prototype.flags@^1.3.0:
   version "1.3.0"
@@ -11841,6 +11930,14 @@ require-main-filename@^2.0.0:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
 
+require_optional@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/require_optional/-/require_optional-1.0.1.tgz#4cf35a4247f64ca3df8c2ef208cc494b1ca8fc2e"
+  integrity sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==
+  dependencies:
+    resolve-from "^2.0.0"
+    semver "^5.1.0"
+
 requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
@@ -11860,6 +11957,11 @@ resolve-dir@^0.1.0:
   dependencies:
     expand-tilde "^1.2.2"
     global-modules "^0.2.3"
+
+resolve-from@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-2.0.0.tgz#9480ab20e94ffa1d9e80a804c7ea147611966b57"
+  integrity sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=
 
 resolve-from@^3.0.0:
   version "3.0.0"
@@ -12048,7 +12150,7 @@ safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
+safe-buffer@5.2.1, safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -12084,6 +12186,13 @@ sanitize.css@^10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/sanitize.css/-/sanitize.css-10.0.0.tgz#b5cb2547e96d8629a60947544665243b1dc3657a"
   integrity sha512-vTxrZz4dX5W86M6oVWVdOVe72ZiPs41Oi7Z6Km4W5Turyz28mrXSJhhEBZoRtzJWIv3833WKVwLSDWWkEfupMg==
+
+saslprep@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/saslprep/-/saslprep-1.0.3.tgz#4c02f946b56cf54297e347ba1093e7acac4cf226"
+  integrity sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==
+  dependencies:
+    sparse-bitfield "^3.0.3"
 
 sass-loader@8.0.2:
   version "8.0.2"
@@ -12389,6 +12498,11 @@ side-channel@^1.0.2:
     es-abstract "^1.17.0-next.1"
     object-inspect "^1.7.0"
 
+sift@7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/sift/-/sift-7.0.1.tgz#47d62c50b159d316f1372f8b53f9c10cd21a4b08"
+  integrity sha512-oqD7PMJ+uO6jV9EQCl0LrRw1OwsiPsiFQR5AR30heR+4Dl7jBBbDLnNvWiak20tzZlSE1H7RB30SX/1j/YYT7g==
+
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
@@ -12452,6 +12566,11 @@ slice-ansi@^4.0.0:
     ansi-styles "^4.0.0"
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
+
+sliced@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/sliced/-/sliced-1.0.1.tgz#0b3a662b5d04c3177b1926bea82b03f837a2ef41"
+  integrity sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E=
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
@@ -12575,6 +12694,13 @@ sourcemap-codec@^1.4.1:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
   integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
+
+sparse-bitfield@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz#ff4ae6e68656056ba4b3e792ab3334d38273ca11"
+  integrity sha1-/0rm5oZWBWuks+eSqzM004JzyhE=
+  dependencies:
+    memory-pager "^1.0.2"
 
 spdx-correct@^3.0.0:
   version "3.1.1"


### PR DESCRIPTION
This PR changes the behaviour when importing boards in the Open Board Format to no longer upload files and instead store them as data URIs. This allows users to see images even when they're offline. 

A few more things that are out of scope, but still included in this PR:

- I noticed an issue with the export to OBZ. From what I understand, the image ids in `manifest.json` need to match the ones in the OBF files. This is fixed in 78e32a7.
- The content type wasn't set properly after #739. This is fixed in 919d3a6.

I did some QA but I encourage everyone to give it a try, especially with Cordova. There are _many_ scenarios to test.

Close #756 