### PR TITLE
Add custom hook for image source handling in Symbol component

### DIFF
--- a/src/components/Board/Symbol/Symbol.js
+++ b/src/components/Board/Symbol/Symbol.js
@@ -1,14 +1,13 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { isCordova } from '../../../cordova-util';
 import OutlinedInput from '@material-ui/core/OutlinedInput';
 import messages from '../Board.messages';
+import useGetSymbolSrc from './useGetSymbolSrc';
 
 import { LABEL_POSITION_BELOW } from '../../Settings/Display/Display.constants';
 import './Symbol.css';
 import { Typography } from '@material-ui/core';
-import { getArasaacDB } from '../../../idb/arasaac/arasaacdb';
 
 const propTypes = {
   /**
@@ -37,35 +36,8 @@ function Symbol(props) {
     image,
     ...other
   } = props;
-  const [src, setSrc] = useState('');
 
-  useEffect(
-    () => {
-      async function getSrc() {
-        let image = null;
-        if (keyPath) {
-          const arasaacDB = await getArasaacDB();
-          image = await arasaacDB.getImageById(keyPath);
-        }
-
-        if (image) {
-          const blob = new Blob([image.data], { type: image.type });
-          setSrc(URL.createObjectURL(blob));
-        } else if (props.image) {
-          // Cordova path cannot be absolute
-          const image =
-            isCordova() && props.image && props.image.search('/') === 0
-              ? `.${props.image}`
-              : props.image;
-
-          setSrc(image);
-        }
-      }
-
-      getSrc();
-    },
-    [keyPath, setSrc, props.image]
-  );
+  const src = useGetSymbolSrc(image, keyPath);
 
   const symbolClassName = classNames('Symbol', className);
 

--- a/src/components/Board/Symbol/Symbol.js
+++ b/src/components/Board/Symbol/Symbol.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import OutlinedInput from '@material-ui/core/OutlinedInput';
 import messages from '../Board.messages';
-import useGetSymbolSrc from './useGetSymbolSrc';
+import { useGetSymbolSrc } from './useGetSymbolSrc';
 
 import { LABEL_POSITION_BELOW } from '../../Settings/Display/Display.constants';
 import './Symbol.css';

--- a/src/components/Board/Symbol/useGetSymbolSrc.ts
+++ b/src/components/Board/Symbol/useGetSymbolSrc.ts
@@ -1,0 +1,70 @@
+import { getArasaacDB } from '../../../idb/arasaac/arasaacdb';
+import { isCordova } from '../../../cordova-util';
+import { useEffect, useState, useCallback, useRef } from 'react';
+
+export default function useGetSymbolSrc(
+  imageSrc?: string,
+  keyPath?: string
+): string {
+  const [src, setSrc] = useState<string>(imageSrc ? formatSrc(imageSrc) : '');
+
+  const objectUrlRef = useRef<string | null>(null);
+
+  const getArasaacImageByKeyPath = useCallback(async (keyPath: string): Promise<string> => {
+    try {
+      const arasaacDB = getArasaacDB();
+      const image = await arasaacDB.getImageById(keyPath);
+      if (image) {
+        const blob = new Blob([image.data], { type: image.type });
+        return URL.createObjectURL(blob);
+      }
+
+      return '';
+    } catch (err) {
+      console.error('Error loading Arasaac image:', err);
+      return '';
+    }
+  }, []);
+
+  useEffect(() => {
+    async function setArasaacImageSrc(keyPath: string): Promise<void> {
+      if (objectUrlRef.current) {
+        URL.revokeObjectURL(objectUrlRef.current);
+        objectUrlRef.current = null;
+      }
+
+      const newSrc = await getArasaacImageByKeyPath(keyPath);
+      if (newSrc) {
+        objectUrlRef.current = newSrc;
+        setSrc(newSrc);
+      }
+    }
+
+    if (!keyPath) return;
+
+    setArasaacImageSrc(keyPath);
+
+    return () => {
+      if (objectUrlRef.current) {
+        URL.revokeObjectURL(objectUrlRef.current);
+        objectUrlRef.current = null;
+      }
+    };
+  }, [keyPath, getArasaacImageByKeyPath]);
+
+  useEffect(() => {
+    if (imageSrc) {
+      if (objectUrlRef.current) {
+        URL.revokeObjectURL(objectUrlRef.current);
+        objectUrlRef.current = null;
+      }
+      setSrc(formatSrc(imageSrc));
+    }
+  }, [imageSrc]);
+
+  return src;
+}
+
+function formatSrc(src: string): string {
+  return isCordova() && src?.startsWith('/') ? `.${src}` : src;
+}

--- a/src/components/Board/Symbol/useGetSymbolSrc.ts
+++ b/src/components/Board/Symbol/useGetSymbolSrc.ts
@@ -2,9 +2,9 @@ import { getArasaacDB } from '../../../idb/arasaac/arasaacdb';
 import { isCordova } from '../../../cordova-util';
 import { useEffect, useState, useCallback, useRef } from 'react';
 
-export default function useGetSymbolSrc(
+function useGetSymbolSrc(
   imageSrc?: string,
-  keyPath?: string
+  keyPath?: string,
 ): string {
   const [src, setSrc] = useState<string>(imageSrc ? formatSrc(imageSrc) : '');
 
@@ -64,6 +64,8 @@ export default function useGetSymbolSrc(
 
   return src;
 }
+
+export default useGetSymbolSrc;
 
 function formatSrc(src: string): string {
   return isCordova() && src?.startsWith('/') ? `.${src}` : src;

--- a/src/components/Board/Symbol/useGetSymbolSrc.ts
+++ b/src/components/Board/Symbol/useGetSymbolSrc.ts
@@ -2,7 +2,7 @@ import { getArasaacDB } from '../../../idb/arasaac/arasaacdb';
 import { isCordova } from '../../../cordova-util';
 import { useEffect, useState, useCallback, useRef } from 'react';
 
-function useGetSymbolSrc(
+export function useGetSymbolSrc(
   imageSrc?: string,
   keyPath?: string,
 ): string {
@@ -64,8 +64,6 @@ function useGetSymbolSrc(
 
   return src;
 }
-
-export default useGetSymbolSrc;
 
 function formatSrc(src: string): string {
   return isCordova() && src?.startsWith('/') ? `.${src}` : src;


### PR DESCRIPTION
Introduce a custom hook, `useGetSymbolSrc`, to streamline image source retrieval in the Symbol component. 


