### PR TITLE
Fix verification in first purchase

### DIFF
--- a/src/providers/SubscriptionProvider/SubscriptionProvider.container.js
+++ b/src/providers/SubscriptionProvider/SubscriptionProvider.container.js
@@ -15,7 +15,13 @@ import {
   showPremiumRequired
 } from './SubscriptionProvider.actions';
 import { onAndroidResume } from '../../cordova-util';
-import { NOT_SUBSCRIBED, PROCCESING } from './SubscriptionProvider.constants';
+import {
+  ACTIVE,
+  CANCELED,
+  IN_GRACE_PERIOD,
+  NOT_SUBSCRIBED,
+  PROCCESING
+} from './SubscriptionProvider.constants';
 import { isLogged } from '../../components/App/App.selectors';
 
 export class SubscriptionProvider extends Component {
@@ -148,12 +154,15 @@ export class SubscriptionProvider extends Component {
       })
       .verified(receipt => {
         console.log('entro en verified');
+        const state = receipt.collection[0]?.subscriptionState;
+        if ([ACTIVE, CANCELED, IN_GRACE_PERIOD].includes(state)) {
         updateSubscription({
           isSubscribed: true,
           expiryDate: receipt.collection[0].expiryDate,
           androidSubscriptionState: receipt.collection[0].subscriptionState
         });
         window.CdvPurchase.store.finish(receipt);
+        }
       });
   };
 

--- a/src/providers/SubscriptionProvider/SubscriptionProvider.container.js
+++ b/src/providers/SubscriptionProvider/SubscriptionProvider.container.js
@@ -129,11 +129,7 @@ export class SubscriptionProvider extends Component {
   };
 
   configInAppPurchasePlugin = () => {
-    const {
-      updateSubscription,
-      androidSubscriptionState,
-      subscriberId
-    } = this.props;
+    const { updateSubscription, androidSubscriptionState } = this.props;
 
     this.configPurchaseValidator();
 
@@ -150,7 +146,7 @@ export class SubscriptionProvider extends Component {
       })
       .receiptUpdated(receipt => {})
       .approved(receipt => {
-        if (subscriberId) window.CdvPurchase.store.verify(receipt);
+        window.CdvPurchase.store.verify(receipt);
       })
       .verified(receipt => {
         console.log('entro en verified');


### PR DESCRIPTION
Two commits were added: 
- A condition to only  activate the subscription if the status is ACTIVE, CANCELED or  IN_GRACE_PERIOD
- Removed the conditional that checks if the subscriber id was present and stopped the plugin to check on first purchase.