### PR TITLE
Navigation buttons on the side fallback

### DIFF
--- a/src/components/Board/Board.component.js
+++ b/src/components/Board/Board.component.js
@@ -319,8 +319,9 @@ export class Board extends Component {
     const cols = DISPLAY_SIZE_GRID_COLS[this.props.displaySettings.uiSize];
     const isLoggedIn = !!userData.email;
     const isNavigationButtonsOnTheSide =
+      navigationSettings.navigationButtonsStyle === undefined ||
       navigationSettings.navigationButtonsStyle ===
-      NAVIGATION_BUTTONS_STYLE_SIDES;
+        NAVIGATION_BUTTONS_STYLE_SIDES;
 
     return (
       <Scanner


### PR DESCRIPTION
close #1305 
After the app loads the new version, the new navigationSettings.navigationButtonsStyle state is not added to the persistent state. To mitigate that, a fallback condition was added to prevent the incorrect behavior.