### PR TITLE
Fix incorrect `image/svg` MIME type during import

### DIFF
--- a/src/components/Settings/Import/Import.helpers.js
+++ b/src/components/Settings/Import/Import.helpers.js
@@ -86,9 +86,14 @@ async function getTilesData(obfBoard, boards = {}, images = {}) {
         if (image) {
           let imageData = image.data || null;
           if (image['content_type'] && image.path && images[image.path]) {
-            imageData = `data:${image['content_type']};base64,${
-              images[image.path]
-              }`;
+            // Certain OBF files have an incorrect MIME type for SVG files, so
+            // the resulting data URI cannot be rendered. We need to fix the
+            // MIME type ourselves.
+            const contentType =
+              image['content_type'] === 'image/svg'
+                ? 'image/svg+xml'
+                : image['content_type'];
+            imageData = `data:${contentType};base64,${images[image.path]}`;
           }
           if (image.url) {
             tileButton.image = image.url;
@@ -224,7 +229,7 @@ export async function obzImportAdapter(file, intl, allBoards) {
             images[k] = result;
           }
         }
-      } catch (e) { }
+      } catch (e) {}
 
       return result;
     })


### PR DESCRIPTION
This PR updates the logic to import boards in the Open Board Format to handle an invalid MIME type for SVG files that currently prevents proper rendering. Before and after:

![image](https://user-images.githubusercontent.com/46613478/89461035-47724400-d739-11ea-8afb-bda06c17bba9.png)

Close #765 