### PR TITLE
Raise nodejs heap limit when building from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /usr/src/app
 COPY package.json yarn.lock ./
 RUN yarn install
 COPY . ./
-RUN yarn build
+RUN NODE_OPTIONS="--max-old-space-size=4192" yarn build
 
 # Stage 2 - the production environment
 FROM nginx:stable-alpine


### PR DESCRIPTION
The defaults of 2096 doesn't seem to be sufficient anymore to build Cboard for production.

The following error was raised :
```
$ react-scripts build && sw-precache --config=sw-precache-config.js
Creating an optimized production build...

<--- Last few GCs --->

[35:0x7f93779763e0]   217185 ms: Scavenge 2036.0 (2079.8) -> 2033.7 (2081.0) MB, 5.8 / 0.0 ms  (average mu = 0.237, current mu = 0.197) allocation failure
[35:0x7f93779763e0]   217200 ms: Scavenge 2037.0 (2081.0) -> 2034.6 (2081.8) MB, 5.9 / 0.0 ms  (average mu = 0.237, current mu = 0.197) allocation failure
[35:0x7f93779763e0]   217217 ms: Scavenge 2037.7 (2081.8) -> 2035.3 (2090.0) MB, 6.4 / 0.0 ms  (average mu = 0.237, current mu = 0.197) allocation failure

<--- JS stacktrace --->

FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
error Command failed with exit code 1.
```

Raising heap limit to 4192 (~4GB) fixed the issue.