### PR TITLE
Revert grid double render fix and optimize grid components

### DIFF
--- a/src/components/Board/Board.component.js
+++ b/src/components/Board/Board.component.js
@@ -475,10 +475,8 @@ export class Board extends Component {
 
                 {board.isFixed && (
                   <FixedGrid
-                    gridState={{
-                      order: board.grid ? board.grid.order : [],
-                      items: board.tiles
-                    }}
+                    order={board.grid ? board.grid.order : []}
+                    items={board.tiles}
                     columns={
                       board.grid ? board.grid.columns : DEFAULT_COLUMNS_NUMBER
                     }

--- a/src/components/FixedGrid/Grid.js
+++ b/src/components/FixedGrid/Grid.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
@@ -32,15 +32,11 @@ function Grid(props) {
     ...other
   } = props;
 
-  const itemsPerPage = other.rows * other.columns;
-  const [pages, setPages] = useState(chunks(items, itemsPerPage));
-
-  useEffect(
-    () => {
-      setPages(chunks(items, itemsPerPage));
-    },
-    [items, itemsPerPage]
-  );
+  const pages = useMemo(() => chunks(items, other.rows * other.columns), [
+    items,
+    other.rows,
+    other.columns
+  ]);
 
   const gridClassName = classNames(styles.grid, className);
 

--- a/src/components/FixedGrid/Grid.js
+++ b/src/components/FixedGrid/Grid.js
@@ -23,15 +23,14 @@ const focusPosition = {
 function Grid(props) {
   const {
     className,
+    items,
     style,
     setIsScroll,
     fixedRef,
     isBigScrollBtns,
     isNavigationButtonsOnTheSide,
-    gridState,
     ...other
   } = props;
-  const { items } = gridState;
 
   const itemsPerPage = other.rows * other.columns;
   const [pages, setPages] = useState(chunks(items, itemsPerPage));
@@ -230,7 +229,7 @@ function Grid(props) {
           <GridBase
             {...other}
             className={gridClassName}
-            gridState={{ items: pageItems, order: gridState.order }}
+            items={pageItems}
             key={i}
             page={i}
           />
@@ -252,17 +251,21 @@ Grid.propTypes = {
    */
   dragAndDropEnabled: PropTypes.bool,
   /**
-   * State of the grid, including items and order.
+   * Items to render.
    */
-  gridState: PropTypes.shape({
-    items: PropTypes.arrayOf(
-      PropTypes.shape({
-        id: PropTypes.string.isRequired
-      })
-    ),
-    order: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)).isRequired
-  }).isRequired,
+  items: PropTypes.arrayOf(
+    PropTypes.shape({
+      /**
+       * Item ID.
+       */
+      id: PropTypes.string.isRequired
+    })
+  ),
   onItemDrop: PropTypes.func,
+  /**
+   * Items order by ID.
+   */
+  order: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)),
   /**
    * Item empty cell.
    */

--- a/src/components/FixedGrid/GridBase.js
+++ b/src/components/FixedGrid/GridBase.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
@@ -25,7 +25,12 @@ function GridBase(props) {
 
   const gridClassName = classNames(styles.root, className);
 
-  const grid = utils.sortGrid({ columns, rows, order, items });
+  const grid = useMemo(() => utils.sortGrid({ columns, rows, order, items }), [
+    columns,
+    rows,
+    order,
+    items
+  ]);
 
   let itemIndex = 0;
 

--- a/src/components/FixedGrid/GridBase.js
+++ b/src/components/FixedGrid/GridBase.js
@@ -7,31 +7,25 @@ import Row from './Row/Row';
 import DroppableCell from './DroppableCell/DroppableCell';
 import DraggableItem from './DraggableItem/DraggableItem';
 import styles from './GridBase.module.css';
-import { useMemo } from 'react';
 
 function GridBase(props) {
   const {
     className,
     columns,
     dragAndDropEnabled,
+    items,
     onItemDrop,
+    order,
     renderEmptyCell,
     renderItem,
     rows,
     page,
-    gridState,
     ...other
   } = props;
 
   const gridClassName = classNames(styles.root, className);
 
-  const { items, order } = gridState;
-  const grid = useMemo(
-    () => {
-      return utils.sortGrid({ columns, rows, order, items });
-    },
-    [columns, rows, order, items]
-  );
+  const grid = utils.sortGrid({ columns, rows, order, items });
 
   let itemIndex = 0;
 
@@ -83,16 +77,20 @@ GridBase.propTypes = {
    */
   dragAndDropEnabled: PropTypes.bool,
   /**
-   * State of the grid, including items and order.
+   * Items to render.
    */
-  gridState: PropTypes.shape({
-    items: PropTypes.arrayOf(
-      PropTypes.shape({
-        id: PropTypes.string.isRequired
-      })
-    ),
-    order: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)).isRequired
-  }).isRequired,
+  items: PropTypes.arrayOf(
+    PropTypes.shape({
+      /**
+       * Item ID.
+       */
+      id: PropTypes.string.isRequired
+    })
+  ),
+  /**
+   * Items order by ID.
+   */
+  order: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)),
   /**
    * Item renderer.
    */


### PR DESCRIPTION
Revert a previous merge that addressed double rendering in fixed boards. Replace `useState` with `useMemo` for better performance in pages calculation and optimize grid sorting in the `GridBase` component.

close #1870
close #1868