### PR TITLE
Fix / Get subscriber loop

### DIFF
--- a/src/components/PremiumFeature/PremiumFeature.js
+++ b/src/components/PremiumFeature/PremiumFeature.js
@@ -8,7 +8,7 @@ import {
   showPremiumRequired
 } from '../../providers/SubscriptionProvider/SubscriptionProvider.actions';
 
-function isUpdateSubscriptionNeeded(lastUpdated) {
+function isUpdateSubscriberStatusNeeded(lastUpdated) {
   if (!lastUpdated) return true;
   const MAX_HOURS_DIFFERENCE = 12;
   const actualTime = new Date().getTime();
@@ -26,7 +26,7 @@ function PremiumFeature({
   lastUpdated
 }) {
   const captured = event => {
-    if (isUpdateSubscriptionNeeded(lastUpdated)) {
+    if (isUpdateSubscriberStatusNeeded(lastUpdated)) {
       const requestOrigin = 'Function: captured - Component: PremiumFeature';
       updateIsSubscribed(requestOrigin);
       updateIsInFreeCountry();

--- a/src/components/PremiumFeature/PremiumFeature.js
+++ b/src/components/PremiumFeature/PremiumFeature.js
@@ -1,15 +1,38 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { showPremiumRequired } from '../../providers/SubscriptionProvider/SubscriptionProvider.actions';
+import {
+  updateIsInFreeCountry,
+  updateIsSubscribed,
+  updateSubscription,
+  updateIsOnTrialPeriod,
+  showPremiumRequired
+} from '../../providers/SubscriptionProvider/SubscriptionProvider.actions';
+
+function isUpdateSubscriptionNeeded(lastUpdated) {
+  if (!lastUpdated) return true;
+  const MAX_HOURS_DIFFERENCE = 12;
+  const actualTime = new Date().getTime();
+  const difference = actualTime - lastUpdated;
+  const hoursDifference = difference / (1000 * 60 * 60);
+  return hoursDifference > MAX_HOURS_DIFFERENCE;
+}
 
 function PremiumFeature({
   children,
   isOnTrialPeriod,
   isSubscribed,
   isInFreeCountry,
-  showPremiumRequired
+  showPremiumRequired,
+  lastUpdated
 }) {
   const captured = event => {
+    if (isUpdateSubscriptionNeeded(lastUpdated)) {
+      const requestOrigin = 'Function: captured - Component: PremiumFeature';
+      updateIsSubscribed(requestOrigin);
+      updateIsInFreeCountry();
+      updateIsOnTrialPeriod();
+    }
+
     if (isInFreeCountry || isSubscribed || isOnTrialPeriod) return;
     event.stopPropagation();
     event.preventDefault();
@@ -26,10 +49,16 @@ function PremiumFeature({
 const mapStateToProps = state => ({
   isOnTrialPeriod: state.subscription.isOnTrialPeriod,
   isSubscribed: state.subscription.isSubscribed,
-  isInFreeCountry: state.subscription.isInFreeCountry
+  isInFreeCountry: state.subscription.isInFreeCountry,
+  lastUpdated: state.subscription.lastUpdated
 });
 
-const mapDispatchToProps = { showPremiumRequired };
+const mapDispatchToProps = {
+  showPremiumRequired,
+  updateIsSubscribed,
+  updateSubscription,
+  updateIsInFreeCountry
+};
 
 export default connect(
   mapStateToProps,

--- a/src/components/Settings/Subscribe/Subscribe.container.js
+++ b/src/components/Settings/Subscribe/Subscribe.container.js
@@ -41,7 +41,7 @@ export class SubscribeContainer extends PureComponent {
     const { updateIsSubscribed, updatePlans } = this.props;
     const requestOrigin =
       'Function: componentDidMount - Component: Subscribe Container';
-    updateIsSubscribed(false, requestOrigin);
+    updateIsSubscribed(requestOrigin);
     updatePlans();
   }
 
@@ -56,7 +56,7 @@ export class SubscribeContainer extends PureComponent {
     const { updateIsSubscribed, updatePlans } = this.props;
     const requestOrigin =
       'Fuction: handleRefreshSubscription() - Component: subscribeContainer';
-    updateIsSubscribed(false, requestOrigin);
+    updateIsSubscribed(requestOrigin);
     updatePlans();
   };
 
@@ -68,7 +68,7 @@ export class SubscribeContainer extends PureComponent {
       this.setState({ cancelSubscriptionStatus: 'ok' });
       const requestOrigin =
         'Function: handleCancelSubscription() - Component:Subscribe Container';
-      updateIsSubscribed(false, requestOrigin);
+      updateIsSubscribed(requestOrigin);
       updatePlans();
     } catch (err) {
       console.error(err.message);

--- a/src/providers/SubscriptionProvider/SubscriptionProvider.actions.js
+++ b/src/providers/SubscriptionProvider/SubscriptionProvider.actions.js
@@ -66,6 +66,12 @@ export function updateIsSubscribed(requestOrigin = 'unkwnown') {
     let status = NOT_SUBSCRIBED;
     let expiryDate = null;
     const state = getState();
+    dispatch(
+      updateSubscription({
+        lastUpdated: new Date().getTime()
+      })
+    );
+
     try {
       if (!isLogged(state)) {
         dispatch(

--- a/src/providers/SubscriptionProvider/SubscriptionProvider.actions.js
+++ b/src/providers/SubscriptionProvider/SubscriptionProvider.actions.js
@@ -59,10 +59,7 @@ export function updateIsOnTrialPeriod() {
   };
 }
 
-export function updateIsSubscribed(
-  isOnResume = false,
-  requestOrigin = 'unkwnown'
-) {
+export function updateIsSubscribed(requestOrigin = 'unkwnown') {
   return async (dispatch, getState) => {
     let isSubscribed = false;
     let ownedProduct = '';
@@ -81,9 +78,6 @@ export function updateIsSubscribed(
         );
       } else {
         if (isAndroid() && state.subscription.status === PROCCESING) {
-          //If just close the subscribe google play modal
-          if (isOnResume) return;
-
           const localReceipts = window.CdvPurchase.store.localReceipts;
           if (localReceipts.length) {
             //Restore purchases to pass to approved

--- a/src/providers/SubscriptionProvider/SubscriptionProvider.container.js
+++ b/src/providers/SubscriptionProvider/SubscriptionProvider.container.js
@@ -13,7 +13,6 @@ import {
   updateIsOnTrialPeriod,
   showPremiumRequired
 } from './SubscriptionProvider.actions';
-import { onCvaResume, cleanUpCvaOnResume } from '../../cordova-util';
 import {
   ACTIVE,
   CANCELED,
@@ -26,20 +25,6 @@ export class SubscriptionProvider extends Component {
     children: PropTypes.node.isRequired
   };
 
-  onResume = async () => {
-    const {
-      updateIsSubscribed,
-      updateIsInFreeCountry,
-      updateIsOnTrialPeriod
-    } = this.props;
-    const isOnResume = true;
-    const requestOrigin =
-      'Function: onCvaResume() - Component: SubscriptionProvider';
-    await updateIsSubscribed(isOnResume, requestOrigin);
-    updateIsInFreeCountry();
-    updateIsOnTrialPeriod();
-  };
-
   async componentDidMount() {
     const {
       isLogged,
@@ -50,11 +35,9 @@ export class SubscriptionProvider extends Component {
       updatePlans
     } = this.props;
 
-    if (isCordova()) onCvaResume(this.onResume);
-
     const requestOrigin =
       'Function: componentDidMount - Component: SubscriptionProvider';
-    const isSubscribed = await updateIsSubscribed(false, requestOrigin);
+    const isSubscribed = await updateIsSubscribed(requestOrigin);
     const isInFreeCountry = updateIsInFreeCountry();
     const isOnTrialPeriod = updateIsOnTrialPeriod();
     await updatePlans();
@@ -74,7 +57,7 @@ export class SubscriptionProvider extends Component {
     if (prevProps.isLogged !== isLogged) {
       const requestOrigin =
         'Function: componentDidUpdate - Component: SubscriptionProvider';
-      const isSubscribed = await updateIsSubscribed(false, requestOrigin);
+      const isSubscribed = await updateIsSubscribed(requestOrigin);
       const isInFreeCountry = updateIsInFreeCountry();
       const isOnTrialPeriod = updateIsOnTrialPeriod();
       if (!isInFreeCountry && !isOnTrialPeriod && !isSubscribed && isLogged) {
@@ -82,10 +65,6 @@ export class SubscriptionProvider extends Component {
       }
     }
   };
-
-  componentWillUnmount() {
-    if (isCordova()) cleanUpCvaOnResume(this.onResume);
-  }
 
   configPurchaseValidator = () => {
     window.CdvPurchase.store.validator = async function(receipt, callback) {

--- a/src/providers/SubscriptionProvider/SubscriptionProvider.container.js
+++ b/src/providers/SubscriptionProvider/SubscriptionProvider.container.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import API from '../../api';
-import { isAndroid, isCordova } from '../../cordova-util';
+import { isAndroid } from '../../cordova-util';
 
 import {
   updateIsInFreeCountry,

--- a/src/providers/SubscriptionProvider/SubscriptionProvider.reducer.js
+++ b/src/providers/SubscriptionProvider/SubscriptionProvider.reducer.js
@@ -37,7 +37,8 @@ const initialState = {
       price: '',
       tag: ''
     }
-  ]
+  ],
+  lastUpdated: null
 };
 
 function subscriptionProviderReducer(state = initialState, action) {

--- a/src/providers/SubscriptionProvider/SubscriptionProvider.reducer.js
+++ b/src/providers/SubscriptionProvider/SubscriptionProvider.reducer.js
@@ -38,7 +38,7 @@ const initialState = {
       tag: ''
     }
   ],
-  lastUpdated: null
+  lastUpdated: undefined
 };
 
 function subscriptionProviderReducer(state = initialState, action) {


### PR DESCRIPTION
On this PR:
- Remove onResume cordova event
- Refreshes the subscriber status when a premium feature is clicked and the last update time was more than 12 hours ago.