### PR TITLE
Refactor Settings component: hidding the addSense section

### DIFF
--- a/src/components/Settings/Settings.component.js
+++ b/src/components/Settings/Settings.component.js
@@ -208,7 +208,7 @@ export class Settings extends PureComponent {
     disableTour({ isSettingsTourEnabled: true });
   };
 
-  addSense = () => {
+  AddSense = () => {
     return (
       !isCordova() && (
         <Paper className="Settings__section">
@@ -254,7 +254,7 @@ export class Settings extends PureComponent {
           )
         }
       >
-        {/*<this.addSense />*/}
+        {/*<this.AddSense />*/}
         {(isDownloadingLang && (
           <div className="Settings__spinner-container">
             <CircularProgress

--- a/src/components/Settings/Settings.component.js
+++ b/src/components/Settings/Settings.component.js
@@ -208,6 +208,22 @@ export class Settings extends PureComponent {
     disableTour({ isSettingsTourEnabled: true });
   };
 
+  addSense = () => {
+    return (
+      !isCordova() && (
+        <Paper className="Settings__section">
+          <Adsense
+            client={ADSENSE_CLIENT}
+            slot={ADD_SLOT_SETTINGS_TOP}
+            data-adtest={ADSENSE_ON_PRODUCTION ? 'off' : 'on'}
+            format="none"
+            className="adSense__marker"
+          />
+        </Paper>
+      )
+    );
+  };
+
   render() {
     const {
       intl,
@@ -238,26 +254,7 @@ export class Settings extends PureComponent {
           )
         }
       >
-        {!isCordova() && (
-          <Paper className="Settings__section">
-            <Adsense
-              style={{
-                display: 'block',
-                height: '30vh',
-                maxHeight: '198px'
-              }}
-              client={ADSENSE_CLIENT}
-              slot={ADD_SLOT_SETTINGS_TOP}
-              data-adtest={ADSENSE_ON_PRODUCTION ? 'off' : 'on'}
-              format="none"
-              className={
-                ADSENSE_ON_PRODUCTION || ADTEST_AVAILABLE
-                  ? null
-                  : 'adSense__test__marker'
-              }
-            />
-          </Paper>
-        )}
+        {/*<this.addSense />*/}
         {(isDownloadingLang && (
           <div className="Settings__spinner-container">
             <CircularProgress

--- a/src/components/Settings/Settings.css
+++ b/src/components/Settings/Settings.css
@@ -12,8 +12,14 @@
 .Settings__loading-Spinner {
   margin-top: 2em;
 }
+
 .Settings__section {
   margin-bottom: 8px;
+}
+
+.adSense__marker {
+  display: none;
+  height: 198px;
 }
 
 .Settings__section--secondaryAction {
@@ -125,6 +131,7 @@
   position: relative;
   background-color: none;
 }
+
 .swiper-pagination-bullets {
   bottom: 5px !important;
 }
@@ -137,6 +144,7 @@
 .Settings_Tour_Description_Scanning {
   margin-top: 4px;
 }
+
 .Settings__Tour__Scanning__Img {
   margin: 7px 0 7px 0;
 }
@@ -149,12 +157,15 @@
   :root {
     --swiper-navigation-size: 25px !important;
   }
+
   .swiper-button-next {
     right: 1px !important;
   }
+
   .swiper-button-prev {
     left: 1px !important;
   }
+
   .Settings__Tour__Step__Swiper__Container {
     height: 270px !important;
   }
@@ -162,6 +173,7 @@
   .mySwiper {
     height: 50% !important;
   }
+
   .swiper-pagination-bullets {
     bottom: -3px !important;
   }


### PR DESCRIPTION
close #1825 

in this issue, I created a class called addSense__Marker

```css:
.adSense__marker {
  display: none;
  height: 198px;
}
```
created a components called AddSense
```js:
  addSense = () => {
    return (
      !isCordova() && (
        <Paper className="Settings__section">
          <Adsense
            client={ADSENSE_CLIENT}
            slot={ADD_SLOT_SETTINGS_TOP}
            data-adtest={ADSENSE_ON_PRODUCTION ? 'off' : 'on'}
            format="none"
            className="adSense__marker"
          />
        </Paper>
      )
    );
  };
```
