### PR TITLE
Fix/symbols fixed board on Safari ios

### DIFF
--- a/src/components/Board/Symbol/Symbol.css
+++ b/src/components/Board/Symbol/Symbol.css
@@ -6,7 +6,15 @@
   justify-content: flex-end;
   overflow: hidden;
   background: none;
+  position: absolute;
+  top: 0;
+  left: 0;
 }
+
+.LiveSymbolOutput__value > .Symbol {
+  padding: 0.2em;
+}
+
 .Symbol textarea {
   align-self: flex-start;
   font-weight: 700;
@@ -34,6 +42,12 @@
 .Symbol__image-container {
   position: relative;
   flex: 1;
+  width: 97%;
+  margin: auto;
+}
+
+.Tile .Symbol__image-container {
+  margin-top: var(--folder-flap-height);
 }
 
 .Symbol__image {
@@ -47,10 +61,10 @@
 }
 
 .Symbol__label {
-  width: 100%;
+  width: 95%;
   font-size: 0.85rem;
   font-weight: 700;
-  margin: 2px 0;
+  margin: 2px auto;
   position: relative;
   text-align: center;
   display: table-cell;
@@ -62,7 +76,7 @@
 @media (min-width: 600px) {
   .Symbol__label {
     font-size: 1rem;
-    margin: 4px 0;
+    margin: 4px auto;
   }
 }
 

--- a/src/components/Board/Symbol/Symbol.css
+++ b/src/components/Board/Symbol/Symbol.css
@@ -11,8 +11,13 @@
   left: 0;
 }
 
+.Tile .Symbol {
+  padding-top: var(--folder-flap-height);
+  padding-bottom: 0.3em;
+}
+
 .LiveSymbolOutput__value > .Symbol {
-  padding: 0.2em 0.5em 0.2em 0.5em;
+  padding: 0.2em 0.9em 0.2em 0.9em;
 }
 
 .Symbol textarea {
@@ -44,10 +49,6 @@
   flex: 1;
   width: 97%;
   margin: auto;
-}
-
-.Tile .Symbol__image-container {
-  margin-top: var(--folder-flap-height);
 }
 
 .Symbol__image {

--- a/src/components/Board/Tile/Tile.css
+++ b/src/components/Board/Tile/Tile.css
@@ -6,6 +6,8 @@
   background: none;
   cursor: pointer;
 
+  --folder-flap-height: 14px;
+
   /* HACK: fixes iOS flicker on scroll */
   transform: translateZ(0);
 }
@@ -68,7 +70,7 @@
 .TileShape--folder::after {
   content: '';
   width: 50%;
-  height: 14px;
+  height: var(--folder-flap-height);
   border-radius: 0 20px 0 0;
   position: absolute;
   top: 0;

--- a/src/components/FixedGrid/DraggableItem/DraggableItem.module.css
+++ b/src/components/FixedGrid/DraggableItem/DraggableItem.module.css
@@ -1,4 +1,7 @@
 .root {
   width: 100%;
   height: 100%;
+  position: absolute;
+  top: 0;
+  right: 0;
 }


### PR DESCRIPTION
### This was developed with #1092 merged 
Until merging it on master would be draft.  The reason for the test fail is commented [here](https://github.com/cboard-org/cboard/pull/1092#issuecomment-995050527)

This PR fixes #853 'Symbols do not show when board is in fixed mode'. Was fixed by adding `position: absolute` to the parent's containers of the images. Was a bug only on the Safari browser, and older versions of google Chrome. it's related to flexbox. 

### Test

This Branch was tested on different devices and browsers. The tests result in an improvement in browsers compatibility.
Cordova Build works too. 

Safari 9: cboard not works
Safari 10: fixed mode not works fine. board visible height is not detected fine
Safari 11: works
Safari 13: works

-----IOS-----
Iphone 6 V8 -safari: cboard not work,
Iphone 7 V10: fixed mode not works,
IPhone 6 V11 -safari: works
12V14.4: works

----Android----
Galaxy S6 - V5.0,
chrome: works
Mozilla: unable to connect

Galaxy S7 - V6:
Chrome: works,
Mozilla: works

Galaxy S21 - V11:
Chrome: works,
Mozilla: works,

----windows 10-----
Lastest
chrome: works
Mozilla: works

chrome 44: Cboard does not work
chrome 49: works; (production does not work on fixed)
chrome 90: works;

Mozilla 50: works
Mozilla 95: works

Yandex 14: Cboard not work

opera 45: works
opera 82: works

-----Build Cordova Android----
Samsung A7:works