### PR TITLE
Fix the order of params on pdfExportAdapter

### DIFF
--- a/src/components/Settings/Export/Export.helpers.js
+++ b/src/components/Settings/Export/Export.helpers.js
@@ -890,9 +890,9 @@ export async function cboardExportAdapter(allBoards = [], board) {
 
 export async function pdfExportAdapter(
   boards = [],
-  labelFontSize,
   intl,
-  picsee = false
+  picsee = false,
+  labelFontSize
 ) {
   const font = definePDFfont(intl);
   const docDefinition = {


### PR DESCRIPTION
This causes an Error using the print button of the navbar.
close #1646 