### PR TITLE
Implemented option to export PDF board with PicseePal dimensions

### DIFF
--- a/src/components/Settings/Export/Export.component.js
+++ b/src/components/Settings/Export/Export.component.js
@@ -204,6 +204,9 @@ class Export extends React.Component {
                             <MenuItem value="cboard">Cboard</MenuItem>
                             <MenuItem value="openboard">OpenBoard</MenuItem>
                             <MenuItem value="pdf">PDF</MenuItem>
+                            <MenuItem value="picsee_pdf">
+                              PicseePal PDF
+                            </MenuItem>
                           </Select>
                         </FormControl>
                       </div>
@@ -268,6 +271,7 @@ class Export extends React.Component {
                           <MenuItem value="cboard">Cboard</MenuItem>
                           <MenuItem value="openboard">OpenBoard</MenuItem>
                           <MenuItem value="pdf">PDF</MenuItem>
+                          <MenuItem value="picsee_pdf">PicseePal PDF</MenuItem>
                         </Select>
                       </FormControl>
                     )}

--- a/src/components/Settings/Export/Export.constants.js
+++ b/src/components/Settings/Export/Export.constants.js
@@ -41,6 +41,6 @@ export const EXPORT_CONFIG_BY_TYPE = {
   },
   picsee_pdf: {
     filename: 'picsee_board.pdf',
-    callback: 'picseePdfExportAdapter'
+    callback: 'pdfExportAdapter'
   }
 };

--- a/src/components/Settings/Export/Export.constants.js
+++ b/src/components/Settings/Export/Export.constants.js
@@ -38,5 +38,9 @@ export const EXPORT_CONFIG_BY_TYPE = {
   pdf: {
     filename: 'board.pdf',
     callback: 'pdfExportAdapter'
+  },
+  picsee_pdf: {
+    filename: 'picsee_board.pdf',
+    callback: 'picseePdfExportAdapter'
   }
 };

