### PR TITLE
Include localhost Web Sockets on Content-Security-Policy to allow Safari development

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,6 +12,10 @@
         http://localhost:3000/
         http://localhost:10010/
         http://www.googletagmanager.com/gtag/js
+        ws://localhost:3000/
+        wss://localhost:3000/
+        ws://192.168.0.109:3000/
+        wss://192.168.0.109:3000/
         wss://*.microsoft.com/cognitiveservices/
         blob:
         gap:


### PR DESCRIPTION
close #1171 