### PR TITLE
Use Firebase Plugin to handle google login on Cordova apps

### DIFF
--- a/src/components/WelcomeScreen/WelcomeScreen.container.js
+++ b/src/components/WelcomeScreen/WelcomeScreen.container.js
@@ -79,7 +79,7 @@ export class WelcomeScreen extends Component {
     if (isAndroid() || isIOS()) {
       const FirebasePlugin = window.FirebasePlugin;
       FirebasePlugin.authenticateUserWithGoogle(
-        '',
+        process.env.REACT_APP_GOOGLE_FIREBASE_WEB_CLIENT_SIGN_IN,
         function(credential) {
           window.location.hash = `#/login/googleidtoken/callback?id_token=${
             credential.idToken

--- a/src/components/WelcomeScreen/WelcomeScreen.container.js
+++ b/src/components/WelcomeScreen/WelcomeScreen.container.js
@@ -77,19 +77,17 @@ export class WelcomeScreen extends Component {
   handleGoogleLoginClick = () => {
     const { intl } = this.props;
     if (isAndroid() || isIOS()) {
-      window.plugins.googleplus.login(
-        {
-          // 'scopes': '... ', // optional, space-separated list of scopes, If not included or empty, defaults to `profile` and `email`.
-          offline: true // optional, but requires the webClientId - if set to true the plugin will also return a serverAuthCode, which can be used to grant offline access to a non-Google server
-        },
-        function(obj) {
-          window.location.hash = `#/login/googletoken/callback?access_token=${
-            obj.accessToken
+      const FirebasePlugin = window.FirebasePlugin;
+      FirebasePlugin.authenticateUserWithGoogle(
+        '',
+        function(credential) {
+          window.location.hash = `#/login/googleidtoken/callback?id_token=${
+            credential.idToken
           }`;
         },
-        function(msg) {
+        function(error) {
           alert(intl.formatMessage(messages.loginErrorAndroid));
-          console.log('error: ' + msg);
+          console.error('Failed to authenticate with Google: ' + error);
         }
       );
     } else {


### PR DESCRIPTION
In this PRs the use of unmaintained 'cordova-plugin-googleplus' is replaced by the use of Firebasex plugin to sign in and sign up using Google Auth login. In order to allow the use of 'cordova-plugin-firebasex' on IOS.
Please @RodriSanchez1 could you build an app for testing the login on the Android APP
close #1599 