### PR TITLE
Fix / Create neccesary default boards on DB

### DIFF
--- a/src/components/Board/Board.container.js
+++ b/src/components/Board/Board.container.js
@@ -277,8 +277,10 @@ export class BoardContainer extends Component {
       const homeBoard = communicator.rootBoard;
       boardExists = boards.find(b => b.id === homeBoard);
       if (!boardExists) {
-        if (isRemoteIdChecker(homeBoard))
-          boardExists = this.tryRemoteBoard(homeBoard);
+        try {
+          if (isRemoteIdChecker(homeBoard))
+            boardExists = await this.tryRemoteBoard(homeBoard);
+        } catch (err) {}
         if (!boardExists)
           boardExists = this.addDefaultBoardIfnecessary(homeBoard);
         if (!boardExists) boardExists = boards.find(b => b.id !== '');

--- a/src/components/Board/Board.reducer.js
+++ b/src/components/Board/Board.reducer.js
@@ -319,6 +319,8 @@ function boardReducer(state = initialState, action) {
       };
     case CREATE_API_BOARD_SUCCESS:
       const creadBoards = [...state.boards];
+      const tilesToUpdateIds = [];
+      const boardsToMarkForCreation = [];
       for (let i = 0; i < creadBoards.length; i++) {
         let tiles = creadBoards[i].tiles;
         if (tiles) {
@@ -330,17 +332,27 @@ function boardReducer(state = initialState, action) {
                 creadBoards[i].hasOwnProperty('email')
               ) {
                 creadBoards[i].markToUpdate = true;
+                const tileUpdatedId = creadBoards[i].tiles[j].id;
+                tilesToUpdateIds.push(tileUpdatedId);
               }
 
               const shouldCreateBoard =
                 creadBoards[i].id.length < SHORT_ID_MAX_LENGTH;
               if (shouldCreateBoard) {
-                creadBoards[i].shouldCreateBoard = true;
+                boardsToMarkForCreation.push(creadBoards[i]);
               }
             }
           }
         }
       }
+      boardsToMarkForCreation.forEach(board => {
+        //if the tile id is already in a api board, we don't need to create it
+        const boardTileIds = board.tiles.map(tile => tile.id);
+        const boardIsAlreadyCreatedOnDb = boardTileIds.some(tileId =>
+          tilesToUpdateIds.includes(tileId)
+        );
+        if (!boardIsAlreadyCreatedOnDb) board.shouldCreateBoard = true;
+      });
       return {
         ...state,
         isFetching: false,

--- a/src/components/Communicator/Communicator.actions.js
+++ b/src/components/Communicator/Communicator.actions.js
@@ -249,12 +249,14 @@ export function getApiMyCommunicators() {
         } catch (e) {
           console.error(e);
         }
-        const activeCommunicator =
-          res.data.find(
-            communicator =>
-              communicator.id === getState().communicator.activeCommunicator
-          ) ?? res.data[res.data.length - 1];
-        const defaultBoardBlackList = activeCommunicator?.defaultBoardBlackList;
+        const getActiveCommunicator = getState => {
+          return getState().communicator.communicators.find(
+            c => c.id === getState().communicator.activeCommunicatorId
+          );
+        };
+        const activeCommunicator = getActiveCommunicator(getState);
+        const defaultBoardBlackList =
+          activeCommunicator?.defaultBoardBlackList ?? [];
         dispatch(
           removeBoardsFromList(
             defaultBoardBlackList,

--- a/src/components/Communicator/Communicator.actions.js
+++ b/src/components/Communicator/Communicator.actions.js
@@ -249,14 +249,12 @@ export function getApiMyCommunicators() {
         } catch (e) {
           console.error(e);
         }
-        const getActiveCommunicator = getState => {
-          return getState().communicator.communicators.find(
-            c => c.id === getState().communicator.activeCommunicatorId
-          );
-        };
-        const activeCommunicator = getActiveCommunicator(getState);
-        const defaultBoardBlackList =
-          activeCommunicator?.defaultBoardBlackList ?? [];
+        const activeCommunicator =
+          res.data.find(
+            communicator =>
+              communicator.id === getState().communicator.activeCommunicator
+          ) ?? res.data[res.data.length - 1];
+        const defaultBoardBlackList = activeCommunicator?.defaultBoardBlackList;
         dispatch(
           removeBoardsFromList(
             defaultBoardBlackList,


### PR DESCRIPTION
Comprobe if an API board contains the tile ID of a default board before marking it to create. Maybe with this solution we can avoid the creation of the defaultBoardBlackList