### PR TITLE
Gets system language and sets it as default on first launch

### DIFF
--- a/src/providers/LanguageProvider/LanguageProvider.reducer.js
+++ b/src/providers/LanguageProvider/LanguageProvider.reducer.js
@@ -4,7 +4,8 @@ import {
   SET_DOWNLOADING_LANG
 } from './LanguageProvider.constants';
 import { LOGIN_SUCCESS } from '../../components/Account/Login/Login.constants';
-import { DEFAULT_LANG } from '../../components/App/App.constants';
+import { APP_LANGS } from '../../components/App/App.constants';
+import { getDefaultLang } from '../../i18n';
 
 function getDir(lang) {
   const locale = lang.slice(0, 2);
@@ -12,7 +13,7 @@ function getDir(lang) {
 }
 
 const initialState = {
-  lang: DEFAULT_LANG,
+  lang: getDefaultLang(APP_LANGS),
   dir: 'ltr',
   langs: [],
   localLangs: [],


### PR DESCRIPTION
Utilizes the existing `getDefaultLang` method from *i18n.js* to set the system language as the default language when the application is first launched or when local storage is deleted.

Closes #1758 