### PR TITLE
Add unique key property to tile buttons for rendering consistency

### DIFF
--- a/src/components/Board/Board.component.js
+++ b/src/components/Board/Board.component.js
@@ -261,6 +261,7 @@ export class Board extends Component {
         onFocus={() => {
           this.handleTileFocus(tile.id);
         }}
+        key={tile.id}
       >
         <Symbol
           image={tile.image}

--- a/src/components/Board/Tile/Tile.component.js
+++ b/src/components/Board/Tile/Tile.component.js
@@ -25,7 +25,12 @@ const propTypes = {
   /**
    * Type of tile
    */
-  variant: PropTypes.oneOf(['button', 'folder', 'board'])
+  variant: PropTypes.oneOf(['button', 'folder', 'board']),
+  /**
+   * Unique key for the tile, used for React reconciliation
+   * and should be unique among siblings.
+   */
+  key: PropTypes.string
 };
 
 const defaultProps = {};


### PR DESCRIPTION
Introduce a key property to tile buttons on FixedGrids to ensure correct image rendering when changing boards. This change enhances React's reconciliation process by providing a unique identifier for each tile.
Close #1842 