### PR TITLE
Fix #1774

### DIFF
--- a/src/components/Board/Board.component.js
+++ b/src/components/Board/Board.component.js
@@ -210,7 +210,8 @@ export class Board extends Component {
             backgroundColor={tile.backgroundColor}
             borderColor={tile.borderColor}
             variant={variant}
-            onClick={() => {
+            onClick={e => {
+              e.stopPropagation();
               this.handleTileClick(tile);
             }}
             onFocus={() => {
@@ -253,7 +254,8 @@ export class Board extends Component {
         backgroundColor={tile.backgroundColor}
         borderColor={tile.borderColor}
         variant={variant}
-        onClick={() => {
+        onClick={e => {
+          e.stopPropagation();
           this.handleTileClick(tile);
         }}
         onFocus={() => {


### PR DESCRIPTION
The bug described in issue #1774 only happens when the scanning mode's scanning method is set to automatic, whereas the problem was that the Tile's onClick event was being fired twice when the output bar was empty.

Upon lots of debugging, I could state that this wasn't being caused by the events bubbling up (in both times the event's target and currentTarget were the same).

The culprit may lie in how the Scanner's automatic strategy handles the click event or the alternating DOM.

This PR fixes the issue by ensuring that the onClick event runs once, and only once.