### PR TITLE
Disable Azure app insights telemetry on development

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -22,7 +22,7 @@ export const AZURE_VOICES_BASE_PATH_API =
 
 // AdSense constants
 
-const NODE_ENV = process.env.NODE_ENV;
+export const NODE_ENV = process.env.NODE_ENV;
 const HOSTNAME = window.location.hostname;
 export const ADSENSE_ON_PRODUCTION =
   HOSTNAME === 'app.cboard.io' && NODE_ENV === 'production';

--- a/src/index.js
+++ b/src/index.js
@@ -17,11 +17,12 @@ import SpeechProvider from './providers/SpeechProvider';
 import ThemeProvider from './providers/ThemeProvider';
 import configureStore, { getStore } from './store';
 import { ApplicationInsights } from '@microsoft/applicationinsights-web';
-import { AZURE_INST_KEY } from './constants';
+import { NODE_ENV, AZURE_INST_KEY } from './constants';
 
 if (AZURE_INST_KEY) {
   const appInsights = new ApplicationInsights({
     config: {
+      disableTelemetry: NODE_ENV === 'development',
       instrumentationKey: AZURE_INST_KEY,
       enableAutoRouteTracking: true,
       loggingLevelTelemetry: 2,


### PR DESCRIPTION
close #1421 
This only solves the problem on the web App
To fix this on cordova Apps we should develop a way to differentiate the build for the production from the debug