### PR TITLE
Prevent creating a board without the tiles property

### DIFF
--- a/src/components/Board/Board.container.js
+++ b/src/components/Board/Board.container.js
@@ -1420,7 +1420,8 @@ export class BoardContainer extends Component {
         email: userData.email
       };
     }
-    createBoard(newBoard);
+    // Prevent creating a board without the tiles property
+    if (newBoard.tiles) createBoard(newBoard);
     // Loggedin user?
     if ('name' in userData && 'email' in userData) {
       try {


### PR DESCRIPTION
During pasting prevent the creation of a board without the tiles property.
Lost boards shouldn't be created during the pasting process. close #1235 