--- a/src/components/Settings/Export/Export.container.js
+++ b/src/components/Settings/Export/Export.container.js
@@ -38,6 +38,13 @@ export class ExportContainer extends PureComponent {
       await EXPORT_HELPERS.openboardExportAdapter(singleBoard, intl);
     } else if (type === 'cboard') {
       await EXPORT_HELPERS.cboardExportAdapter(boards, singleBoard);
+    } else if (type === 'picsee_pdf') {
+      if (singleBoard) {
+        await EXPORT_HELPERS[exportConfig.callback]([singleBoard], intl, true);
+      } else {
+        const currentBoard = boards.filter(board => board.id === activeBoardId);
+        await EXPORT_HELPERS[exportConfig.callback](currentBoard, intl, true);
+      }
     } else if (type !== 'pdf' && !singleBoard) {
       await EXPORT_HELPERS[exportConfig.callback](boards, intl);
     } else {

--- a/src/components/Settings/Export/Export.helpers.js
+++ b/src/components/Settings/Export/Export.helpers.js
@@ -521,7 +521,7 @@ const addTileToGrid = async (
       1: 130,
       2: 130,
       3: 80,
-      4: 80,
+      4: 84,
       5: 75,
       6: 60,
       7: 55,
@@ -530,19 +530,33 @@ const addTileToGrid = async (
       10: 45,
       11: 40,
       12: 37
-      // max num of columns or rows is 12
+      // max num of columns is 12
     };
-    var colFontSizes = {
-      9: 9,
-      10: 9,
-      11: 8,
-      12: 7
+    var rowImgWidths = {
+      1: 130,
+      2: 130,
+      3: 86,
+      4: 59,
+      5: 45,
+      6: 33,
+      7: 32,
+      8: 26,
+      9: 21,
+      10: 17,
+      11: 14,
+      12: 11
+      // max num of rows is 12
     };
-    imageData.width = colImgWidths[columns];
-    if (columns in colFontSizes) {
-      labelData.fontSize = colFontSizes[columns];
+
+    imageData.width = Math.min(colImgWidths[columns], rowImgWidths[rows]);
+
+    if (imageData.width <= 37) {
+      labelData.fontSize = 7;
+    } else if (imageData.width <= 40) {
+      labelData.fontSize = 8;
+    } else if (imageData.width <= 45) {
+      labelData.fontSize = 9;
     }
-    console.log(columns);
   } else {
     // if not picseepal PDF, then retain old method for computing image widths
     if (11 === columns || columns === 12 || rows >= 6) {
@@ -851,7 +865,7 @@ export async function pdfExportAdapter(boards = [], intl, picsee = false) {
       };
     };
 
-    docDefinition.pageMargins = [144, 93, 144, 158];
+    docDefinition.pageMargins = [144, 93, 144, 130];
   }
 
   const lastBoardIndex = boards.length - 1;

--- a/src/components/Settings/Export/Export.helpers.js
+++ b/src/components/Settings/Export/Export.helpers.js
@@ -330,7 +330,7 @@ async function toDataURL(url, styles = {}, outputFormat = 'image/jpeg') {
   });
 }
 
-async function generatePDFBoard(board, intl, breakPage = true) {
+async function generatePDFBoard(board, intl, breakPage = true, picsee = false) {
   const header = board.name || '';
   const columns =
     board.isFixed && board.grid ? board.grid.columns : CBOARD_COLUMNS;
@@ -352,8 +352,8 @@ async function generatePDFBoard(board, intl, breakPage = true) {
   }
 
   const grid = board.isFixed
-    ? await generateFixedBoard(board, rows, columns, intl, table)
-    : await generateNonFixedBoard(board, rows, columns, intl, table);
+    ? await generateFixedBoard(board, rows, columns, intl, picsee)
+    : await generateNonFixedBoard(board, rows, columns, intl, picsee);
 
   const lastGridRowDiff = columns - grid[grid.length - 2].length; // labels row
   if (lastGridRowDiff > 0) {
@@ -378,7 +378,7 @@ function chunks(array, size) {
   return results;
 }
 
-async function generateFixedBoard(board, rows, columns, intl) {
+async function generateFixedBoard(board, rows, columns, intl, picsee = false) {
   let currentRow = 0;
   let cont = 0;
 
@@ -430,7 +430,8 @@ async function generateFixedBoard(board, rows, columns, intl) {
           rows,
           columns,
           currentRow,
-          pageBreak
+          pageBreak,
+          picsee
         );
         cont++;
       }
@@ -439,7 +440,13 @@ async function generateFixedBoard(board, rows, columns, intl) {
   return grid;
 }
 
-async function generateNonFixedBoard(board, rows, columns, intl) {
+async function generateNonFixedBoard(
+  board,
+  rows,
+  columns,
+  intl,
+  picsee = false
+) {
   // Do a grid with 2n rows
   const grid = new Array(Math.ceil(board.tiles.length / columns) * 2);
   let currentRow = 0;
@@ -448,7 +455,16 @@ async function generateNonFixedBoard(board, rows, columns, intl) {
     // Wait for previous tile
     await prev;
     currentRow = i >= (currentRow + 1) * columns ? currentRow + 1 : currentRow;
-    return await addTileToGrid(tile, intl, grid, rows, columns, currentRow);
+    return await addTileToGrid(
+      tile,
+      intl,
+      grid,
+      rows,
+      columns,
+      currentRow,
+      false,
+      picsee
+    );
   }, Promise.resolve());
   return grid;
 }
@@ -460,7 +476,8 @@ const addTileToGrid = async (
   rows,
   columns,
   currentRow,
-  pageBreak = false
+  pageBreak = false,
+  picsee = false
 ) => {
   const { label, image } = getPDFTileData(tile, intl);
   const fixedRow = currentRow * 2;
@@ -491,6 +508,10 @@ const addTileToGrid = async (
     alignment: 'center',
     width: '100'
   };
+  if (picsee) {
+    // scale down images to fit inside PicseePal dimensions
+    imageData.width = '60';
+  }
 
   const labelData = {
     text: label,
@@ -754,6 +775,97 @@ export async function pdfExportAdapter(boards = [], intl) {
     const prevContent = await prev;
     const breakPage = i !== lastBoardIndex;
     const boardPDFData = await generatePDFBoard(board, intl, breakPage);
+    return prevContent.concat(boardPDFData);
+  }, Promise.resolve([]));
+
+  docDefinition.content = content;
+  const pdfObj = pdfMake.createPdf(docDefinition);
+
+  if (pdfObj) {
+    let prefix = getDatetimePrefix();
+    if (content.length === 2) {
+      prefix = prefix + content[0] + ' ';
+    } else {
+      prefix = prefix + 'boardsset ';
+    }
+    if (isAndroid()) {
+      requestCvaWritePermissions();
+      pdfObj.getBuffer(buffer => {
+        var blob = new Blob([buffer], { type: 'application/pdf' });
+        const name = 'Download/' + prefix + EXPORT_CONFIG_BY_TYPE.pdf.filename;
+        writeCvaFile(name, blob);
+      });
+    } else {
+      // On a browser simply use download!
+      pdfObj.download(prefix + EXPORT_CONFIG_BY_TYPE.pdf.filename);
+    }
+  }
+}
+
+export async function picseePdfExportAdapter(boards = [], intl) {
+  // modified version of pdfExportAdapter function for PicseePal compatible PDF
+  const docDefinition = {
+    pageSize: 'A4',
+    background: function() {
+      return {
+        stack: [
+          {
+            text: [
+              {
+                text: '\nPicseePal compatible PDF',
+                fontSize: 18,
+                alignment: 'center',
+                bold: true
+              }
+            ]
+          },
+          {
+            canvas: [
+              {
+                // rectangle showing PicseePal viewable area
+                type: 'rect',
+                x: 137.5,
+                y: 48,
+                w: 567,
+                h: 374.22,
+                r: 5,
+                lineColor: 'black'
+              },
+              {
+                // dashed line rectangle to cut
+                type: 'rect',
+                x: 101.65,
+                y: 11.5,
+                w: 638.7,
+                h: 447,
+                r: 55,
+                dash: { length: 5 },
+                lineColor: 'black'
+              }
+            ]
+          },
+          {
+            text: [
+              {
+                text: `\nPlease print on A4 / US Letter paper at 100% scale.
+                          Cut along dashed line before inserting into PicseePal device.`,
+                fontSize: 15,
+                alignment: 'center'
+              }
+            ]
+          }
+        ]
+      };
+    },
+    pageOrientation: 'landscape',
+    pageMargins: [144, 93, 144, 130],
+    content: []
+  };
+  const lastBoardIndex = boards.length - 1;
+  const content = await boards.reduce(async (prev, board, i) => {
+    const prevContent = await prev;
+    const breakPage = i !== lastBoardIndex;
+    const boardPDFData = await generatePDFBoard(board, intl, breakPage, true);
     return prevContent.concat(boardPDFData);
   }, Promise.resolve([]));
 

--- a/src/components/Settings/Export/__snapshots__/Export.test.js.snap
+++ b/src/components/Settings/Export/__snapshots__/Export.test.js.snap
@@ -106,6 +106,11 @@ exports[`Export tests default renderer 1`] = `
                     >
                       PDF
                     </ForwardRef(WithStyles(ForwardRef(MenuItem)))>
+                    <ForwardRef(WithStyles(ForwardRef(MenuItem)))
+                      value="picsee_pdf"
+                    >
+                      PicseePal PDF
+                    </ForwardRef(WithStyles(ForwardRef(MenuItem)))>
                   </ForwardRef(WithStyles(ForwardRef(Select)))>
                 </ForwardRef(WithStyles(ForwardRef(FormControl)))>
               </div>
@@ -179,6 +184,11 @@ exports[`Export tests default renderer 1`] = `
                     value="pdf"
                   >
                     PDF
+                  </ForwardRef(WithStyles(ForwardRef(MenuItem)))>
+                  <ForwardRef(WithStyles(ForwardRef(MenuItem)))
+                    value="picsee_pdf"
+                  >
+                    PicseePal PDF
                   </ForwardRef(WithStyles(ForwardRef(MenuItem)))>
                 </ForwardRef(WithStyles(ForwardRef(Select)))>
               </ForwardRef(WithStyles(ForwardRef(FormControl)))>


### PR DESCRIPTION
As requested in #1126, I’ve implemented PDF generation with PicseePal dimensions and have tested it with multiple boards. The PicseePal PDF is generated on standard A4 sized paper. The icons are scaled down and the PDF has guides to cut the paper to the right size to fit within the PicseePal device (200mm x 132mm viewable area). The solid line on the PDF represents the viewable area and the dashed line is where the paper should be cut.

Provided the user sets the scale in the print dialog to 100%, the dimensions will also be exactly correct when printed on US Letter sized paper (standard paper size in the US). Setting the scale to 100%, and NOT fit/shrink to fit, will ensure the print will be the correct dimensions regardless of the printer paper size.

If the user forgets to set the scale to 100%, then the size will still be exactly correct on A4 paper, but will be slightly smaller (~92%) on US letter paper. This reduction is not large, so it can still be used in a PicseePal (with a few mm extra white border).

Please let me know if you would like this implemented any differently. I also considered adding an option to ask the user if they would like the pdf in A4 or US Letter size, but I thought this may add confusion.
