### PR TITLE
README: Add Cauldron metrics and stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ Languages were machine translated and require proofreading, if you want to help 
 
 **You do not need to be a programmer!**
 
-Translations play a major role in this project and they contribute a lot for inclusion of children specially in non developed countries. Please consider to collaborate with us! 
+Translations play a major role in this project and they contribute a lot for inclusion of children specially in non developed countries. Please consider to collaborate with us!
 
-### Translations for developers 
+### Translations for developers
 
 In order to pull the latest translations from CrowdIn into the codebase, you can run `yarn translations:pull`. This will update all language files such as `en.json` as well as the central `cboard.json` file. Please note that this requires the CrowdIn API key to be available in the `.private` config file. Refer to [Secrets Management](#secrets-management). After the script completes, changes to the translation files will need to be committed to the repo by the usual process.
 
@@ -84,6 +84,10 @@ If you need to add or change a secret, make the change to the `.private/local.js
 
 _Note: These keys/secrets are *not* required to run or develop Cboard._ They are used with scripts by some team members.
 
+## About the Cboard community
+
+[![Cauldron dashboard and metrics for the Cboard project community](https://cauldron.io/project/1683/stats.svg)](https://cauldron.io/project/1683 "Cauldron dashboard and metrics for the Cboard project community")
+
 ## Thanks
 
 ### Symbols sources
@@ -102,7 +106,7 @@ _Note: These keys/secrets are *not* required to run or develop Cboard._ They are
 
 <img src="https://avatars2.githubusercontent.com/u/1119453?s=200&v=4" href="https://www.browserstack.com/" alt="Browserstack" width="40" height="40">[  Browserstack](https://www.browserstack.com/) - for providing the automation infrastructure for testing.
 
-### Development 
+### Development
 
 <img src="./public/images/sponsers/css-tricks.svg" alt="CSS-Tricks" width="120" height="39">[  CSS Tricks](https://css-tricks.com) - for providing feedback and support from the early stage.
 


### PR DESCRIPTION
This commit adds a pre-generated infographic about the project activity
and community. I thought it was impressive, so I figured to suggest
adding it into the README.

![Screenshot of added section in the README](https://user-images.githubusercontent.com/4721034/118978750-ae1dc280-b945-11eb-9c69-8ac7ac45201f.png "Screenshot of added section in the README")

FYI: @GeorgLink @jjmerchante @anajsana