### PR TITLE
Optimise Board component

### DIFF
--- a/src/components/Board/Board.analytics.js
+++ b/src/components/Board/Board.analytics.js
@@ -17,7 +17,10 @@ const getTiles = (boards, boardId, tilesId) => {
 
   const tiles = board.tiles
     .filter(tile => tilesId.includes(tile.id))
-    .reduce((acc, tile) => (acc ? `${acc}, ${tile.label}` : tile.label), '');
+    .reduce((acc, tile) => {
+      const label = tile.label || tile.labelKey || tile.id;
+      return acc ? `${acc}, ${label}` : label;
+    }, '');
   return tiles;
 };
 
@@ -93,10 +96,10 @@ const deleteTiles = trackEvent((action, prevState, nextState) => {
 });
 
 const editTiles = trackEvent((action, prevState, nextState) => {
-  const editedTiles = action.tiles.reduce(
-    (acc, tile) => (acc ? `${acc}, ${tile.label}` : tile.label),
-    ''
-  );
+  const editedTiles = action.tiles.reduce((acc, tile) => {
+    const label = tile.label || tile.labelKey || tile.id;
+    return acc ? `${acc}, ${label}` : label;
+  }, '');
   const gaEvent = {
     category: 'Editing',
     action: 'Edit Tiles',

--- a/src/components/Board/Board.component.js
+++ b/src/components/Board/Board.component.js
@@ -35,6 +35,7 @@ import BoardTour from './BoardTour/BoardTour';
 import ScrollButtons from '../ScrollButtons';
 import { NAVIGATION_BUTTONS_STYLE_SIDES } from '../Settings/Navigation/Navigation.constants';
 import ImprovePhraseOutput from './ImprovePhraseOutput';
+import { resolveLabel } from '../../helpers';
 
 export class Board extends Component {
   static propTypes = {
@@ -220,9 +221,7 @@ export class Board extends Component {
           >
             <Symbol
               image={tile.image}
-              label={
-                tile.label ?? (this.props.intl?.messages[tile.labelKey] || '')
-              }
+              label={resolveLabel(tile, this.props.intl)}
               keyPath={tile.keyPath}
               labelpos={displaySettings.labelPosition}
             />
@@ -267,7 +266,7 @@ export class Board extends Component {
       >
         <Symbol
           image={tile.image}
-          label={tile.label ?? (this.props.intl?.messages[tile.labelKey] || '')}
+          label={resolveLabel(tile, this.props.intl)}
           keyPath={tile.keyPath}
           labelpos={displaySettings.labelPosition}
         />

--- a/src/components/Board/Board.component.js
+++ b/src/components/Board/Board.component.js
@@ -220,7 +220,9 @@ export class Board extends Component {
           >
             <Symbol
               image={tile.image}
-              label={tile.label}
+              label={
+                tile.label ?? (this.props.intl?.messages[tile.labelKey] || '')
+              }
               keyPath={tile.keyPath}
               labelpos={displaySettings.labelPosition}
             />
@@ -265,7 +267,7 @@ export class Board extends Component {
       >
         <Symbol
           image={tile.image}
-          label={tile.label}
+          label={tile.label ?? (this.props.intl?.messages[tile.labelKey] || '')}
           keyPath={tile.keyPath}
           labelpos={displaySettings.labelPosition}
         />

--- a/src/components/Board/Board.component.js
+++ b/src/components/Board/Board.component.js
@@ -35,7 +35,7 @@ import BoardTour from './BoardTour/BoardTour';
 import ScrollButtons from '../ScrollButtons';
 import { NAVIGATION_BUTTONS_STYLE_SIDES } from '../Settings/Navigation/Navigation.constants';
 import ImprovePhraseOutput from './ImprovePhraseOutput';
-import { resolveLabel } from '../../helpers';
+import { resolveTileLabel } from '../../helpers';
 
 export class Board extends Component {
   static propTypes = {
@@ -204,7 +204,7 @@ export class Board extends Component {
     return tiles.map(tileToRender => {
       const tile = {
         ...tileToRender,
-        label: resolveLabel(tileToRender, this.props.intl)
+        label: resolveTileLabel(tileToRender, this.props.intl)
       };
       const isSelected = selectedTileIds.includes(tile.id);
       const variant = Boolean(tile.loadBoard) ? 'folder' : 'button';
@@ -246,7 +246,7 @@ export class Board extends Component {
   renderTileFixedBoard = tileToRender => {
     const tile = {
       ...tileToRender,
-      label: resolveLabel(tileToRender, this.props.intl)
+      label: resolveTileLabel(tileToRender, this.props.intl)
     };
     const {
       isSelecting,

--- a/src/components/Board/Board.component.js
+++ b/src/components/Board/Board.component.js
@@ -201,7 +201,11 @@ export class Board extends Component {
       displaySettings
     } = this.props;
 
-    return tiles.map(tile => {
+    return tiles.map(tileToRender => {
+      const tile = {
+        ...tileToRender,
+        label: resolveLabel(tileToRender, this.props.intl)
+      };
       const isSelected = selectedTileIds.includes(tile.id);
       const variant = Boolean(tile.loadBoard) ? 'folder' : 'button';
 
@@ -221,7 +225,7 @@ export class Board extends Component {
           >
             <Symbol
               image={tile.image}
-              label={resolveLabel(tile, this.props.intl)}
+              label={tile.label}
               keyPath={tile.keyPath}
               labelpos={displaySettings.labelPosition}
             />
@@ -239,7 +243,11 @@ export class Board extends Component {
     });
   }
 
-  renderTileFixedBoard = tile => {
+  renderTileFixedBoard = tileToRender => {
+    const tile = {
+      ...tileToRender,
+      label: resolveLabel(tileToRender, this.props.intl)
+    };
     const {
       isSelecting,
       isSaving,
@@ -266,7 +274,7 @@ export class Board extends Component {
       >
         <Symbol
           image={tile.image}
-          label={resolveLabel(tile, this.props.intl)}
+          label={tile.label}
           keyPath={tile.keyPath}
           labelpos={displaySettings.labelPosition}
         />

--- a/src/components/Board/Board.container.js
+++ b/src/components/Board/Board.container.js
@@ -820,7 +820,11 @@ export class BoardContainer extends Component {
       if (tile.sound) {
         this.playAudio(tile.sound);
       } else {
-        const toSpeak = !hasAction ? tile.vocalization || tile.label : null;
+        const toSpeak =
+          (!hasAction && tile.vocalization) ||
+          tile.label ||
+          this.props.intl?.messages[tile.labelKey] ||
+          '';
         if (toSpeak) {
           speak(toSpeak);
         }

--- a/src/components/Board/Board.container.js
+++ b/src/components/Board/Board.container.js
@@ -193,7 +193,6 @@ export class BoardContainer extends Component {
     isSelecting: false,
     isLocked: true,
     tileEditorOpen: false,
-    translatedBoard: null,
     isGettingApiObjects: false,
     copyPublicBoard: false,
     blockedPrivateBoard: false,
@@ -285,9 +284,6 @@ export class BoardContainer extends Component {
     const goTo = id ? boardId : `board/${boardId}`;
     history.replace(goTo);
 
-    const translatedBoard = this.translateBoard(boardExists);
-    this.setState({ translatedBoard });
-
     //set board type
     this.setState({ isFixedBoard: !!boardExists.isFixed });
 
@@ -326,10 +322,6 @@ export class BoardContainer extends Component {
         }
       }
     }
-
-    // TODO: perf issues
-    const translatedBoard = this.translateBoard(nextProps.board);
-    this.setState({ translatedBoard });
   }
 
   componentDidUpdate(prevProps) {
@@ -420,48 +412,6 @@ export class BoardContainer extends Component {
     }
   }
 
-  translateBoard(board) {
-    if (!board) {
-      return null;
-    }
-
-    const { intl } = this.props;
-    let name;
-    let nameFromKey;
-    if (board.nameKey) {
-      const nameKeyArray = board.nameKey.split('.');
-      nameFromKey = nameKeyArray[nameKeyArray.length - 1];
-    }
-    if (board.nameKey && !board.name) {
-      name = intl.formatMessage({ id: board.nameKey });
-    } else if (
-      board.nameKey &&
-      board.name &&
-      nameFromKey === board.name &&
-      intl.messages[board.nameKey]
-    ) {
-      name = intl.formatMessage({ id: board.nameKey });
-    } else {
-      name = board.name;
-    }
-    const validTiles = board.tiles.filter(tile => (tile ? true : false));
-    const tiles = validTiles.map(tile => ({
-      ...tile,
-      label:
-        tile.labelKey && intl.messages[tile.labelKey]
-          ? intl.formatMessage({ id: tile.labelKey })
-          : tile.label
-    }));
-
-    const translatedBoard = {
-      ...board,
-      name,
-      tiles
-    };
-
-    return translatedBoard;
-  }
-
   async captureBoardScreenshot() {
     const node = document.getElementById('BoardTilesContainer').firstChild;
     let dataURL = null;
@@ -470,18 +420,6 @@ export class BoardContainer extends Component {
     } catch (e) {}
 
     return dataURL;
-  }
-
-  async updateBoardScreenshot() {
-    let url = null;
-    const dataURL = await this.captureBoardScreenshot();
-    if (dataURL && dataURL !== 'data:,') {
-      const filename = `${this.state.translatedBoard.name ||
-        this.state.translatedBoard.id}.png`;
-      url = await API.uploadFromDataURL(dataURL, filename);
-    }
-
-    return url;
   }
 
   async playAudio(src) {
@@ -905,7 +843,9 @@ export class BoardContainer extends Component {
         showNotification(intl.formatMessage(messages.boardMissed));
       }
     } else {
-      clickSymbol(tile.label);
+      clickSymbol(
+        tile.label ?? (this.props.intl?.messages[tile.labelKey] || '')
+      );
       if (!navigationSettings.quietBuilderMode) {
         say();
       }
@@ -1222,9 +1162,7 @@ export class BoardContainer extends Component {
       }
       switchBoard(copiedBoard.id);
       history.replace(`/board/${copiedBoard.id}`, []);
-      const translatedBoard = this.translateBoard(copiedBoard);
       this.setState({
-        translatedBoard,
         copyPublicBoard: false,
         blockedPrivateBoard: false
       });
@@ -1554,7 +1492,7 @@ export class BoardContainer extends Component {
     } = this.props;
     const { isCbuilderBoard } = this.state;
 
-    if (!this.state.translatedBoard) {
+    if (!this.props.board) {
       return (
         <div className="Board__loading">
           <CircularProgress size={60} thickness={5} color="inherit" />
@@ -1576,7 +1514,7 @@ export class BoardContainer extends Component {
     return (
       <Fragment>
         <Board
-          board={this.state.translatedBoard}
+          board={board}
           intl={this.props.intl}
           scannerSettings={this.props.scannerSettings}
           deactivateScanner={this.props.deactivateScanner}

--- a/src/components/Board/Board.container.js
+++ b/src/components/Board/Board.container.js
@@ -798,7 +798,11 @@ export class BoardContainer extends Component {
     }));
   };
 
-  handleTileClick = tile => {
+  handleTileClick = clickedTile => {
+    const tile = {
+      ...clickedTile,
+      label: resolveLabel(clickedTile, this.props.intl)
+    };
     if (this.state.isSelecting) {
       this.toggleTileSelect(tile.id);
       return;
@@ -821,8 +825,7 @@ export class BoardContainer extends Component {
       if (tile.sound) {
         this.playAudio(tile.sound);
       } else {
-        const toSpeak =
-          (!hasAction && tile.vocalization) || resolveLabel(tile, intl);
+        const toSpeak = !hasAction ? tile.vocalization || tile.label : null;
         if (toSpeak) {
           speak(toSpeak);
         }
@@ -845,7 +848,7 @@ export class BoardContainer extends Component {
         showNotification(intl.formatMessage(messages.boardMissed));
       }
     } else {
-      clickSymbol(resolveLabel(tile, intl));
+      clickSymbol(tile.label);
       if (!navigationSettings.quietBuilderMode) {
         say();
       }

--- a/src/components/Board/Board.container.js
+++ b/src/components/Board/Board.container.js
@@ -71,7 +71,7 @@ import {
   IS_BROWSING_FROM_SAFARI
 } from '../../constants';
 import LoadingIcon from '../UI/LoadingIcon';
-import { resolveLabel } from '../../helpers';
+import { resolveTileLabel } from '../../helpers';
 //import { isAndroid } from '../../cordova-util';
 
 const ogv = require('ogv');
@@ -801,7 +801,7 @@ export class BoardContainer extends Component {
   handleTileClick = clickedTile => {
     const tile = {
       ...clickedTile,
-      label: resolveLabel(clickedTile, this.props.intl)
+      label: resolveTileLabel(clickedTile, this.props.intl)
     };
     if (this.state.isSelecting) {
       this.toggleTileSelect(tile.id);

--- a/src/components/Board/Board.container.js
+++ b/src/components/Board/Board.container.js
@@ -71,6 +71,7 @@ import {
   IS_BROWSING_FROM_SAFARI
 } from '../../constants';
 import LoadingIcon from '../UI/LoadingIcon';
+import { resolveLabel } from '../../helpers';
 //import { isAndroid } from '../../cordova-util';
 
 const ogv = require('ogv');
@@ -821,10 +822,7 @@ export class BoardContainer extends Component {
         this.playAudio(tile.sound);
       } else {
         const toSpeak =
-          (!hasAction && tile.vocalization) ||
-          tile.label ||
-          this.props.intl?.messages[tile.labelKey] ||
-          '';
+          (!hasAction && tile.vocalization) || resolveLabel(tile, intl);
         if (toSpeak) {
           speak(toSpeak);
         }
@@ -847,9 +845,7 @@ export class BoardContainer extends Component {
         showNotification(intl.formatMessage(messages.boardMissed));
       }
     } else {
-      clickSymbol(
-        tile.label ?? (this.props.intl?.messages[tile.labelKey] || '')
-      );
+      clickSymbol(resolveLabel(tile, intl));
       if (!navigationSettings.quietBuilderMode) {
         say();
       }

--- a/src/components/Board/EditToolbar/EditToolbar.component.js
+++ b/src/components/Board/EditToolbar/EditToolbar.component.js
@@ -125,7 +125,9 @@ function EditToolbar({
       })}
     >
       {(isSaving || !isLoggedIn) && (
-        <span className="EditToolbar__BoardTitle">{board.name}</span>
+        <span className="EditToolbar__BoardTitle">
+          {board.name || intl.formatMessage({ id: board.nameKey })}
+        </span>
       )}
 
       {!isSaving && isLoggedIn && (
@@ -135,7 +137,7 @@ function EditToolbar({
           })}
           onClick={onBoardTitleClick}
         >
-          {board.name}
+          {board.name || intl.formatMessage({ id: board.nameKey })}
         </Button>
       )}
 

--- a/src/components/Board/EditToolbar/EditToolbar.component.js
+++ b/src/components/Board/EditToolbar/EditToolbar.component.js
@@ -24,6 +24,7 @@ import messages from './EditToolbar.messages';
 import './EditToolbar.css';
 import { FormControlLabel } from '@material-ui/core';
 import PremiumFeature from '../../PremiumFeature';
+import { resolveBoardName } from '../../../helpers';
 
 EditToolbar.propTypes = {
   /**
@@ -126,7 +127,7 @@ function EditToolbar({
     >
       {(isSaving || !isLoggedIn) && (
         <span className="EditToolbar__BoardTitle">
-          {board.name || intl.formatMessage({ id: board.nameKey })}
+          {resolveBoardName(board, intl)}
         </span>
       )}
 
@@ -137,7 +138,7 @@ function EditToolbar({
           })}
           onClick={onBoardTitleClick}
         >
-          {board.name || intl.formatMessage({ id: board.nameKey })}
+          {resolveBoardName(board, intl)}
         </Button>
       )}
 

--- a/src/components/Board/Output/SymbolOutput/SymbolOutput.js
+++ b/src/components/Board/Output/SymbolOutput/SymbolOutput.js
@@ -115,7 +115,7 @@ class SymbolOutput extends PureComponent {
     return (
       <div className="SymbolOutput">
         <Scroll scrollContainerReference={this.scrollContainerRef} {...other}>
-          {symbols.map(({ image, label, labelKey, type, keyPath }, index) => (
+          {symbols.map(({ image, label, type, keyPath }, index) => (
             <div
               className={
                 type === 'live'
@@ -128,13 +128,7 @@ class SymbolOutput extends PureComponent {
                 className="SymbolOutput__symbol"
                 image={image}
                 keyPath={keyPath}
-                label={resolveLabel(
-                  {
-                    label,
-                    labelKey
-                  },
-                  intl
-                )}
+                label={label}
                 type={type}
                 labelpos="Below"
                 onWrite={onWriteSymbol(index)}

--- a/src/components/Board/Output/SymbolOutput/SymbolOutput.js
+++ b/src/components/Board/Output/SymbolOutput/SymbolOutput.js
@@ -114,7 +114,7 @@ class SymbolOutput extends PureComponent {
     return (
       <div className="SymbolOutput">
         <Scroll scrollContainerReference={this.scrollContainerRef} {...other}>
-          {symbols.map(({ image, label, type, keyPath }, index) => (
+          {symbols.map(({ image, label, labelKey, type, keyPath }, index) => (
             <div
               className={
                 type === 'live'
@@ -127,7 +127,7 @@ class SymbolOutput extends PureComponent {
                 className="SymbolOutput__symbol"
                 image={image}
                 keyPath={keyPath}
-                label={label}
+                label={label ?? (this.props.intl?.messages[labelKey] || '')}
                 type={type}
                 labelpos="Below"
                 onWrite={onWriteSymbol(index)}

--- a/src/components/Board/Output/SymbolOutput/SymbolOutput.js
+++ b/src/components/Board/Output/SymbolOutput/SymbolOutput.js
@@ -14,7 +14,6 @@ import PhraseShare from '../PhraseShare';
 import Scroll from './Scroll';
 import './SymbolOutput.css';
 import { injectIntl } from 'react-intl';
-import { resolveLabel } from '../../../../helpers';
 
 class SymbolOutput extends PureComponent {
   constructor(props) {

--- a/src/components/Board/Output/SymbolOutput/SymbolOutput.js
+++ b/src/components/Board/Output/SymbolOutput/SymbolOutput.js
@@ -14,6 +14,7 @@ import PhraseShare from '../PhraseShare';
 import Scroll from './Scroll';
 import './SymbolOutput.css';
 import { injectIntl } from 'react-intl';
+import { resolveLabel } from '../../../../helpers';
 
 class SymbolOutput extends PureComponent {
   constructor(props) {
@@ -127,7 +128,13 @@ class SymbolOutput extends PureComponent {
                 className="SymbolOutput__symbol"
                 image={image}
                 keyPath={keyPath}
-                label={label ?? (this.props.intl?.messages[labelKey] || '')}
+                label={resolveLabel(
+                  {
+                    label,
+                    labelKey
+                  },
+                  intl
+                )}
                 type={type}
                 labelpos="Below"
                 onWrite={onWriteSymbol(index)}

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -48,3 +48,11 @@ export const convertImageUrlToCatchable = imageUrl => {
   if (isCboardProductionBlobContainer) return cboardBlobUsingCDN(imageUrl);
   return null;
 };
+
+export const resolveLabel = ({ label, labelKey }, intl) => {
+  if (label) return label;
+  if (labelKey && intl?.messages?.[labelKey]) {
+    return intl.formatMessage({ id: labelKey });
+  }
+  return '';
+};

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -49,7 +49,7 @@ export const convertImageUrlToCatchable = imageUrl => {
   return null;
 };
 
-export const resolveLabel = ({ label, labelKey }, intl) => {
+export const resolveTileLabel = ({ label, labelKey }, intl) => {
   if (label) return label;
   if (labelKey && intl?.messages?.[labelKey]) {
     return intl.formatMessage({ id: labelKey });

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -49,6 +49,14 @@ export const convertImageUrlToCatchable = imageUrl => {
   return null;
 };
 
+export const resolveBoardName = ({ name, nameKey }, intl) => {
+  if (name) return name;
+  if (nameKey && intl?.messages?.[nameKey]) {
+    return intl.formatMessage({ id: nameKey });
+  }
+  return '';
+};
+
 export const resolveTileLabel = ({ label, labelKey }, intl) => {
   if (label) return label;
   if (labelKey && intl?.messages?.[labelKey]) {


### PR DESCRIPTION
Remove unnecessary translatedBoard state and related logic from BoardContainer to improve performance and reduce re-renders.
Manage translations of labels when the Symbol component is rendered, providing a translation using labelKey. 
Please try to define if this way of translating labels is okay, if we can improve it, or find a better solution.

This PR drastically reduces the number of rerenders of our main `board` components.
Please let me know your thoughts, and thanks to @RodriSanchez1 for noting this performance issue.
Close #1884 
