### PR TITLE
Resolve Google login button bug

### DIFF
--- a/src/components/WelcomeScreen/WelcomeScreen.css
+++ b/src/components/WelcomeScreen/WelcomeScreen.css
@@ -5,7 +5,7 @@
   color: #eceff1;
   overflow: auto;
   background: url('/images/bg/bg-pattern.png'),
-   linear-gradient(to right, rgb(121, 22, 254), rgb(172, 47, 138));
+    linear-gradient(to right, rgb(121, 22, 254), rgb(172, 47, 138));
 }
 
 .WelcomeScreen__container {
@@ -47,7 +47,7 @@
   justify-content: space-between;
   width: calc(50% - 0.5em);
   min-width: 300px;
-  margin: 0 auto;
+  margin: 0 auto 8%;
 }
 
 .WelcomeScreen__footer .WelcomeScreen__button {


### PR DESCRIPTION
the Google login button doesn't work properly if the device uses the android navigation bar on the touch screen. This PR adds a margin-bottom on the footer tag to prevent the overlap of the main nav and the login buttons.
this is a screenshot using master branch: 
![imagen](https://user-images.githubusercontent.com/21298844/129812472-0ad9da22-372c-4898-bfc3-7a9e768cec49.png)
apk generated with this branch:
https://drive.google.com/file/d/1tcseLKceAseYewZrRqY9661a8VcdSu2s/view?usp=sharing
