### PR TITLE
Fix/connection setter

### DIFF
--- a/src/components/App/App.actions.js
+++ b/src/components/App/App.actions.js
@@ -7,10 +7,18 @@ import {
   DISABLE_TOUR,
   ENABLE_ALL_TOURS,
   SET_UNLOGGED_USER_LOCATION,
-  UPDATE_SYMBOLS_SETTINGS
+  UPDATE_SYMBOLS_SETTINGS,
+  UPDATE_CONNECTIVITY
 } from './App.constants';
 
 import { updateIsInFreeCountry } from '../../providers/SubscriptionProvider/SubscriptionProvider.actions';
+
+export function updateConnectivity({ isConnected = false }) {
+  return {
+    type: UPDATE_CONNECTIVITY,
+    payload: isConnected
+  };
+}
 
 export function updateDisplaySettings(payload = {}) {
   return {

--- a/src/components/App/App.container.js
+++ b/src/components/App/App.container.js
@@ -13,7 +13,8 @@ import { DISPLAY_SIZE_STANDARD } from '../Settings/Display/Display.constants';
 import {
   updateUserDataFromAPI,
   updateLoggedUserLocation,
-  updateUnloggedUserLocation
+  updateUnloggedUserLocation,
+  updateConnectivity
 } from '../App/App.actions';
 import { isCordova, isElectron } from '../../cordova-util';
 export class AppContainer extends Component {
@@ -85,6 +86,36 @@ export class AppContainer extends Component {
     localizeUser();
 
     if (isCordova()) initCVAGa4();
+
+    const configureConnectionStatus = () => {
+      const { updateConnectivity } = this.props;
+      const setAsOnline = () => {
+        updateConnectivity({ isConnected: true });
+      };
+
+      const setAsOffline = () => {
+        updateConnectivity({ isConnected: false });
+      };
+
+      const addConnectionEventListeners = () => {
+        window.addEventListener('offline', setAsOffline);
+        window.addEventListener('online', setAsOnline);
+      };
+
+      const setCurrentConnectionStatus = () => {
+        if (!navigator.onLine) {
+          setAsOffline();
+          return;
+        }
+        setAsOnline();
+        return;
+      };
+
+      setCurrentConnectionStatus();
+      addConnectionEventListeners();
+    };
+
+    configureConnectionStatus();
   }
 
   handleNewContentAvailable = () => {
@@ -148,7 +179,8 @@ const mapDispatchToProps = {
   showNotification,
   updateUserDataFromAPI,
   updateLoggedUserLocation,
-  updateUnloggedUserLocation
+  updateUnloggedUserLocation,
+  updateConnectivity
 };
 
 export default connect(

--- a/src/store.js
+++ b/src/store.js
@@ -1,7 +1,6 @@
 import { createStore, applyMiddleware, compose } from 'redux';
 import thunk from 'redux-thunk';
 import { persistStore } from 'redux-persist';
-import { UPDATE_CONNECTIVITY } from './components/App/App.constants';
 import googleAnalytics from './analytics';
 import createReducer from './reducers';
 
@@ -25,21 +24,6 @@ export default function configureStore(initialState = {}) {
     initialState,
     composeEnhancers(...enhancers)
   );
-
-  // TODO refactor not here
-  window.addEventListener('offline', () => {
-    store.dispatch({
-      type: UPDATE_CONNECTIVITY,
-      payload: false
-    });
-  });
-
-  window.addEventListener('online', () => {
-    store.dispatch({
-      type: UPDATE_CONNECTIVITY,
-      payload: true
-    });
-  });
 
   const persistor = persistStore(store);
 


### PR DESCRIPTION
In this PR the isConnected state is set when the app is mounted. with this use, the isConnected state is properly established and the persisted state from the previous session is discarded.
Also, the connections event listeners are configured on the app container and are removed from the store file.