### PR TITLE
Android - Share board on facebook

### DIFF
--- a/src/components/Board/BoardShare/BoardShare.component.js
+++ b/src/components/Board/BoardShare/BoardShare.component.js
@@ -36,27 +36,29 @@ function shareBoardOnFacebook(url, intl) {
     hashtag: '#Cboard',
     quote: intl.formatMessage(messages.subject)
   };
+
+  const errorFunction = msg => {
+    if (msg.errorCode != '4201')
+      alert(intl.formatMessage(messages.cannotShare));
+  };
+
   window.facebookConnectPlugin.logout(
     function succcesFunction(msg) {},
     function(msg) {
       console.log('error facebook disconnect msg' + msg);
     }
   );
+
   window.facebookConnectPlugin.login(
     ['email'],
     function succesLogin(userData) {
       window.facebookConnectPlugin.showDialog(
         shareData,
         function succcesFunction() {},
-        function errorFunction() {
-          alert(intl.formatMessage(messages.cannotShare));
-        }
+        msg => errorFunction(msg)
       );
     },
-    function errorLogin(msg) {
-      alert(intl.formatMessage(messages.cannotShare));
-      console.log(msg);
-    }
+    msg => errorFunction(msg)
   );
 }
 

--- a/src/components/Board/BoardShare/BoardShare.component.js
+++ b/src/components/Board/BoardShare/BoardShare.component.js
@@ -38,7 +38,7 @@ function shareBoardOnFacebook(url, intl) {
   };
 
   const errorFunction = msg => {
-    if (msg.errorCode != '4201')
+    if (msg.errorCode !== '4201')
       alert(intl.formatMessage(messages.cannotShare));
   };
 

--- a/src/components/Board/BoardShare/BoardShare.component.js
+++ b/src/components/Board/BoardShare/BoardShare.component.js
@@ -27,6 +27,38 @@ import withMobileDialog from '@material-ui/core/withMobileDialog';
 import messages from './BoardShare.messages';
 
 import './BoardShare.css';
+import { isAndroid } from '../../../cordova-util';
+
+function shareBoardOnFacebook(url, intl) {
+  const shareData = {
+    method: 'share',
+    href: url,
+    hashtag: '#Cboard',
+    quote: intl.formatMessage(messages.subject)
+  };
+  window.facebookConnectPlugin.logout(
+    function succcesFunction(msg) {},
+    function(msg) {
+      console.log('error facebook disconnect msg' + msg);
+    }
+  );
+  window.facebookConnectPlugin.login(
+    ['email'],
+    function succesLogin(userData) {
+      window.facebookConnectPlugin.showDialog(
+        shareData,
+        function succcesFunction() {},
+        function errorFunction() {
+          alert(intl.formatMessage(messages.cannotShare));
+        }
+      );
+    },
+    function errorLogin(msg) {
+      alert(intl.formatMessage(messages.cannotShare));
+      console.log(msg);
+    }
+  );
+}
 
 const BoardShare = ({
   label,
@@ -118,15 +150,29 @@ const BoardShare = ({
                 <FormattedMessage id="email" {...messages.email} />
               </EmailShareButton>
             </Button>
-            <Button disabled={!isPublic}>
-              <FacebookShareButton
-                quote={intl.formatMessage(messages.subject)}
-                url={url}
+
+            {!isAndroid() ? (
+              <Button disabled={!isPublic}>
+                <FacebookShareButton
+                  quote={intl.formatMessage(messages.subject)}
+                  url={url}
+                >
+                  <FacebookIcon round />
+                  <FormattedMessage id="facebook" {...messages.facebook} />
+                </FacebookShareButton>
+              </Button>
+            ) : (
+              <Button
+                disabled={!isPublic}
+                onClick={() => shareBoardOnFacebook(url, intl)}
               >
-                <FacebookIcon round />
-                <FormattedMessage id="facebook" {...messages.facebook} />
-              </FacebookShareButton>
-            </Button>
+                <div>
+                  <FacebookIcon round />
+                  <FormattedMessage id="facebook" {...messages.facebook} />
+                </div>
+              </Button>
+            )}
+
             <Button disabled={!isPublic}>
               <TwitterShareButton
                 title={intl.formatMessage(messages.subject)}

--- a/src/components/Board/BoardShare/BoardShare.messages.js
+++ b/src/components/Board/BoardShare/BoardShare.messages.js
@@ -57,5 +57,10 @@ export default defineMessages({
     id: 'cboard.components.BoardShare.body',
     defaultMessage:
       'Hello! I want to share a communication board from the Cboard tool. Please find it at: {url}'
+  },
+  cannotShare: {
+    id: 'cboard.components.BoardShare.cannotShare',
+    defaultMessage:
+      'Cannot share the board on facebook. Please try again later.'
   }
 });

--- a/src/translations/src/cboard.json
+++ b/src/translations/src/cboard.json
@@ -178,6 +178,7 @@
   "cboard.components.BoardShare.reddit": "Reddit",
   "cboard.components.BoardShare.subject": "Check out this board from Cboard!",
   "cboard.components.BoardShare.body": "Hello! I want to share a communication board from the Cboard tool. Please find it at: {url}",
+  "cboard.components.BoardShare.cannotshare": "Cannot share the board on facebook. Please try again later.",
   "cboard.components.PhraseShare.title": "Share or copy your Phrase",
   "cboard.components.PhraseShare.close": "Close",
   "cboard.components.PhraseShare.copyPhrase": "Copy phrase",


### PR DESCRIPTION
This pull request will close: #769

It uses the recently added cordova facebook-connect plugin.
It allows you to share boards on facebook. It does not matter whether or not the user has the Facebook app installed on their device.
