### PR TITLE
Implement facebook login on Android devices

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -52,8 +52,16 @@ class API {
         ) {
           if (isAndroid()) {
             window.plugins.googleplus.disconnect(function(msg) {
-              console.log('disconnect msg' + msg);
+              console.log('disconnect google msg' + msg);
             });
+            window.facebookConnectPlugin.logout(
+              function(msg) {
+                console.log('disconnect facebook msg' + msg);
+              },
+              function(msg) {
+                console.log('error facebook disconnect msg' + msg);
+              }
+            );
           }
           getStore().dispatch(logout());
           history.push('/login-signup/');

--- a/src/components/Settings/People/People.container.js
+++ b/src/components/Settings/People/People.container.js
@@ -50,8 +50,16 @@ export class PeopleContainer extends PureComponent {
   handleLogout = () => {
     if (isAndroid()) {
       window.plugins.googleplus.disconnect(function(msg) {
-        console.log('disconnect msg' + msg);
+        console.log('disconnect google msg' + msg);
       });
+      window.facebookConnectPlugin.logout(
+        function(msg) {
+          console.log('disconnect facebook msg' + msg);
+        },
+        function(msg) {
+          console.log('error facebook disconnect msg' + msg);
+        }
+      );
     }
     this.props.logout();
   };

--- a/src/components/Settings/Settings.component.js
+++ b/src/components/Settings/Settings.component.js
@@ -44,8 +44,16 @@ export class Settings extends PureComponent {
     function handleLogOutClick() {
       if (isAndroid()) {
         window.plugins.googleplus.disconnect(function(msg) {
-          console.log('disconnect msg' + msg);
+          console.log('disconnect google msg' + msg);
         });
+        window.facebookConnectPlugin.logout(
+          function(msg) {
+            console.log('disconnect facebook msg' + msg);
+          },
+          function(msg) {
+            console.log('error facebook disconnect msg' + msg);
+          }
+        );
       }
       logout();
     }

--- a/src/components/WelcomeScreen/WelcomeScreen.container.js
+++ b/src/components/WelcomeScreen/WelcomeScreen.container.js
@@ -82,12 +82,6 @@ export class WelcomeScreen extends Component {
   handleFacebookLoginClick = () => {
     const { intl, login } = this.props;
     if (isAndroid()) {
-      window.facebookConnectPlugin.setApplicationId(FACEBOOK_APP_ID, () =>
-        console.log('App id changed successfully')
-      );
-      window.facebookConnectPlugin.setApplicationName(FACEBOOK_APP_NAME, () =>
-        console.log('App name changed successfully')
-      );
       window.facebookConnectPlugin.login(
         ['email'],
         function(userData) {

--- a/src/components/WelcomeScreen/WelcomeScreen.container.js
+++ b/src/components/WelcomeScreen/WelcomeScreen.container.js
@@ -19,8 +19,8 @@ import SignUp from '../Account/SignUp';
 import ResetPassword from '../Account/ResetPassword';
 import CboardLogo from './CboardLogo/CboardLogo.component';
 import './WelcomeScreen.css';
-import { API_URL } from '../../constants';
-import { isCordova, isAndroid, isElectron } from '../../cordova-util';
+import { API_URL, FACEBOOK_APP_ID, FACEBOOK_APP_NAME } from '../../constants';
+import { isAndroid, isElectron } from '../../cordova-util';
 import { login } from '../Account/Login/Login.actions';
 
 export class WelcomeScreen extends Component {
@@ -70,12 +70,44 @@ export class WelcomeScreen extends Component {
           );
         },
         function(msg) {
-          alert(intl.formatMessage(messages.googleLoginErrorAndroid));
+          alert(intl.formatMessage(messages.loginErrorAndroid));
           console.log('error: ' + msg);
         }
       );
     } else {
       window.location = `${API_URL}/login/google`;
+    }
+  };
+
+  handleFacebookLoginClick = () => {
+    const { intl, login } = this.props;
+    if (isAndroid()) {
+      window.facebookConnectPlugin.setApplicationId(FACEBOOK_APP_ID, () =>
+        console.log('App id changed successfully')
+      );
+      window.facebookConnectPlugin.setApplicationName(FACEBOOK_APP_NAME, () =>
+        console.log('App name changed successfully')
+      );
+      window.facebookConnectPlugin.login(
+        ['email'],
+        function(userData) {
+          window.facebookConnectPlugin.getAccessToken(function(accesToken) {
+            login(
+              {
+                email: 'facebooktoken',
+                password: `?access_token=${accesToken}`
+              },
+              'oAuth'
+            );
+          });
+        },
+        function(msg) {
+          alert(intl.formatMessage(messages.loginErrorAndroid));
+          console.log(msg);
+        }
+      );
+    } else {
+      window.location = `${API_URL}/login/facebook`;
     }
   };
 
@@ -124,12 +156,10 @@ export class WelcomeScreen extends Component {
                 </GoogleLoginButton>
               )}
 
-              {!isCordova() && (
+              {!isElectron() && (
                 <FacebookLoginButton
                   className="WelcomeScreen__button WelcomeScreen__button--facebook"
-                  onClick={() => {
-                    window.location = `${API_URL}/login/facebook`;
-                  }}
+                  onClick={this.handleFacebookLoginClick}
                 >
                   <FormattedMessage {...messages.facebook} />
                 </FacebookLoginButton>

--- a/src/components/WelcomeScreen/WelcomeScreen.container.js
+++ b/src/components/WelcomeScreen/WelcomeScreen.container.js
@@ -19,7 +19,7 @@ import SignUp from '../Account/SignUp';
 import ResetPassword from '../Account/ResetPassword';
 import CboardLogo from './CboardLogo/CboardLogo.component';
 import './WelcomeScreen.css';
-import { API_URL, FACEBOOK_APP_ID, FACEBOOK_APP_NAME } from '../../constants';
+import { API_URL } from '../../constants';
 import { isAndroid, isElectron } from '../../cordova-util';
 import { login } from '../Account/Login/Login.actions';
 

--- a/src/components/WelcomeScreen/WelcomeScreen.messages.js
+++ b/src/components/WelcomeScreen/WelcomeScreen.messages.js
@@ -21,8 +21,8 @@ export default defineMessages({
     id: 'cboard.components.WelcomeScreen.skipForNow',
     defaultMessage: 'Skip for now'
   },
-  googleLoginErrorAndroid: {
-    id: 'cboard.components.WelcomeScreen.googleLoginErrorAndroid',
+  loginErrorAndroid: {
+    id: 'cboard.components.WelcomeScreen.loginErrorAndroid',
     defaultMessage:
       'Sorry. An error occurred during authenticate process. Please try it again'
   },

--- a/src/constants.js
+++ b/src/constants.js
@@ -19,7 +19,3 @@ export const AZURE_VOICES_BASE_PATH_API =
   'https://' +
   AZURE_SPEECH_SERVICE_REGION +
   '.tts.speech.microsoft.com/cognitiveservices/voices/';
-export const FACEBOOK_APP_ID =
-  process.env.REACT_APP_FACEBOOK_APP_ID || '340205533290626';
-export const FACEBOOK_APP_NAME =
-  process.env.REACT_APP_FACEBOOK_APP_NAME || 'Cboard - Development';

--- a/src/constants.js
+++ b/src/constants.js
@@ -19,3 +19,7 @@ export const AZURE_VOICES_BASE_PATH_API =
   'https://' +
   AZURE_SPEECH_SERVICE_REGION +
   '.tts.speech.microsoft.com/cognitiveservices/voices/';
+export const FACEBOOK_APP_ID =
+  process.env.REACT_APP_FACEBOOK_APP_ID || '340205533290626';
+export const FACEBOOK_APP_NAME =
+  process.env.REACT_APP_FACEBOOK_APP_NAME || 'Cboard - Development';

--- a/src/cordova-util.js
+++ b/src/cordova-util.js
@@ -1,3 +1,5 @@
+import { FACEBOOK_APP_ID, FACEBOOK_APP_NAME } from './constants';
+
 export const isCordova = () => !!window.cordova;
 
 export const isAndroid = () =>
@@ -35,6 +37,12 @@ export const initCordovaPlugins = () => {
     } catch (err) {
       console.log(err.message);
     }
+    window.facebookConnectPlugin.setApplicationId(FACEBOOK_APP_ID, () =>
+      console.log('Facebook plugin - App id changed successfully')
+    );
+    window.facebookConnectPlugin.setApplicationName(FACEBOOK_APP_NAME, () =>
+      console.log('Facebook plugin - App name changed successfully')
+    );
   }
 };
 

--- a/src/cordova-util.js
+++ b/src/cordova-util.js
@@ -1,5 +1,3 @@
-import { FACEBOOK_APP_ID, FACEBOOK_APP_NAME } from './constants';
-
 export const isCordova = () => !!window.cordova;
 
 export const isAndroid = () =>
@@ -37,13 +35,29 @@ export const initCordovaPlugins = () => {
     } catch (err) {
       console.log(err.message);
     }
-    window.facebookConnectPlugin.setApplicationId(FACEBOOK_APP_ID, () =>
-      console.log('Facebook plugin - App id changed successfully')
-    );
-    window.facebookConnectPlugin.setApplicationName(FACEBOOK_APP_NAME, () =>
-      console.log('Facebook plugin - App name changed successfully')
-    );
+    configFacebookPlugin();
   }
+};
+
+const configFacebookPlugin = () => {
+  const FACEBOOK_APP_ID =
+    process.env.REACT_APP_FACEBOOK_APP_ID || '340205533290626';
+  const FACEBOOK_APP_NAME =
+    process.env.REACT_APP_FACEBOOK_APP_NAME || 'Cboard - Development';
+  window.facebookConnectPlugin.setApplicationId(
+    FACEBOOK_APP_ID,
+    function successFunction() {},
+    function errorFunction(error) {
+      console.error(error);
+    }
+  );
+  window.facebookConnectPlugin.setApplicationName(
+    FACEBOOK_APP_NAME,
+    function successFunction() {},
+    function errorFunction(error) {
+      console.error(error);
+    }
+  );
 };
 
 export const cvaTrackEvent = (category, action, label) => {

--- a/src/cordova-util.js
+++ b/src/cordova-util.js
@@ -29,7 +29,7 @@ export const initCordovaPlugins = () => {
       window.AndroidFullScreen.immersiveMode(
         function successFunction() {},
         function errorFunction(error) {
-          console.error(error);
+          console.error(error.message);
         }
       );
     } catch (err) {
@@ -48,14 +48,14 @@ const configFacebookPlugin = () => {
     FACEBOOK_APP_ID,
     function successFunction() {},
     function errorFunction(error) {
-      console.error(error);
+      console.error(error.message);
     }
   );
   window.facebookConnectPlugin.setApplicationName(
     FACEBOOK_APP_NAME,
     function successFunction() {},
     function errorFunction(error) {
-      console.error(error);
+      console.error(error.message);
     }
   );
 };

--- a/src/translations/src/cboard.json
+++ b/src/translations/src/cboard.json
@@ -4,7 +4,7 @@
   "cboard.components.WelcomeScreen.skipForNow": "Skip for now",
   "cboard.components.WelcomeScreen.google": "Sign in with Google",
   "cboard.components.WelcomeScreen.facebook": "Sign in with Facebook",
-  "cboard.components.WelcomeScreen.googleLoginErrorAndroid": "Sorry. An error occurred during authenticate process. Please try it again",
+  "cboard.components.WelcomeScreen.loginErrorAndroid": "Sorry. An error occurred during authenticate process. Please try it again",
   "cboard.components.WelcomeScreen.terms": "Terms",
   "cboard.components.WelcomeScreen.privacy": "Privacy Policy",
   "cboard.components.WelcomeScreenInformation.heading": "Welcome to Cboard",


### PR DESCRIPTION
In this PR, a new plugin of Cordova was added [Facebook connect plugin](https://github.com/cordova-plugin-facebook-connect/cordova-plugin-facebook-connect)  for implement the  login with Facebook  on android devices - [Cordova PR](https://github.com/cboard-org/ccboard/pull/23)
First, you need to set the appId and appName of the facebook  developer. After that, send a login request to get the acces token of the client and ask for the email permission.
The cboard api uses the acces token to verify with a passport strategy the login of the user - [API PR](https://github.com/cboard-org/cboard-api/pull/190#issue-838667704)


Issue: #862