### PR TITLE
Logout Android Google Users and prevent render of the button on electron

### DIFF
--- a/src/components/Settings/People/People.container.js
+++ b/src/components/Settings/People/People.container.js
@@ -8,6 +8,8 @@ import People from './People.component';
 import { getUser, isLogged } from '../../App/App.selectors';
 import API from '../../../api';
 
+import { isAndroid } from '../../../cordova-util';
+
 export class PeopleContainer extends PureComponent {
   static propTypes = {
     history: PropTypes.object.isRequired
@@ -46,21 +48,29 @@ export class PeopleContainer extends PureComponent {
   };
 
   handleLogout = () => {
+    if (isAndroid()) {
+      window.plugins.googleplus.disconnect(function(msg) {
+        console.log('disconnect msg' + msg);
+      });
+    }
     this.props.logout();
   };
 
   render() {
     const { history } = this.props;
 
-    return <People
-      onClose={history.goBack}
-      isLogged={this.props.isLogged}
-      logout={this.handleLogout}
-      name={this.state.name}
-      email={this.state.email}
-      birthdate={this.state.birthdate}
-      onChangePeople={this.handleChange}
-      onSubmitPeople={this.handleSubmit} />;
+    return (
+      <People
+        onClose={history.goBack}
+        isLogged={this.props.isLogged}
+        logout={this.handleLogout}
+        name={this.state.name}
+        email={this.state.email}
+        birthdate={this.state.birthdate}
+        onChangePeople={this.handleChange}
+        onSubmitPeople={this.handleSubmit}
+      />
+    );
   }
 }
 
@@ -74,4 +84,7 @@ const mapDispatchToProps = {
   updateUserData: updateUserData
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(PeopleContainer);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(PeopleContainer);

--- a/src/components/Settings/Settings.component.js
+++ b/src/components/Settings/Settings.component.js
@@ -21,6 +21,8 @@ import SettingsSection from './SettingsSection.component';
 import FullScreenDialog from '../UI/FullScreenDialog';
 import UserIcon from '../UI/UserIcon';
 
+import { isAndroid } from '../../cordova-util';
+
 import './Settings.css';
 
 const propTypes = {
@@ -32,6 +34,15 @@ const propTypes = {
 export class Settings extends PureComponent {
   getSettingsSections() {
     const { isLogged, logout, user } = this.props;
+
+    function handleLogOutClick() {
+      if (isAndroid()) {
+        window.plugins.googleplus.disconnect(function(msg) {
+          console.log('disconnect msg' + msg);
+        });
+      }
+      logout();
+    }
 
     return [
       {
@@ -47,7 +58,11 @@ export class Settings extends PureComponent {
             text: isLogged ? messages.username : messages.guest,
             url: '/settings/people',
             rightContent: isLogged ? (
-              <Button color="primary" onClick={logout} variant="outlined">
+              <Button
+                color="primary"
+                onClick={handleLogOutClick}
+                variant="outlined"
+              >
                 <FormattedMessage {...messages.logout} />
               </Button>
             ) : (

--- a/src/components/WelcomeScreen/WelcomeScreen.container.js
+++ b/src/components/WelcomeScreen/WelcomeScreen.container.js
@@ -19,7 +19,7 @@ import ResetPassword from '../Account/ResetPassword';
 import CboardLogo from './CboardLogo/CboardLogo.component';
 import './WelcomeScreen.css';
 import { API_URL } from '../../constants';
-import { isCordova, isAndroid } from '../../cordova-util';
+import { isCordova, isAndroid, isElectron } from '../../cordova-util';
 import { login } from '../Account/Login/Login.actions';
 
 export class WelcomeScreen extends Component {
@@ -114,12 +114,14 @@ export class WelcomeScreen extends Component {
             </Button>
 
             <div className="WelcomeScreen__button WelcomeScreen__button">
-              <GoogleLoginButton
-                className="WelcomeScreen__button WelcomeScreen__button--google"
-                onClick={this.handleGoogleLoginClick}
-              >
-                <FormattedMessage {...messages.google} />
-              </GoogleLoginButton>
+              {!isElectron() && (
+                <GoogleLoginButton
+                  className="WelcomeScreen__button WelcomeScreen__button--google"
+                  onClick={this.handleGoogleLoginClick}
+                >
+                  <FormattedMessage {...messages.google} />
+                </GoogleLoginButton>
+              )}
 
               {!isCordova() && (
                 <FacebookLoginButton


### PR DESCRIPTION
This PR brings the possibility to clear the OAuth2 token, forget which account was used to log in, and disconnect that account from the app. This will require the user to allow the app access again the next time they sign in.
and Prevent de render of the google login button on electron devices.