### PR TITLE
Fix #1752: Quiet mode incorrectly shows activation state in settings

### DIFF
--- a/src/components/Settings/Navigation/Navigation.component.js
+++ b/src/components/Settings/Navigation/Navigation.component.js
@@ -293,7 +293,7 @@ class Navigation extends React.Component {
                 />
                 <ListItemSecondaryAction>
                   <Switch
-                    checked={this.state.enableQuietBuilderMode}
+                    checked={this.state.quietBuilderMode}
                     onChange={this.toggleQuietBuilderMode}
                     value="active"
                     color="secondary"


### PR DESCRIPTION
Related issue: [#1752](https://github.com/cboard-org/cboard/issues/1752)

- Fix the `checked={this.state.enableQuietBuilderMode}` to `checked={this.state.quietBuilderMode}`