### PR TITLE
Avoid loop after a 403 response of cboard-api

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -73,7 +73,6 @@ class API {
           }
           getStore().dispatch(logout());
           history.push('/login-signup/');
-          window.location.reload();
         }
         return Promise.reject(error);
       }


### PR DESCRIPTION
Window.location.reload() does not make sense after logout a User. With this change only a redirect to the sign-in screen occurs. avoiding a loop caused by location.reload on Cordova apps
close #1504 