### PR TITLE
EditToolbar prop bug

### DIFF
--- a/src/components/Board/EditToolbar/EditToolbar.component.js
+++ b/src/components/Board/EditToolbar/EditToolbar.component.js
@@ -75,10 +75,7 @@ EditToolbar.propTypes = {
    */
   onAddClick: PropTypes.func,
   onBoardTypeChange: PropTypes.func,
-  copiedTiles: PropTypes.arrayOf(PropTypes.object),
-  open: PropTypes.bool.isRequired,
-  onClose: PropTypes.func.isRequired,
-  onDialogAccecpted: PropTypes.func.isRequired
+  copiedTiles: PropTypes.arrayOf(PropTypes.object)
 };
 
 function EditToolbar({


### PR DESCRIPTION
refactor EditToolbar prop types to make open, onClose, and onDialogAccepted optional
close #1851 