### PR TITLE
Fix/dialogs behind keyboard on Android and IOS

### DIFF
--- a/src/components/Account/Login/Login.component.js
+++ b/src/components/Account/Login/Login.component.js
@@ -23,8 +23,7 @@ export class Login extends Component {
     isDialogOpen: PropTypes.bool.isRequired,
     onClose: PropTypes.func.isRequired,
     onResetPasswordClick: PropTypes.func.isRequired,
-    isKeyboardOpen: PropTypes.bool,
-    dialogContentWithKeyboardStyle: PropTypes.object
+    dialogWithKeyboardStyle: PropTypes.object
   };
 
   state = {
@@ -52,23 +51,22 @@ export class Login extends Component {
       isDialogOpen,
       onClose,
       onResetPasswordClick,
-      isKeyboardOpen,
-      dialogContentWithKeyboardStyle
+      dialogWithKeyboardStyle: { dialogStyle, dialogContentStyle }
     } = this.props;
 
     const isButtonDisabled = isLogging || !!loginStatus.success;
 
     return (
       <Dialog
-        className={isKeyboardOpen ? 'is_keyboard_open' : ''}
         open={isDialogOpen}
         onClose={onClose}
         aria-labelledby="login"
+        style={dialogStyle}
       >
         <DialogTitle id="login">
           <FormattedMessage {...messages.login} />
         </DialogTitle>
-        <DialogContent style={dialogContentWithKeyboardStyle}>
+        <DialogContent style={dialogContentStyle}>
           <div
             className={classNames('Login__status', {
               'Login__status--error': !loginStatus.success,

--- a/src/components/Account/Login/Login.component.js
+++ b/src/components/Account/Login/Login.component.js
@@ -22,7 +22,9 @@ export class Login extends Component {
     intl: intlShape.isRequired,
     isDialogOpen: PropTypes.bool.isRequired,
     onClose: PropTypes.func.isRequired,
-    onResetPasswordClick: PropTypes.func.isRequired
+    onResetPasswordClick: PropTypes.func.isRequired,
+    isKeyboardOpen: PropTypes.bool,
+    dialogContentWithKeyboardStyle: PropTypes.object
   };
 
   state = {
@@ -45,16 +47,28 @@ export class Login extends Component {
 
   render() {
     const { isLogging, loginStatus } = this.state;
-    const { intl, isDialogOpen, onClose, onResetPasswordClick } = this.props;
+    const {
+      intl,
+      isDialogOpen,
+      onClose,
+      onResetPasswordClick,
+      isKeyboardOpen,
+      dialogContentWithKeyboardStyle
+    } = this.props;
 
     const isButtonDisabled = isLogging || !!loginStatus.success;
 
     return (
-      <Dialog open={isDialogOpen} onClose={onClose} aria-labelledby="login">
+      <Dialog
+        className={isKeyboardOpen ? 'is_keyboard_open' : ''}
+        open={isDialogOpen}
+        onClose={onClose}
+        aria-labelledby="login"
+      >
         <DialogTitle id="login">
           <FormattedMessage {...messages.login} />
         </DialogTitle>
-        <DialogContent>
+        <DialogContent style={dialogContentWithKeyboardStyle}>
           <div
             className={classNames('Login__status', {
               'Login__status--error': !loginStatus.success,

--- a/src/components/Account/Login/Login.component.js
+++ b/src/components/Account/Login/Login.component.js
@@ -55,8 +55,9 @@ export class Login extends Component {
       isDialogOpen,
       onClose,
       onResetPasswordClick,
-      dialogWithKeyboardStyle: { dialogStyle, dialogContentStyle }
+      dialogWithKeyboardStyle
     } = this.props;
+    const { dialogStyle, dialogContentStyle } = dialogWithKeyboardStyle ?? {};
 
     const isButtonDisabled = isLogging || !!loginStatus.success;
 

--- a/src/components/Account/Login/Login.component.js
+++ b/src/components/Account/Login/Login.component.js
@@ -26,6 +26,10 @@ export class Login extends Component {
     dialogWithKeyboardStyle: PropTypes.object
   };
 
+  static defaultProps = {
+    dialogWithKeyboardStyle: {}
+  };
+
   state = {
     isLogging: false,
     loginStatus: {}

--- a/src/components/Account/SignUp/SignUp.component.js
+++ b/src/components/Account/SignUp/SignUp.component.js
@@ -24,7 +24,7 @@ export class SignUp extends Component {
     isDialogOpen: PropTypes.bool.isRequired,
     onClose: PropTypes.func.isRequired,
     isKeyboardOpen: PropTypes.bool,
-    dialogContentWithKeyboardStyle: PropTypes.object
+    dialogWithKeyboardStyle: PropTypes.object
   };
 
   state = {
@@ -58,8 +58,7 @@ export class SignUp extends Component {
       isDialogOpen,
       onClose,
       intl,
-      isKeyboardOpen,
-      dialogContentWithKeyboardStyle
+      dialogWithKeyboardStyle: { dialogStyle, dialogContentStyle }
     } = this.props;
 
     const isButtonDisabled = isSigningUp || !!signUpStatus.success;
@@ -69,12 +68,12 @@ export class SignUp extends Component {
         open={isDialogOpen}
         onClose={onClose}
         aria-labelledby="sign-up"
-        className={isKeyboardOpen ? 'is_keyboard_open' : ''}
+        style={dialogStyle}
       >
         <DialogTitle id="sign-up">
           <FormattedMessage {...messages.signUp} />
         </DialogTitle>
-        <DialogContent style={dialogContentWithKeyboardStyle}>
+        <DialogContent style={dialogContentStyle}>
           <div
             className={classNames('SignUp__status', {
               'SignUp__status--error': !signUpStatus.success,

--- a/src/components/Account/SignUp/SignUp.component.js
+++ b/src/components/Account/SignUp/SignUp.component.js
@@ -22,7 +22,9 @@ export class SignUp extends Component {
   static propTypes = {
     intl: intlShape.isRequired,
     isDialogOpen: PropTypes.bool.isRequired,
-    onClose: PropTypes.func.isRequired
+    onClose: PropTypes.func.isRequired,
+    isKeyboardOpen: PropTypes.bool,
+    dialogContentWithKeyboardStyle: PropTypes.object
   };
 
   state = {
@@ -52,16 +54,27 @@ export class SignUp extends Component {
 
   render() {
     const { signUpStatus, isSigningUp } = this.state;
-    const { isDialogOpen, onClose, intl } = this.props;
+    const {
+      isDialogOpen,
+      onClose,
+      intl,
+      isKeyboardOpen,
+      dialogContentWithKeyboardStyle
+    } = this.props;
 
     const isButtonDisabled = isSigningUp || !!signUpStatus.success;
 
     return (
-      <Dialog open={isDialogOpen} onClose={onClose} aria-labelledby="sign-up">
+      <Dialog
+        open={isDialogOpen}
+        onClose={onClose}
+        aria-labelledby="sign-up"
+        className={isKeyboardOpen ? 'is_keyboard_open' : ''}
+      >
         <DialogTitle id="sign-up">
           <FormattedMessage {...messages.signUp} />
         </DialogTitle>
-        <DialogContent>
+        <DialogContent style={dialogContentWithKeyboardStyle}>
           <div
             className={classNames('SignUp__status', {
               'SignUp__status--error': !signUpStatus.success,

--- a/src/components/Account/SignUp/SignUp.component.js
+++ b/src/components/Account/SignUp/SignUp.component.js
@@ -27,6 +27,10 @@ export class SignUp extends Component {
     dialogWithKeyboardStyle: PropTypes.object
   };
 
+  static defaultProps = {
+    dialogWithKeyboardStyle: {}
+  };
+
   state = {
     isSigningUp: false,
     signUpStatus: {}

--- a/src/components/Account/SignUp/SignUp.component.js
+++ b/src/components/Account/SignUp/SignUp.component.js
@@ -58,12 +58,9 @@ export class SignUp extends Component {
 
   render() {
     const { signUpStatus, isSigningUp } = this.state;
-    const {
-      isDialogOpen,
-      onClose,
-      intl,
-      dialogWithKeyboardStyle: { dialogStyle, dialogContentStyle }
-    } = this.props;
+    const { isDialogOpen, onClose, intl, dialogWithKeyboardStyle } = this.props;
+
+    const { dialogStyle, dialogContentStyle } = dialogWithKeyboardStyle ?? {};
 
     const isButtonDisabled = isSigningUp || !!signUpStatus.success;
 

--- a/src/components/WelcomeScreen/WelcomeScreen.container.js
+++ b/src/components/WelcomeScreen/WelcomeScreen.container.js
@@ -134,7 +134,7 @@ export class WelcomeScreen extends Component {
   };
 
   updateDialogContentStyle() {
-    if (!isAndroid()) return;
+    if (!(isAndroid() || isIOS())) return;
     const { isKeyboardOpen, keyboardHeight } = this.state.keyboard;
     if (isKeyboardOpen) {
       console.log('keyboardHeight', keyboardHeight);
@@ -152,7 +152,7 @@ export class WelcomeScreen extends Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    if (!isAndroid()) return;
+    if (!(isAndroid() || isIOS())) return;
     const { isKeyboardOpen: wasKeyboardOpen } = prevState.keyboard;
     const { isKeyboardOpen } = this.state.keyboard;
     console.log(wasKeyboardOpen, isKeyboardOpen);
@@ -164,14 +164,14 @@ export class WelcomeScreen extends Component {
   }
 
   componentDidMount() {
-    if (!isAndroid()) return;
+    if (!(isAndroid() || isIOS())) return;
     manageKeyboardEvents({
       onShow: this.handleKeyboardDidShow,
       onHide: this.handlekeyboardDidHide
     });
   }
   componentWillUnmount() {
-    if (!isAndroid()) return;
+    if (!(isAndroid() || isIOS())) return;
     manageKeyboardEvents({
       onShow: this.handleKeyboardDidShow,
       onHide: this.handlekeyboardDidHide,

--- a/src/components/WelcomeScreen/WelcomeScreen.container.js
+++ b/src/components/WelcomeScreen/WelcomeScreen.container.js
@@ -285,7 +285,7 @@ export class WelcomeScreen extends Component {
           isDialogOpen={activeView === 'login'}
           onResetPasswordClick={this.onResetPasswordClick}
           onClose={this.resetActiveView}
-          dialogWithKeyboardStyle={dialogWithKeyboardStyle || {}}
+          dialogWithKeyboardStyle={dialogWithKeyboardStyle}
         />
         <ResetPassword
           isDialogOpen={activeView === 'forgot'}
@@ -294,7 +294,7 @@ export class WelcomeScreen extends Component {
         <SignUp
           isDialogOpen={activeView === 'signup'}
           onClose={this.resetActiveView}
-          dialogWithKeyboardStyle={dialogWithKeyboardStyle || {}}
+          dialogWithKeyboardStyle={dialogWithKeyboardStyle}
         />
       </div>
     );

--- a/src/components/WelcomeScreen/WelcomeScreen.container.js
+++ b/src/components/WelcomeScreen/WelcomeScreen.container.js
@@ -190,8 +190,6 @@ export class WelcomeScreen extends Component {
     const { finishFirstVisit, heading, text, onClose } = this.props;
     const { activeView, dialogWithKeyboardStyle } = this.state;
 
-    //const dialogContentWithKeyboardStyle = this.dialogContentStyle();
-
     return (
       <div className="WelcomeScreen">
         <div className="WelcomeScreen__container">

--- a/src/components/WelcomeScreen/WelcomeScreen.container.js
+++ b/src/components/WelcomeScreen/WelcomeScreen.container.js
@@ -31,7 +31,11 @@ import {
 export class WelcomeScreen extends Component {
   state = {
     activeView: '',
-    keyboard: { isKeyboardOpen: false, keyboardHeight: undefined }
+    keyboard: { isKeyboardOpen: false, keyboardHeight: undefined },
+    dialogWithKeyboardStyle: {
+      dialogStyle: {},
+      dialogContentStyle: {}
+    }
   };
 
   static propTypes = {
@@ -133,19 +137,24 @@ export class WelcomeScreen extends Component {
     window.location = `${API_URL}login/apple-web`;
   };
 
-  updateDialogContentStyle() {
+  updateDialogStyle() {
     if (!(isAndroid() || isIOS())) return;
     const { isKeyboardOpen, keyboardHeight } = this.state.keyboard;
     if (isKeyboardOpen) {
       console.log('keyboardHeight', keyboardHeight);
-      const DIALOG_MARGIN_TOP = 30;
+      const KEYBOARD_MARGIN_TOP = 30;
       const DEFAULT_KEYBOARD_SPACE = 310;
       const keyboardSpace = keyboardHeight
-        ? keyboardHeight + DIALOG_MARGIN_TOP
+        ? keyboardHeight + KEYBOARD_MARGIN_TOP
         : DEFAULT_KEYBOARD_SPACE;
       return {
-        maxHeight: `calc(92vh - ${keyboardSpace}px)`,
-        overflow: 'scroll'
+        dialogStyle: {
+          marginBottom: `${keyboardSpace}px`
+        },
+        dialogContentStyle: {
+          maxHeight: `calc(92vh - ${keyboardSpace}px)`,
+          overflow: 'scroll'
+        }
       };
     }
     return null;
@@ -158,7 +167,7 @@ export class WelcomeScreen extends Component {
     console.log(wasKeyboardOpen, isKeyboardOpen);
     if (wasKeyboardOpen !== isKeyboardOpen) {
       this.setState({
-        dialogContentWithKeyboardStyle: this.updateDialogContentStyle()
+        dialogWithKeyboardStyle: this.updateDialogStyle()
       });
     }
   }
@@ -181,7 +190,7 @@ export class WelcomeScreen extends Component {
 
   render() {
     const { finishFirstVisit, heading, text, onClose } = this.props;
-    const { activeView, keyboard, dialogContentWithKeyboardStyle } = this.state;
+    const { activeView, dialogWithKeyboardStyle } = this.state;
 
     //const dialogContentWithKeyboardStyle = this.dialogContentStyle();
 
@@ -278,8 +287,7 @@ export class WelcomeScreen extends Component {
           isDialogOpen={activeView === 'login'}
           onResetPasswordClick={this.onResetPasswordClick}
           onClose={this.resetActiveView}
-          isKeyboardOpen={keyboard.isKeyboardOpen}
-          dialogContentWithKeyboardStyle={dialogContentWithKeyboardStyle}
+          dialogWithKeyboardStyle={dialogWithKeyboardStyle || {}}
         />
         <ResetPassword
           isDialogOpen={activeView === 'forgot'}
@@ -288,8 +296,7 @@ export class WelcomeScreen extends Component {
         <SignUp
           isDialogOpen={activeView === 'signup'}
           onClose={this.resetActiveView}
-          isKeyboardOpen={keyboard.isKeyboardOpen}
-          dialogContentWithKeyboardStyle={dialogContentWithKeyboardStyle}
+          dialogWithKeyboardStyle={dialogWithKeyboardStyle || {}}
         />
       </div>
     );

--- a/src/components/WelcomeScreen/WelcomeScreen.container.js
+++ b/src/components/WelcomeScreen/WelcomeScreen.container.js
@@ -51,7 +51,7 @@ export class WelcomeScreen extends Component {
     });
   };
 
-  handlekeyboardDidHide = () => {
+  handleKeyboardDidHide = () => {
     this.setState({
       keyboard: { isKeyboardOpen: false, keyboardHeight: null }
     });
@@ -174,14 +174,14 @@ export class WelcomeScreen extends Component {
     if (!(isAndroid() || isIOS())) return;
     manageKeyboardEvents({
       onShow: this.handleKeyboardDidShow,
-      onHide: this.handlekeyboardDidHide
+      onHide: this.handleKeyboardDidHide
     });
   }
   componentWillUnmount() {
     if (!(isAndroid() || isIOS())) return;
     manageKeyboardEvents({
       onShow: this.handleKeyboardDidShow,
-      onHide: this.handlekeyboardDidHide,
+      onHide: this.handleKeyboardDidHide,
       removeEvent: true
     });
   }

--- a/src/components/WelcomeScreen/WelcomeScreen.container.js
+++ b/src/components/WelcomeScreen/WelcomeScreen.container.js
@@ -141,7 +141,6 @@ export class WelcomeScreen extends Component {
     if (!(isAndroid() || isIOS())) return;
     const { isKeyboardOpen, keyboardHeight } = this.state.keyboard;
     if (isKeyboardOpen) {
-      console.log('keyboardHeight', keyboardHeight);
       const KEYBOARD_MARGIN_TOP = 30;
       const DEFAULT_KEYBOARD_SPACE = 310;
       const keyboardSpace = keyboardHeight
@@ -164,7 +163,6 @@ export class WelcomeScreen extends Component {
     if (!(isAndroid() || isIOS())) return;
     const { isKeyboardOpen: wasKeyboardOpen } = prevState.keyboard;
     const { isKeyboardOpen } = this.state.keyboard;
-    console.log(wasKeyboardOpen, isKeyboardOpen);
     if (wasKeyboardOpen !== isKeyboardOpen) {
       this.setState({
         dialogWithKeyboardStyle: this.updateDialogStyle()

--- a/src/components/WelcomeScreen/WelcomeScreen.container.js
+++ b/src/components/WelcomeScreen/WelcomeScreen.container.js
@@ -138,10 +138,10 @@ export class WelcomeScreen extends Component {
     const { isKeyboardOpen, keyboardHeight } = this.state.keyboard;
     if (isKeyboardOpen) {
       console.log('keyboardHeight', keyboardHeight);
-      const DIALOG_MARGIN_TOP = 32;
+      const DIALOG_MARGIN_TOP = 30;
       const DEFAULT_KEYBOARD_SPACE = 310;
       const keyboardSpace = keyboardHeight
-        ? keyboardHeight
+        ? keyboardHeight + DIALOG_MARGIN_TOP
         : DEFAULT_KEYBOARD_SPACE;
       return {
         maxHeight: `calc(92vh - ${keyboardSpace}px)`,

--- a/src/components/WelcomeScreen/WelcomeScreen.container.js
+++ b/src/components/WelcomeScreen/WelcomeScreen.container.js
@@ -278,6 +278,8 @@ export class WelcomeScreen extends Component {
           isDialogOpen={activeView === 'login'}
           onResetPasswordClick={this.onResetPasswordClick}
           onClose={this.resetActiveView}
+          isKeyboardOpen={keyboard.isKeyboardOpen}
+          dialogContentWithKeyboardStyle={dialogContentWithKeyboardStyle}
         />
         <ResetPassword
           isDialogOpen={activeView === 'forgot'}
@@ -286,6 +288,8 @@ export class WelcomeScreen extends Component {
         <SignUp
           isDialogOpen={activeView === 'signup'}
           onClose={this.resetActiveView}
+          isKeyboardOpen={keyboard.isKeyboardOpen}
+          dialogContentWithKeyboardStyle={dialogContentWithKeyboardStyle}
         />
       </div>
     );

--- a/src/components/WelcomeScreen/WelcomeScreen.css
+++ b/src/components/WelcomeScreen/WelcomeScreen.css
@@ -1,7 +1,3 @@
-.is_keyboard_open [role='dialog'] {
-  align-self: flex-start;
-}
-
 .WelcomeScreen {
   height: 100%;
   padding: 1.5rem;

--- a/src/components/WelcomeScreen/WelcomeScreen.css
+++ b/src/components/WelcomeScreen/WelcomeScreen.css
@@ -1,3 +1,7 @@
+.is_keyboard_open [role='dialog'] {
+  align-self: flex-start;
+}
+
 .WelcomeScreen {
   height: 100%;
   padding: 1.5rem;

--- a/src/cordova-util.js
+++ b/src/cordova-util.js
@@ -14,6 +14,20 @@ export const onCordovaReady = onReady =>
 export const onAndroidPause = onPause =>
   document.addEventListener('pause', onPause, false);
 
+export const manageKeyboardEvents = ({
+  onShow,
+  onHide,
+  removeEvent = false
+}) => {
+  if (!removeEvent) {
+    window.addEventListener('keyboardDidShow', onShow, false);
+    window.addEventListener('keyboardDidHide', onHide, false);
+    return;
+  }
+  window.removeEventListener('keyboardDidShow', onShow, false);
+  window.removeEventListener('keyboardDidHide', onHide, false);
+};
+
 export const onCvaResume = onResume =>
   document.addEventListener('resume', onResume, false);
 


### PR DESCRIPTION
This PR uses a newly added plugin to adjust welcome dialog sizes to not be covered by the keyboard on Android and IOS. Please @RodriSanchez1 can you Test it? Also, please use the keyboard with live mode to make sure the board is not resized.