### PR TITLE
Fix/Output bar on Ios

### DIFF
--- a/src/components/Board/Output/SymbolOutput/Scroll/Scroll.css
+++ b/src/components/Board/Output/SymbolOutput/Scroll/Scroll.css
@@ -5,7 +5,7 @@
   display: flex;
   flex-grow: 1;
   align-items: center;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .Scroll__container:not(:empty):focus {

--- a/src/components/Board/Output/SymbolOutput/Scroll/Scroll.css
+++ b/src/components/Board/Output/SymbolOutput/Scroll/Scroll.css
@@ -1,11 +1,3 @@
-.Scroll {
-  position: relative;
-  flex: 1;
-  overflow-x: auto;
-  overflow-y: hidden;
-  -webkit-overflow-scrolling: touch;
-}
-
 .Scroll__container {
   position: absolute;
   min-width: 100%;

--- a/src/components/Board/Output/SymbolOutput/Scroll/Scroll.css
+++ b/src/components/Board/Output/SymbolOutput/Scroll/Scroll.css
@@ -6,6 +6,8 @@
   flex-grow: 1;
   align-items: center;
   overflow-x: auto;
+  padding-left: 0.7em;
+  padding-right: 0.7em;
 }
 
 .Scroll__container:not(:empty):focus {

--- a/src/components/Board/Output/SymbolOutput/Scroll/Scroll.css
+++ b/src/components/Board/Output/SymbolOutput/Scroll/Scroll.css
@@ -1,9 +1,11 @@
 .Scroll__container {
-  position: absolute;
-  min-width: 100%;
+  position: relative;
+  width: auto;
   height: 100%;
   display: flex;
+  flex-grow: 1;
   align-items: center;
+  overflow-x: scroll;
 }
 
 .Scroll__container:not(:empty):focus {

--- a/src/components/Board/Output/SymbolOutput/Scroll/Scroll.js
+++ b/src/components/Board/Output/SymbolOutput/Scroll/Scroll.js
@@ -5,8 +5,6 @@ import { Scannable } from 'react-scannable';
 
 import './Scroll.css';
 
-const invertDir = dir => (dir === 'rtl' ? 'ltr' : 'rtl');
-
 export class Scroll extends PureComponent {
   static propTypes = {
     /**
@@ -23,20 +21,16 @@ export class Scroll extends PureComponent {
       ...other
     } = this.props;
 
-    const scrollStyle = { direction: invertDir(direction) };
-
     return (
-      <div className="Scroll" style={scrollStyle}>
-        <Scannable>
-          <div
-            className="Scroll__container"
-            style={{ ...style, direction }}
-            {...other}
-          >
-            {children}
-          </div>
-        </Scannable>
-      </div>
+      <Scannable>
+        <div
+          className="Scroll__container"
+          style={{ ...style, direction }}
+          {...other}
+        >
+          {children}
+        </div>
+      </Scannable>
     );
   }
 }

--- a/src/components/Board/Output/SymbolOutput/Scroll/Scroll.js
+++ b/src/components/Board/Output/SymbolOutput/Scroll/Scroll.js
@@ -18,6 +18,7 @@ export class Scroll extends PureComponent {
       children,
       style,
       theme: { direction },
+      scrollContainerReference,
       ...other
     } = this.props;
 
@@ -26,6 +27,7 @@ export class Scroll extends PureComponent {
         <div
           className="Scroll__container"
           style={{ ...style, direction }}
+          ref={scrollContainerReference}
           {...other}
         >
           {children}

--- a/src/components/Board/Output/SymbolOutput/SymbolOutput.css
+++ b/src/components/Board/Output/SymbolOutput/SymbolOutput.css
@@ -13,7 +13,7 @@
 
 .SymbolOutput__value {
   height: calc(100% - 10px);
-  width: 100px;
+  min-width: 100px;
   padding: 0 5px;
   position: relative;
 }
@@ -21,7 +21,7 @@
 .LiveSymbolOutput__value {
   display: flex;
   height: 100%;
-  width: 140px;
+  min-width: 140px;
   padding: 3px 5px;
   align-self: flex-end;
   position: relative;

--- a/src/components/Board/Output/SymbolOutput/SymbolOutput.js
+++ b/src/components/Board/Output/SymbolOutput/SymbolOutput.js
@@ -139,7 +139,13 @@ class SymbolOutput extends PureComponent {
             </div>
           ))}
         </Scroll>
-        <div style={{ display: 'flex' }}>
+        <div
+          style={{
+            display: 'flex',
+            marginLeft: 'auto',
+            minWidth: 'fit-content'
+          }}
+        >
           {navigationSettings.shareShowActive && (
             <PhraseShare
               label={intl.formatMessage(messages.share)}

--- a/src/components/Board/Output/SymbolOutput/SymbolOutput.js
+++ b/src/components/Board/Output/SymbolOutput/SymbolOutput.js
@@ -18,7 +18,7 @@ import { injectIntl } from 'react-intl';
 class SymbolOutput extends PureComponent {
   constructor(props) {
     super(props);
-
+    this.myRef = React.createRef();
     this.state = {
       openPhraseShareDialog: false
     };
@@ -53,6 +53,21 @@ class SymbolOutput extends PureComponent {
   static defaultProps = {
     symbols: []
   };
+
+  componentDidUpdate(prevProps) {
+    const scrollToLastSymbol = () => {
+      const { symbols } = this.props;
+      if (prevProps.symbols.length < symbols.length) {
+        try {
+          this.myRef.current.lastElementChild.scrollIntoView();
+        } catch (err) {
+          console.error('Error during autoScroll of output bar', err);
+        }
+      }
+    };
+
+    scrollToLastSymbol();
+  }
 
   render() {
     const {
@@ -99,6 +114,7 @@ class SymbolOutput extends PureComponent {
                   : 'SymbolOutput__value'
               }
               key={index}
+              ref={this.myRef}
             >
               <Symbol
                 className="SymbolOutput__symbol"

--- a/src/components/Board/Output/SymbolOutput/SymbolOutput.js
+++ b/src/components/Board/Output/SymbolOutput/SymbolOutput.js
@@ -18,7 +18,7 @@ import { injectIntl } from 'react-intl';
 class SymbolOutput extends PureComponent {
   constructor(props) {
     super(props);
-    this.myRef = React.createRef();
+    this.scrollContainerRef = React.createRef();
     this.state = {
       openPhraseShareDialog: false
     };
@@ -108,7 +108,7 @@ class SymbolOutput extends PureComponent {
 
     return (
       <div className="SymbolOutput">
-        <Scroll {...other}>
+        <Scroll scrollContainerReference={this.scrollContainerRef} {...other}>
           {symbols.map(({ image, label, type }, index) => (
             <div
               className={
@@ -117,7 +117,6 @@ class SymbolOutput extends PureComponent {
                   : 'SymbolOutput__value'
               }
               key={index}
-              ref={this.myRef}
             >
               <Symbol
                 className="SymbolOutput__symbol"

--- a/src/components/Board/Output/SymbolOutput/SymbolOutput.js
+++ b/src/components/Board/Output/SymbolOutput/SymbolOutput.js
@@ -54,22 +54,26 @@ class SymbolOutput extends PureComponent {
     symbols: []
   };
 
-  componentDidUpdate(prevProps) {
-    const scrollToLastSymbol = () => {
-      const { symbols } = this.props;
-      if (prevProps.symbols.length < symbols.length) {
-        try {
-          this.myRef.current.lastElementChild.scrollIntoView({
-            behavior: 'smooth',
-            inline: 'end'
-          });
-        } catch (err) {
-          console.error('Error during autoScroll of output bar', err);
-        }
-      }
-    };
+  scrollToLastSymbol = () => {
+    try {
+      const lastOutputSymbol = this.scrollContainerRef.current.lastElementChild;
+      lastOutputSymbol.scrollIntoView({
+        behavior: 'smooth',
+        inline: 'start'
+      });
+    } catch (err) {
+      console.error('Error during autoScroll of output bar', err);
+    }
+  };
 
-    scrollToLastSymbol();
+  componentDidMount() {
+    //using a setTimeout to propperly works of scroll in to view depending of screen size render
+    setTimeout(this.scrollToLastSymbol, 200);
+  }
+
+  componentDidUpdate(prevProps) {
+    const { symbols } = this.props;
+    if (prevProps.symbols.length < symbols.length) this.scrollToLastSymbol();
   }
 
   render() {

--- a/src/components/Board/Output/SymbolOutput/SymbolOutput.js
+++ b/src/components/Board/Output/SymbolOutput/SymbolOutput.js
@@ -59,7 +59,10 @@ class SymbolOutput extends PureComponent {
       const { symbols } = this.props;
       if (prevProps.symbols.length < symbols.length) {
         try {
-          this.myRef.current.lastElementChild.scrollIntoView();
+          this.myRef.current.lastElementChild.scrollIntoView({
+            behavior: 'smooth',
+            inline: 'end'
+          });
         } catch (err) {
           console.error('Error during autoScroll of output bar', err);
         }


### PR DESCRIPTION
In order to create a global solution for all browsers and user agents. This fix implements a new way to auto-scroll to the output bar's last symbol. 
close #1397 