### PR TITLE
Quick fix for remove rows and columns function on fixed boards

### DIFF
--- a/src/components/Board/Board.container.js
+++ b/src/components/Board/Board.container.js
@@ -24,7 +24,7 @@ import {
   speak,
   cancelSpeech
 } from '../../providers/SpeechProvider/SpeechProvider.actions';
-import { moveOrderItem } from '../FixedGrid/utils';
+import { getDeprecatedOrderedPages, moveOrderItem } from '../FixedGrid/utils';
 import {
   addBoards,
   changeBoard,
@@ -664,8 +664,15 @@ export class BoardContainer extends Component {
       } else {
         newOrder = this.getDefaultOrdering(board.tiles);
       }
+      const newPages = getDeprecatedOrderedPages({
+        tileItems: board.tiles,
+        order: newOrder
+      });
+      const tilesForNewOrder = newPages.flat();
+
       const newBoard = {
         ...board,
+        tiles: tilesForNewOrder,
         grid: {
           ...board.grid,
           rows: newRows,

--- a/src/components/Board/Board.container.js
+++ b/src/components/Board/Board.container.js
@@ -24,7 +24,7 @@ import {
   speak,
   cancelSpeech
 } from '../../providers/SpeechProvider/SpeechProvider.actions';
-import { getDeprecatedOrderedPages, moveOrderItem } from '../FixedGrid/utils';
+import { getTilesListForNewOrder, moveOrderItem } from '../FixedGrid/utils';
 import {
   addBoards,
   changeBoard,
@@ -664,11 +664,10 @@ export class BoardContainer extends Component {
       } else {
         newOrder = this.getDefaultOrdering(board.tiles);
       }
-      const newPages = getDeprecatedOrderedPages({
+      const tilesForNewOrder = getTilesListForNewOrder({
         tileItems: board.tiles,
         order: newOrder
       });
-      const tilesForNewOrder = newPages.flat();
 
       const newBoard = {
         ...board,
@@ -704,8 +703,13 @@ export class BoardContainer extends Component {
       } else {
         newOrder = this.getDefaultOrdering(board.tiles);
       }
+      const tilesForNewOrder = getTilesListForNewOrder({
+        tileItems: board.tiles,
+        order: newOrder
+      });
       const newBoard = {
         ...board,
+        tiles: tilesForNewOrder,
         grid: {
           ...board.grid,
           columns: newColumns,

--- a/src/components/FixedGrid/Grid.js
+++ b/src/components/FixedGrid/Grid.js
@@ -4,17 +4,7 @@ import classNames from 'classnames';
 
 import GridBase from './GridBase';
 import styles from './Grid.module.css';
-
-function chunks(array, size) {
-  const newArray = [...array];
-  const results = [];
-
-  while (newArray.length) {
-    results.push(newArray.splice(0, size));
-  }
-
-  return results;
-}
+import { compatibleDeprecatedChunks } from './utils';
 
 const focusPosition = {
   x: 0,
@@ -29,14 +19,14 @@ function Grid(props) {
     fixedRef,
     isBigScrollBtns,
     isNavigationButtonsOnTheSide,
+    order,
     ...other
   } = props;
 
-  const pages = useMemo(() => chunks(items, other.rows * other.columns), [
-    items,
-    other.rows,
-    other.columns
-  ]);
+  const pages = useMemo(
+    () => compatibleDeprecatedChunks({ tileItems: items, order }),
+    [items, order]
+  );
 
   const gridClassName = classNames(styles.grid, className);
 
@@ -226,12 +216,19 @@ function Grid(props) {
             {...other}
             className={gridClassName}
             items={pageItems}
+            order={order}
             key={i}
             page={i}
           />
         ))
       ) : (
-        <GridBase {...other} className={gridClassName} page={0} />
+        <GridBase
+          {...other}
+          order={order}
+          items={items}
+          className={gridClassName}
+          page={0}
+        />
       )}
     </div>
   );

--- a/src/components/FixedGrid/Grid.js
+++ b/src/components/FixedGrid/Grid.js
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 
 import GridBase from './GridBase';
 import styles from './Grid.module.css';
-import { compatibleDeprecatedChunks } from './utils';
+import { getDeprecatedOrderedPages } from './utils';
 
 const focusPosition = {
   x: 0,
@@ -24,7 +24,7 @@ function Grid(props) {
   } = props;
 
   const pages = useMemo(
-    () => compatibleDeprecatedChunks({ tileItems: items, order }),
+    () => getDeprecatedOrderedPages({ tileItems: items, order }),
     [items, order]
   );
 

--- a/src/components/FixedGrid/Grid.js
+++ b/src/components/FixedGrid/Grid.js
@@ -4,7 +4,17 @@ import classNames from 'classnames';
 
 import GridBase from './GridBase';
 import styles from './Grid.module.css';
-import { getDeprecatedOrderedPages } from './utils';
+
+function chunks(array, size) {
+  const newArray = [...array];
+  const results = [];
+
+  while (newArray.length) {
+    results.push(newArray.splice(0, size));
+  }
+
+  return results;
+}
 
 const focusPosition = {
   x: 0,
@@ -19,14 +29,14 @@ function Grid(props) {
     fixedRef,
     isBigScrollBtns,
     isNavigationButtonsOnTheSide,
-    order,
     ...other
   } = props;
 
-  const pages = useMemo(
-    () => getDeprecatedOrderedPages({ tileItems: items, order }),
-    [items, order]
-  );
+  const pages = useMemo(() => chunks(items, other.rows * other.columns), [
+    items,
+    other.rows,
+    other.columns
+  ]);
 
   const gridClassName = classNames(styles.grid, className);
 
@@ -216,19 +226,12 @@ function Grid(props) {
             {...other}
             className={gridClassName}
             items={pageItems}
-            order={order}
             key={i}
             page={i}
           />
         ))
       ) : (
-        <GridBase
-          {...other}
-          order={order}
-          items={items}
-          className={gridClassName}
-          page={0}
-        />
+        <GridBase {...other} className={gridClassName} page={0} />
       )}
     </div>
   );

--- a/src/components/FixedGrid/utils.ts
+++ b/src/components/FixedGrid/utils.ts
@@ -183,8 +183,8 @@ export function getTilesListForNewOrder({
   order: GridOrder;
 }): TileItem[] {
   const newPages = getDeprecatedOrderedPages({
-    tileItems,
     order,
+    tileItems,
   });
   const tilesListForNewOrder = newPages.flat();
   return tilesListForNewOrder;

--- a/src/components/FixedGrid/utils.ts
+++ b/src/components/FixedGrid/utils.ts
@@ -126,32 +126,48 @@ export function removeOrderItems(ids: string, order: GridOrder): GridOrder {
   return order.map(row => row.map(id => (id && ids.includes(id) ? null : id)));
 }
 
-function getDeprecatedOrderedPages({ tileItems, order }:{
+function getDeprecatedOrderedPages({
+  tileItems,
+  order,
+}: {
   tileItems: Array<TileItem>;
   order: GridOrder;
-}):TileItem[][] {
-  const firstPageItemsInOrder = order.map(row =>
-    row.map(id => tileItems.find(item => item.id === id)||null)
+}): TileItem[][] {
+  const firstPageItemsInOrder = order.map((row) =>
+    row.map((id) => tileItems.find((item) => item.id === id) || null),
   );
 
   const firstPageIds = order.flat();
   const orderedIds = new Set(order.flat());
-  const unorderedTiles = tileItems.filter(item => !orderedIds.has(item.id));
-  const fillEmptyPositionsWithUnorderedTilesForOldBoards = ({firstPageItemsInOrder,unorderedTiles}:{firstPageItemsInOrder:(TileItem|null)[][],unorderedTiles:Array<TileItem> }) => {
+  const unorderedTiles = tileItems.filter((item) => !orderedIds.has(item.id));
+  const fillEmptyPositionsWithUnorderedTilesForOldBoards = ({
+    firstPageItemsInOrder,
+    unorderedTiles,
+  }: {
+    firstPageItemsInOrder: (TileItem | null)[][];
+    unorderedTiles: Array<TileItem>;
+  }) => {
     let index = 0;
-    const deprecatedFirstPageItemsInOrder = firstPageItemsInOrder.map(row=>
-    row.map(item => {
+    const deprecatedFirstPageItemsInOrder = firstPageItemsInOrder.map((row) =>
+      row.map((item) => {
       if (item) return item;
       index++;
-      return unorderedTiles[index - 1]|| null;
-    }));
-    const deprecatedFirstPage = deprecatedFirstPageItemsInOrder.flat().filter(item => item !== null);
+        return unorderedTiles[index - 1] || null;
+      }),
+    );
+    const deprecatedFirstPage = deprecatedFirstPageItemsInOrder
+      .flat()
+      .filter((item) => item !== null);
     const restOfTiles = unorderedTiles.slice(index);
 
-    return {deprecatedFirstPage,restOfTiles};
-  }
+    return { deprecatedFirstPage, restOfTiles };
+  };
   
-  const {deprecatedFirstPage ,restOfTiles} = fillEmptyPositionsWithUnorderedTilesForOldBoards({firstPageItemsInOrder,unorderedTiles});
+  const { deprecatedFirstPage, restOfTiles } =
+    fillEmptyPositionsWithUnorderedTilesForOldBoards({
+      firstPageItemsInOrder,
+      unorderedTiles,
+    });
 
   const size = firstPageIds.length;
   const restOfPages = lodash.chunk(restOfTiles, size);
@@ -159,14 +175,17 @@ function getDeprecatedOrderedPages({ tileItems, order }:{
   return [deprecatedFirstPage, ...restOfPages];
 }
 
-export function getTilesListForNewOrder({ tileItems, order }:{
+export function getTilesListForNewOrder({
+  tileItems,
+  order,
+}: {
   tileItems: Array<TileItem>;
   order: GridOrder;
-}):TileItem[]{
+}): TileItem[] {
   const newPages = getDeprecatedOrderedPages({
     tileItems,
-    order
+    order,
   });
   const tilesListForNewOrder = newPages.flat();
-  return tilesListForNewOrder
+  return tilesListForNewOrder;
 }

--- a/src/components/FixedGrid/utils.ts
+++ b/src/components/FixedGrid/utils.ts
@@ -134,7 +134,7 @@ export function compatibleDeprecatedChunks({ tileItems, order }:{
     row.map(id => tileItems.find(item => item.id === id)||null)
   );
 
-  const firstPage = lodash.flatten(firstPageItemsInOrder);
+  const firstPage = firstPageItemsInOrder.flat();
   const unnorderedTiles = tileItems.filter(
     item => !firstPage.find(tile => tile?.id === item.id)
   );
@@ -146,7 +146,7 @@ export function compatibleDeprecatedChunks({ tileItems, order }:{
       index++;
       return unnorderedTiles[index - 1]|| null;
     }));
-    const deprecatedFirstPage = lodash.flatten(deprecatedFirstPageItemsInOrder).filter(item => item !== null);//
+    const deprecatedFirstPage = deprecatedFirstPageItemsInOrder.flat().filter(item => item !== null);
     const restOfTiles = unnorderedTiles.slice(index);
 
     return {deprecatedFirstPage,restOfTiles};

--- a/src/components/FixedGrid/utils.ts
+++ b/src/components/FixedGrid/utils.ts
@@ -126,7 +126,7 @@ export function removeOrderItems(ids: string, order: GridOrder): GridOrder {
   return order.map(row => row.map(id => (id && ids.includes(id) ? null : id)));
 }
 
-export function getDeprecatedOrderedPages({ tileItems, order }:{
+function getDeprecatedOrderedPages({ tileItems, order }:{
   tileItems: Array<TileItem>;
   order: GridOrder;
 }):TileItem[][] {
@@ -157,4 +157,16 @@ export function getDeprecatedOrderedPages({ tileItems, order }:{
   const restOfPages = lodash.chunk(restOfTiles, size);
   
   return [deprecatedFirstPage, ...restOfPages];
+}
+
+export function getTilesListForNewOrder({ tileItems, order }:{
+  tileItems: Array<TileItem>;
+  order: GridOrder;
+}):TileItem[]{
+  const newPages = getDeprecatedOrderedPages({
+    tileItems,
+    order
+  });
+  const tilesListForNewOrder = newPages.flat();
+  return tilesListForNewOrder
 }

--- a/src/components/FixedGrid/utils.ts
+++ b/src/components/FixedGrid/utils.ts
@@ -126,7 +126,7 @@ export function removeOrderItems(ids: string, order: GridOrder): GridOrder {
   return order.map(row => row.map(id => (id && ids.includes(id) ? null : id)));
 }
 
-export function compatibleDeprecatedChunks({ tileItems, order }:{
+export function getDeprecatedOrderedPages({ tileItems, order }:{
   tileItems: Array<TileItem>;
   order: GridOrder;
 }):TileItem[][] {

--- a/src/components/FixedGrid/utils.ts
+++ b/src/components/FixedGrid/utils.ts
@@ -1,4 +1,5 @@
 import lodash from 'lodash';
+import { TileItem } from './../../types';
 export interface Grid {
   rows: number;
   columns: number;
@@ -123,19 +124,6 @@ export function getNewOrder({ columns,
 
 export function removeOrderItems(ids: string, order: GridOrder): GridOrder {
   return order.map(row => row.map(id => (id && ids.includes(id) ? null : id)));
-}
-
-interface TileItem {
-  id: string;
-  label?: string;
-  labelKey?: string;
-  vocalization?: string;
-  image: string;
-  loadBoard?: string;
-  sound?: string;
-  type?: string;
-  backgroundColor: string;
-  linkedBoard?: boolean;
 }
 
 export function compatibleDeprecatedChunks({ tileItems, order }:{

--- a/src/components/FixedGrid/utils.ts
+++ b/src/components/FixedGrid/utils.ts
@@ -134,10 +134,9 @@ export function getDeprecatedOrderedPages({ tileItems, order }:{
     row.map(id => tileItems.find(item => item.id === id)||null)
   );
 
-  const firstPage = firstPageItemsInOrder.flat();
-  const unorderedTiles = tileItems.filter(
-    item => !firstPage.find(tile => tile?.id === item.id)
-  );
+  const firstPageIds = order.flat();
+  const orderedIds = new Set(order.flat());
+  const unorderedTiles = tileItems.filter(item => !orderedIds.has(item.id));
   const fillEmptyPositionsWithUnorderedTilesForOldBoards = ({firstPageItemsInOrder,unorderedTiles}:{firstPageItemsInOrder:(TileItem|null)[][],unorderedTiles:Array<TileItem> }) => {
     let index = 0;
     const deprecatedFirstPageItemsInOrder = firstPageItemsInOrder.map(row=>
@@ -154,7 +153,7 @@ export function getDeprecatedOrderedPages({ tileItems, order }:{
   
   const {deprecatedFirstPage ,restOfTiles} = fillEmptyPositionsWithUnorderedTilesForOldBoards({firstPageItemsInOrder,unorderedTiles});
 
-  const size = firstPage.length;
+  const size = firstPageIds.length;
   const restOfPages = lodash.chunk(restOfTiles, size);
   
   return [deprecatedFirstPage, ...restOfPages];

--- a/src/components/FixedGrid/utils.ts
+++ b/src/components/FixedGrid/utils.ts
@@ -135,24 +135,24 @@ export function compatibleDeprecatedChunks({ tileItems, order }:{
   );
 
   const firstPage = firstPageItemsInOrder.flat();
-  const unnorderedTiles = tileItems.filter(
+  const unorderedTiles = tileItems.filter(
     item => !firstPage.find(tile => tile?.id === item.id)
   );
-  const fillEmptyPositionsWithUnnorderedTilesForOldBoards = ({firstPageItemsInOrder,unnorderedTiles}:{firstPageItemsInOrder:(TileItem|null)[][],unnorderedTiles:Array<TileItem> }) => {
+  const fillEmptyPositionsWithUnorderedTilesForOldBoards = ({firstPageItemsInOrder,unorderedTiles}:{firstPageItemsInOrder:(TileItem|null)[][],unorderedTiles:Array<TileItem> }) => {
     let index = 0;
     const deprecatedFirstPageItemsInOrder = firstPageItemsInOrder.map(row=>
     row.map(item => {
       if (item) return item;
       index++;
-      return unnorderedTiles[index - 1]|| null;
+      return unorderedTiles[index - 1]|| null;
     }));
     const deprecatedFirstPage = deprecatedFirstPageItemsInOrder.flat().filter(item => item !== null);
-    const restOfTiles = unnorderedTiles.slice(index);
+    const restOfTiles = unorderedTiles.slice(index);
 
     return {deprecatedFirstPage,restOfTiles};
   }
   
-  const {deprecatedFirstPage ,restOfTiles} = fillEmptyPositionsWithUnnorderedTilesForOldBoards({firstPageItemsInOrder,unnorderedTiles});
+  const {deprecatedFirstPage ,restOfTiles} = fillEmptyPositionsWithUnorderedTilesForOldBoards({firstPageItemsInOrder,unorderedTiles});
 
   const size = firstPage.length;
   const restOfPages = lodash.chunk(restOfTiles, size);

--- a/src/components/FixedGrid/utils.ts
+++ b/src/components/FixedGrid/utils.ts
@@ -1,3 +1,4 @@
+import lodash from 'lodash';
 export interface Grid {
   rows: number;
   columns: number;
@@ -122,4 +123,48 @@ export function getNewOrder({ columns,
 
 export function removeOrderItems(ids: string, order: GridOrder): GridOrder {
   return order.map(row => row.map(id => (id && ids.includes(id) ? null : id)));
+}
+
+interface TileItem {
+  id: string;
+  label?: string;
+  labelKey?: string;
+  vocalization?: string;
+  image: string;
+  loadBoard?: string;
+  sound?: string;
+  type?: string;
+  backgroundColor: string;
+  linkedBoard?: boolean;
+}
+
+export function deprecatedChunks(tileItems: Array<TileItem>, size: number) {
+  const newArray = [...tileItems];
+  const results = [];
+
+  while (newArray.length) {
+    results.push(newArray.splice(0, size));
+  }
+
+  return results;
+}
+
+export function chunks({ tileItems, order }:{
+  tileItems: Array<TileItem>;
+  order: GridOrder;
+}) {
+  const firstPageItemsInOrder = order.map(row =>
+    row.map(id => tileItems.find(item => item.id === id))
+  );
+
+  const firstPage = lodash.flatten(firstPageItemsInOrder);
+
+  const size = firstPage.length;
+
+  const restOfItems = tileItems.filter(
+    item => !firstPage.find(firstItem => firstItem?.id === item.id)
+  );
+  const restOfPages = lodash.chunk(restOfItems, size);
+
+  return [firstPage, ...restOfPages];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,12 @@
+export interface TileItem {
+  id: string;
+  label?: string;
+  labelKey?: string;
+  vocalization?: string;
+  image: string;
+  loadBoard?: string;
+  sound?: string;
+  type?: string;
+  backgroundColor: string;
+  linkedBoard?: boolean;
+}


### PR DESCRIPTION
Introduce a functions to chunk fixed boards efficiently while maintaining compatibility with deprecated chunking methods that cause 'order' issues when users removes columns or rows.
Now when we remove rows or columns the board conserve it's structure but remain filling empty spaces with tiles.
This is a quick fix until solve #1878
Close #1109 