### PR TITLE
Update Output.container.js to simplify the props.output.map from symbol to labels

### DIFF
--- a/src/components/Board/Output/Output.container.js
+++ b/src/components/Board/Output/Output.container.js
@@ -183,8 +183,7 @@ export class OutputContainer extends Component {
 
   handleCopyClick = () => {
     const { intl, showNotification } = this.props;
-    let labels = [];
-    this.props.output.map(symbol => labels.push(symbol.label));
+    const labels = this.props.output.map(symbol => symbol.label);
     navigator.clipboard.writeText(labels.join(' '));
     showNotification(intl.formatMessage(messages.copyMessage));
   };


### PR DESCRIPTION
As @sylvansson commented, it would be simpler to assign the value when declaring the variable, so updating for improved style.