### PR TITLE
Bug/live mode clean output bar

### DIFF
--- a/src/components/Board/Symbol/Symbol.js
+++ b/src/components/Board/Symbol/Symbol.js
@@ -53,7 +53,6 @@ function Symbol(props) {
           autoFocus={true}
           multiline
           rows={5}
-          defaultValue={label}
           value={label}
           onChange={onWrite}
           fullWidth={true}


### PR DESCRIPTION
Fix for console error ForwardRef(InputBase) contains a textarea with both value and defaultValue props. Textarea elements must be either controlled or uncontrolled (specify either the value prop, or the defaultValue prop, but not both). Decide between using a controlled or uncontrolled textarea and remove one of these props.