### PR TITLE
Revert "wrap snackbar content in a ReactFragment container"

### DIFF
--- a/src/components/Notifications/Notifications.component.js
+++ b/src/components/Notifications/Notifications.component.js
@@ -42,23 +42,21 @@ const Notifications = ({
     // present one transitions out
     onExited={showQueuedNotificationIfAny}
   >
-    <>
-      {kind === 'refresh' && (
-        <Alert
-          elevation={6}
-          variant="filled"
-          onClose={handleNotificationDismissal}
-          severity="info"
-          action={
-            <Button variant="outlined" onClick={onRefreshPage}>
-              <FormattedMessage {...messages.refreshPage} />
-            </Button>
-          }
-        >
-          <span id="message-id">{message}</span>
-        </Alert>
-      )}
-    </>
+    {kind === 'refresh' && (
+      <Alert
+        elevation={6}
+        variant="filled"
+        onClose={handleNotificationDismissal}
+        severity="info"
+        action={
+          <Button variant="outlined" onClick={onRefreshPage}>
+            <FormattedMessage {...messages.refreshPage} />
+          </Button>
+        }
+      >
+        <span id="message-id">{message}</span>
+      </Alert>
+    )}
   </Snackbar>
 );
 


### PR DESCRIPTION
Reverts cboard-org/cboard#906

This introduced a critical bug, causing blank page as soon a snackbar is displayed 

```
utils.js:2 Uncaught TypeError: Cannot read property 'scrollTop' of null
    at reflow (utils.js:2)
    at Grow.js:77
    at Object.onEnter (Grow.js:69)
    at Transition.performEnter (Transition.js:262)
    at Transition.updateStatus (Transition.js:228)
    at Transition.componentDidMount (Transition.js:172)
    at commitLifeCycles (react-dom.development.js:20663)
    at commitLayoutEffects (react-dom.development.js:23426)
    at HTMLUnknownElement.callCallback (react-dom.development.js:3945)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:3994)
    at invokeGuardedCallback (react-dom.development.js:4056)
    at commitRootImpl (react-dom.development.js:23151)
    at unstable_runWithPriority (scheduler.development.js:468)
    at runWithPriority$1 (react-dom.development.js:11276)
    at commitRoot (react-dom.development.js:22990)
    at performSyncWorkOnRoot (react-dom.development.js:22329)
    at react-dom.development.js:11327
    at unstable_runWithPriority (scheduler.development.js:468)
    at runWithPriority$1 (react-dom.development.js:11276)
    at flushSyncCallbackQueueImpl (react-dom.development.js:11322)
    at flushSyncCallbackQueue (react-dom.development.js:11309)
    at scheduleUpdateOnFiber (react-dom.development.js:21893)
    at Object.enqueueSetState (react-dom.development.js:12467)
    at Connect.push../node_modules/react/cjs/react.development.js.Component.setState (react.development.js:365)
    at Connect.onStateChange (connectAdvanced.js:207)
    at Object.notify (Subscription.js:23)
    at Subscription.notifyNestedSubs (Subscription.js:62)
    at Connect.onStateChange (connectAdvanced.js:204)
    at Object.notify (Subscription.js:23)
    at Subscription.notifyNestedSubs (Subscription.js:62)
    at Connect.onStateChange (connectAdvanced.js:204)
    at Object.notify (Subscription.js:23)
    at Subscription.notifyNestedSubs (Subscription.js:62)
    at Connect.onStateChange (connectAdvanced.js:204)
    at Object.notify (Subscription.js:23)
    at Subscription.notifyNestedSubs (Subscription.js:62)
    at Connect.onStateChange (connectAdvanced.js:204)
    at dispatch (redux.js:222)
    at create-middleware.js:17
    at index.js:11
    at redux.js:477
    at Board.container.js:886
```