### PR TITLE
Add long-term HTTP caching headers for public/ assets in Nginx config

### DIFF
--- a/rootfs/etc/nginx/conf.d/default.conf
+++ b/rootfs/etc/nginx/conf.d/default.conf
@@ -8,7 +8,6 @@ server {
     root   /usr/share/nginx/html;
     index  index.html index.html;
     location ~* ^/(images|symbols|ogv)(/.*)*\.(svg|png|jpe?g|gif|webp|ico|js|css|woff2?)$ {
-        expires 1y;
         add_header Cache-Control "public, max-age=31536000, immutable" always;
         access_log off;
         log_not_found off;

--- a/rootfs/etc/nginx/conf.d/default.conf
+++ b/rootfs/etc/nginx/conf.d/default.conf
@@ -7,7 +7,12 @@ server {
 
     root   /usr/share/nginx/html;
     index  index.html index.html;
-    
+    location ~* ^/(images|symbols|ogv)(/.*)*\.(svg|png|jpe?g|gif|webp|ico|js|css|woff2?)$ {
+        expires 1y;
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
+        access_log off;
+        log_not_found off;
+    }
     try_files $uri $uri/ /index.html;
     
     set $auth_basic off;


### PR DESCRIPTION
## 🔧 Changes

* Added a new `location` block in `default.conf` to match static assets in `/public` (e.g. `/images`, `/symbols`, `/ogv`), including subfolders.

* Applies to file types: `.svg`, `.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.ico`, `.js`, `.css`, `.woff`, `.woff2`.

* Sets a single `Cache-Control` header:

  ```http
  Cache-Control: public, max-age=31536000, immutable
  ```

* Removed the `expires` directive to avoid duplicate cache headers.

* Suppressed access and 404 logs for these static assets to reduce log noise.

---

## 🌟 Why

* **Improved performance on repeat visits**: assets are cached for up to 1 year.
* **Better CDN and browser caching**: allows intermediaries to reuse responses efficiently.
* **Works seamlessly with Create React App’s service worker setup**:

  * Assets are fingerprinted (`.hash.ext`), so long-term caching is safe.
  * The service worker still controls updates and offline capabilities.

---

## ✅ How to Test Locally

```bash
# From the project root, build the Docker image
docker build -t my-react-app .

# Run the container, exposing port 8080
docker run --rm -p 8080:80 my-react-app
```

1. Open the app in your browser at: [http://localhost:8080](http://localhost:8080)

2. In DevTools → Network tab, inspect a request to any asset in `/images`, `/symbols`, etc.

3. Confirm the response includes the header:

   ```http
   Cache-Control: public, max-age=31536000, immutable
   ```

4. Validate service worker behavior:

   * It installs correctly
   * Caches assets for offline use
   * Prompts the user when new content is available
