### PR TITLE
Avoid recursive function when converting images to data URI

### DIFF
--- a/src/components/Settings/Export/Export.helpers.js
+++ b/src/components/Settings/Export/Export.helpers.js
@@ -98,7 +98,10 @@ export async function getDataUri(url) {
 
     // Convert the array buffer to a Base64-encoded string.
     const encodedImage = btoa(
-      String.fromCharCode.apply(null, new Uint8Array(result.data))
+      new Uint8Array(result.data).reduce(
+        (data, byte) => data + String.fromCharCode(byte),
+        ''
+      )
     );
     const contentType = result.headers['content-type'];
 
@@ -108,7 +111,7 @@ export async function getDataUri(url) {
       data: `data:${contentType};base64,${encodedImage}`
     };
   } catch (e) {
-    console.error(`Failed to get image at ${url}.`);
+    console.error(`Failed to get image at ${url}.`, e);
   }
 }
 


### PR DESCRIPTION
Large images stored remotely currently cannot be exported because the function to convert them to a data URI is recursive, which causes us to exceed the maximum call stack size.

This PR replaces the function call with a reduce operation to avoid getting a `RangeError`.

Close #763