### PR TITLE
Save only necessary keys on local userData

### DIFF
--- a/src/components/App/App.constants.js
+++ b/src/components/App/App.constants.js
@@ -63,3 +63,23 @@ export const APP_LANGS = [
   'zh-CN',
   'zu-ZA' // for crowdin contextual translation
 ];
+
+export const USER_DATA_PROPERTIES = [
+  'id',
+  'google',
+  'facebook',
+  'apple',
+  'name',
+  'role',
+  'provider',
+  'locale',
+  'password',
+  'location',
+  'email',
+  'isFirstLogin',
+  'birthdate',
+  'lastlogin',
+  'createdAt',
+  'updatedAt',
+  'authToken'
+];

--- a/src/components/App/App.reducer.js
+++ b/src/components/App/App.reducer.js
@@ -155,6 +155,7 @@ function appReducer(state = initialState, action) {
         userData: {}
       };
     case UPDATE_USER_DATA:
+      if (action.userData.boards) delete action.userData.boards;
       return {
         ...state,
         userData: action.userData

--- a/src/components/App/App.reducer.js
+++ b/src/components/App/App.reducer.js
@@ -7,7 +7,8 @@ import {
   UPDATE_USER_DATA,
   DISABLE_TOUR,
   ENABLE_ALL_TOURS,
-  SET_UNLOGGED_USER_LOCATION
+  SET_UNLOGGED_USER_LOCATION,
+  USER_DATA_PROPERTIES
 } from './App.constants';
 import { LOGIN_SUCCESS, LOGOUT } from '../Account/Login/Login.constants';
 import {
@@ -58,6 +59,15 @@ const initialState = {
     arasaacActive: false
   },
   userData: {}
+};
+
+const getKeysFromApiUserDataResponse = payload => {
+  const newUser = {};
+  if (!payload) return newUser;
+  USER_DATA_PROPERTIES.forEach(prop => {
+    newUser[prop] = payload[prop];
+  });
+  return newUser;
 };
 
 function appReducer(state = initialState, action) {
@@ -147,7 +157,7 @@ function appReducer(state = initialState, action) {
         isFirstVisit: false,
         displaySettings,
         navigationSettings,
-        userData: action.payload || {}
+        userData: getKeysFromApiUserDataResponse(action.payload)
       };
     case LOGOUT:
       return {
@@ -155,10 +165,9 @@ function appReducer(state = initialState, action) {
         userData: {}
       };
     case UPDATE_USER_DATA:
-      if (action.userData.boards) delete action.userData.boards;
       return {
         ...state,
-        userData: action.userData
+        userData: getKeysFromApiUserDataResponse(action.userData)
       };
     case SET_UNLOGGED_USER_LOCATION:
       return {

--- a/src/components/App/App.reducer.js
+++ b/src/components/App/App.reducer.js
@@ -65,7 +65,7 @@ const getKeysFromApiUserDataResponse = payload => {
   const newUser = {};
   if (!payload) return newUser;
   USER_DATA_PROPERTIES.forEach(prop => {
-    newUser[prop] = payload[prop];
+    if (payload[prop] !== undefined) newUser[prop] = payload[prop];
   });
   return newUser;
 };


### PR DESCRIPTION
On this PR, the API responses containing the user information are filtered to get only the necessary keys to save on the App.UserData local state. See [API PR](https://github.com/cboard-org/cboard-api/pull/362)
Close #1730 