### PR TITLE
Fix - Avoid loop on getsubscriber request

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -512,13 +512,14 @@ class API {
     return data;
   }
 
-  async getSubscriber(userId = getUserData().id) {
+  async getSubscriber(userId = getUserData().id, requestOrigin = 'unknown') {
     const authToken = getAuthToken();
     if (!(authToken && authToken.length)) {
       throw new Error('Need to be authenticated to perform this request');
     }
     const headers = {
-      Authorization: `Bearer ${authToken}`
+      Authorization: `Bearer ${authToken}`,
+      requestOrigin
     };
     const { data } = await this.axiosInstance.get(`/subscriber/${userId}`, {
       headers

--- a/src/appInsights.js
+++ b/src/appInsights.js
@@ -28,5 +28,13 @@ const initializeAppInsights = () => {
   appInsights.loadAppInsights();
   appInsights.trackPageView();
 };
+// Debug - Register which component made the getSubscriber() http request
+appInsights.addDependencyInitializer(dependencyTelemetry => {
+  const calledFrom =
+    dependencyTelemetry?.item?.properties?.requestHeaders?.CalledFrom;
+  if (calledFrom) {
+    dependencyTelemetry.item.properties.calledFrom = calledFrom;
+  }
+});
 
 export { initializeAppInsights };

--- a/src/appInsights.js
+++ b/src/appInsights.js
@@ -28,12 +28,12 @@ const initializeAppInsights = () => {
   appInsights.loadAppInsights();
   appInsights.trackPageView();
 };
-// Debug - Register which component made the getSubscriber() http request
+// Debug - Register getSubscriber() http request origin
 appInsights.addDependencyInitializer(dependencyTelemetry => {
-  const calledFrom =
-    dependencyTelemetry?.item?.properties?.requestHeaders?.CalledFrom;
-  if (calledFrom) {
-    dependencyTelemetry.item.properties.calledFrom = calledFrom;
+  const requestOrigin =
+    dependencyTelemetry?.item?.properties?.requestHeaders?.requestOrigin;
+  if (requestOrigin) {
+    dependencyTelemetry.item.properties.requestOrigin = requestOrigin;
   }
 });
 

--- a/src/appInsights.js
+++ b/src/appInsights.js
@@ -1,0 +1,32 @@
+import { ApplicationInsights } from '@microsoft/applicationinsights-web';
+import { NODE_ENV, AZURE_INST_KEY } from './constants';
+
+export const appInsights = new ApplicationInsights({
+  config: {
+    disableTelemetry: NODE_ENV === 'development',
+    instrumentationKey: AZURE_INST_KEY,
+    enableAutoRouteTracking: true,
+    loggingLevelTelemetry: 2,
+    enableCorsCorrelation: true,
+    enableRequestHeaderTracking: true,
+    enableResponseHeaderTracking: true,
+    enableAjaxErrorStatusText: true,
+    correlationHeaderExcludedDomains: [
+      '*.google-analytics.com',
+      'globalsymbols.com',
+      '*.arasaac.org',
+      'mulberrysymbols.org',
+      'madaportal.org',
+      '*.doubleclick.net',
+      'pagead2.googlesyndication.com',
+      'eastus.tts.speech.microsoft.com'
+    ]
+  }
+});
+
+const initializeAppInsights = () => {
+  appInsights.loadAppInsights();
+  appInsights.trackPageView();
+};
+
+export { initializeAppInsights };

--- a/src/components/Settings/Subscribe/Subscribe.container.js
+++ b/src/components/Settings/Subscribe/Subscribe.container.js
@@ -39,7 +39,9 @@ export class SubscribeContainer extends PureComponent {
 
   componentDidMount() {
     const { updateIsSubscribed, updatePlans } = this.props;
-    updateIsSubscribed();
+    const requestOrigin =
+      'Function: componentDidMount - Component: Subscribe Container';
+    updateIsSubscribed(false, requestOrigin);
     updatePlans();
   }
 
@@ -52,7 +54,9 @@ export class SubscribeContainer extends PureComponent {
 
   handleRefreshSubscription = () => {
     const { updateIsSubscribed, updatePlans } = this.props;
-    updateIsSubscribed();
+    const requestOrigin =
+      'Fuction: handleRefreshSubscription() - Component: subscribeContainer';
+    updateIsSubscribed(false, requestOrigin);
     updatePlans();
   };
 
@@ -62,7 +66,9 @@ export class SubscribeContainer extends PureComponent {
       this.setState({ cancelSubscriptionStatus: 'cancelling' });
       await API.cancelPlan(ownedProduct.paypalSubscriptionId);
       this.setState({ cancelSubscriptionStatus: 'ok' });
-      updateIsSubscribed();
+      const requestOrigin =
+        'Function: handleCancelSubscription() - Component:Subscribe Container';
+      updateIsSubscribed(false, requestOrigin);
       updatePlans();
     } catch (err) {
       console.error(err.message);
@@ -130,7 +136,9 @@ export class SubscribeContainer extends PureComponent {
     try {
       const res = await API.postTransaction(transaction);
       if (!res.ok) throw res;
-      const subscriber = await API.getSubscriber();
+      const requestOrigin =
+        'Function: handlePaypalApprove - Component: Subscribe Container';
+      const subscriber = await API.getSubscriber(false, requestOrigin);
       updateSubscription({
         ownedProduct: {
           ...product,
@@ -209,7 +217,9 @@ export class SubscribeContainer extends PureComponent {
 
       try {
         // update the api
-        const subscriber = await API.getSubscriber(user.id);
+        const requestOrigin =
+          'Function: handleSubscribe()- Component: Subscribe';
+        const subscriber = await API.getSubscriber(user.id, requestOrigin);
         updateSubscriberId(subscriber._id);
 
         // check if current subscriber already bought in this device

--- a/src/cordova-util.js
+++ b/src/cordova-util.js
@@ -14,10 +14,10 @@ export const onCordovaReady = onReady =>
 export const onAndroidPause = onPause =>
   document.addEventListener('pause', onPause, false);
 
-export const onAndroidResume = onResume =>
+export const onCvaResume = onResume =>
   document.addEventListener('resume', onResume, false);
 
-export const cleanUpOnAndroidResume = onResume => {
+export const cleanUpCvaOnResume = onResume => {
   document.removeEventListener('resume', onResume, false);
 };
 

--- a/src/cordova-util.js
+++ b/src/cordova-util.js
@@ -17,6 +17,10 @@ export const onAndroidPause = onPause =>
 export const onAndroidResume = onResume =>
   document.addEventListener('resume', onResume, false);
 
+export const cleanUpOnAndroidResume = onResume => {
+  document.removeEventListener('resume', onResume, false);
+};
+
 export const initCordovaPlugins = () => {
   console.log('now cordova is ready ');
   if (isCordova()) {

--- a/src/index.js
+++ b/src/index.js
@@ -17,35 +17,11 @@ import LanguageProvider from './providers/LanguageProvider';
 import SpeechProvider from './providers/SpeechProvider';
 import ThemeProvider from './providers/ThemeProvider';
 import configureStore, { getStore } from './store';
-import { ApplicationInsights } from '@microsoft/applicationinsights-web';
 import SubscriptionProvider from './providers/SubscriptionProvider';
-import { NODE_ENV, AZURE_INST_KEY, PAYPAL_CLIENT_ID } from './constants';
+import { PAYPAL_CLIENT_ID } from './constants';
+import { initializeAppInsights } from './appInsights';
 
-if (AZURE_INST_KEY) {
-  const appInsights = new ApplicationInsights({
-    config: {
-      disableTelemetry: NODE_ENV === 'development',
-      instrumentationKey: AZURE_INST_KEY,
-      enableAutoRouteTracking: true,
-      loggingLevelTelemetry: 2,
-      enableCorsCorrelation: true,
-      enableRequestHeaderTracking: true,
-      enableResponseHeaderTracking: true,
-      correlationHeaderExcludedDomains: [
-        '*.google-analytics.com',
-        'globalsymbols.com',
-        '*.arasaac.org',
-        'mulberrysymbols.org',
-        'madaportal.org',
-        '*.doubleclick.net',
-        'pagead2.googlesyndication.com',
-        'eastus.tts.speech.microsoft.com'
-      ]
-    }
-  });
-  appInsights.loadAppInsights();
-  appInsights.trackPageView(); // Manually call trackPageView to establish the current user/session/pageview
-}
+initializeAppInsights();
 const { persistor } = configureStore();
 const store = getStore();
 const dndOptions = {

--- a/src/providers/SubscriptionProvider/SubscriptionProvider.actions.js
+++ b/src/providers/SubscriptionProvider/SubscriptionProvider.actions.js
@@ -59,7 +59,10 @@ export function updateIsOnTrialPeriod() {
   };
 }
 
-export function updateIsSubscribed(isOnResume = false) {
+export function updateIsSubscribed(
+  isOnResume = false,
+  requestOrigin = 'unkwnown'
+) {
   return async (dispatch, getState) => {
     let isSubscribed = false;
     let ownedProduct = '';
@@ -99,8 +102,10 @@ export function updateIsSubscribed(isOnResume = false) {
 
         const userId = state.app.userData.id;
         const { status, product, transaction } = await API.getSubscriber(
-          userId
+          userId,
+          requestOrigin
         );
+
         isSubscribed =
           status.toLowerCase() === ACTIVE ||
           status.toLowerCase() === CANCELED ||

--- a/src/providers/SubscriptionProvider/SubscriptionProvider.container.js
+++ b/src/providers/SubscriptionProvider/SubscriptionProvider.container.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import API from '../../api';
-import { isAndroid } from '../../cordova-util';
+import { isAndroid, isCordova } from '../../cordova-util';
 
 import {
   updateIsInFreeCountry,
@@ -50,7 +50,8 @@ export class SubscriptionProvider extends Component {
       updatePlans
     } = this.props;
 
-    onCvaResume(this.onResume);
+    if (isCordova()) onCvaResume(this.onResume);
+
     const requestOrigin =
       'Function: componentDidMount - Component: SubscriptionProvider';
 
@@ -84,7 +85,7 @@ export class SubscriptionProvider extends Component {
   };
 
   componentWillUnmount() {
-    cleanUpCvaOnResume(this.onResume);
+    if (isCordova()) cleanUpCvaOnResume(this.onResume);
   }
 
   configPurchaseValidator = () => {

--- a/src/providers/SubscriptionProvider/SubscriptionProvider.container.js
+++ b/src/providers/SubscriptionProvider/SubscriptionProvider.container.js
@@ -13,7 +13,7 @@ import {
   updateIsOnTrialPeriod,
   showPremiumRequired
 } from './SubscriptionProvider.actions';
-import { onAndroidResume, cleanUpOnAndroidResume } from '../../cordova-util';
+import { onCvaResume, cleanUpCvaOnResume } from '../../cordova-util';
 import {
   ACTIVE,
   CANCELED,
@@ -34,7 +34,7 @@ export class SubscriptionProvider extends Component {
     } = this.props;
     const isOnResume = true;
     const requestOrigin =
-      'Function: onAndroidResume() - Component: SubscriptionProvider';
+      'Function: onCvaResume() - Component: SubscriptionProvider';
     await updateIsSubscribed(isOnResume, requestOrigin);
     updateIsInFreeCountry();
     updateIsOnTrialPeriod();
@@ -50,7 +50,7 @@ export class SubscriptionProvider extends Component {
       updatePlans
     } = this.props;
 
-    onAndroidResume(this.onResume);
+    onCvaResume(this.onResume);
     const requestOrigin =
       'Function: componentDidMount - Component: SubscriptionProvider';
 
@@ -84,7 +84,7 @@ export class SubscriptionProvider extends Component {
   };
 
   componentWillUnmount() {
-    cleanUpOnAndroidResume(this.onResume);
+    cleanUpCvaOnResume(this.onResume);
   }
 
   configPurchaseValidator = () => {

--- a/src/providers/SubscriptionProvider/SubscriptionProvider.container.js
+++ b/src/providers/SubscriptionProvider/SubscriptionProvider.container.js
@@ -54,7 +54,6 @@ export class SubscriptionProvider extends Component {
 
     const requestOrigin =
       'Function: componentDidMount - Component: SubscriptionProvider';
-
     const isSubscribed = await updateIsSubscribed(false, requestOrigin);
     const isInFreeCountry = updateIsInFreeCountry();
     const isOnTrialPeriod = updateIsOnTrialPeriod();

--- a/src/providers/SubscriptionProvider/SubscriptionProvider.container.js
+++ b/src/providers/SubscriptionProvider/SubscriptionProvider.container.js
@@ -36,7 +36,10 @@ export class SubscriptionProvider extends Component {
       updatePlans
     } = this.props;
 
-    const isSubscribed = await updateIsSubscribed();
+    const requestOrigin =
+      'Function: componentDidMount - Component: SubscriptionProvider';
+
+    const isSubscribed = await updateIsSubscribed(false, requestOrigin);
     const isInFreeCountry = updateIsInFreeCountry();
     const isOnTrialPeriod = updateIsOnTrialPeriod();
     await updatePlans();
@@ -60,7 +63,9 @@ export class SubscriptionProvider extends Component {
       updateIsOnTrialPeriod
     } = this.props;
     if (prevProps.isLogged !== isLogged) {
-      const isSubscribed = await updateIsSubscribed();
+      const requestOrigin =
+        'Function: componentDidUpdate - Component: SubscriptionProvider';
+      const isSubscribed = await updateIsSubscribed(false, requestOrigin);
       const isInFreeCountry = updateIsInFreeCountry();
       const isOnTrialPeriod = updateIsOnTrialPeriod();
       if (!isInFreeCountry && !isOnTrialPeriod && !isSubscribed && isLogged) {


### PR DESCRIPTION
PR contains:
* Log getSubscriber request origin to debug on app insight. You will find it on: End-to-end transaction details - app insights page
* CleanUp resume cordova event listener, to avoid multiple declarations for the same event. 