### PR TITLE
Allow Redux-devtools to test on qa

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -14,9 +14,7 @@ export default function configureStore(initialState = {}) {
   // If Redux DevTools Extension is installed use it, otherwise use Redux compose
   /* eslint-disable no-underscore-dangle */
   const composeEnhancers =
-    process.env.NODE_ENV !== 'production' &&
-    typeof window === 'object' &&
-    window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
+    typeof window === 'object' && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
       ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
       : compose;
 


### PR DESCRIPTION
Should be reverted