### PR TITLE
Fix memory leak and improve image fetching in Symbol component

### DIFF
--- a/src/components/Board/Symbol/Symbol.js
+++ b/src/components/Board/Symbol/Symbol.js
@@ -91,7 +91,6 @@ function Symbol(props) {
       }
       getSrc();
 
-      // Cleanup function
       return () => {
         cancelled = true;
         if (objectUrlRef.current) {

--- a/src/components/Board/Symbol/Symbol.js
+++ b/src/components/Board/Symbol/Symbol.js
@@ -72,7 +72,7 @@ function Symbol(props) {
         }
       };
     },
-    [keyPath, setSrc, props.image]
+    [keyPath, props.image]
   );
 
   const symbolClassName = classNames('Symbol', className);

--- a/src/components/Board/Symbol/Symbol.js
+++ b/src/components/Board/Symbol/Symbol.js
@@ -45,14 +45,14 @@ function Symbol(props) {
   const [src, setSrc] = useState(image ? formatSrc(image) : '');
   const objectUrlRef = useRef(null);
 
-  const fetchArasaacImage = useCallback(async id => {
+  const fetchArasaacImagefromIndexedDB = useCallback(async id => {
     if (!id) return null;
 
     try {
       const arasaacDB = getArasaacDB();
       return await arasaacDB.getImageById(id);
     } catch (error) {
-      console.error('Failed to fetch Arasaac image:', error);
+      console.error('Failed to fetch Arasaac image from Indexed DB:', error);
       return null;
     }
   }, []);
@@ -62,7 +62,9 @@ function Symbol(props) {
       let cancelled = false;
 
       async function getSrc() {
-        const imageFromIndexedDb = await fetchArasaacImage(keyPath);
+        const imageFromIndexedDb = await fetchArasaacImagefromIndexedDB(
+          keyPath
+        );
 
         if (cancelled) return;
 
@@ -98,7 +100,7 @@ function Symbol(props) {
         }
       };
     },
-    [fetchArasaacImage, image, keyPath]
+    [fetchArasaacImagefromIndexedDB, image, keyPath]
   );
 
   const symbolClassName = classNames('Symbol', className);

--- a/src/components/Board/Symbol/Symbol.js
+++ b/src/components/Board/Symbol/Symbol.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { isCordova } from '../../../cordova-util';
@@ -43,6 +43,17 @@ function Symbol(props) {
   } = props;
 
   const [src, setSrc] = useState(image ? formatSrc(image) : '');
+  const fetchArasaacImage = useCallback(async id => {
+    if (!id) return null;
+
+    try {
+      const arasaacDB = getArasaacDB();
+      return await arasaacDB.getImageById(id);
+    } catch (error) {
+      console.error('Failed to fetch Arasaac image:', error);
+      return null;
+    }
+  }, []);
 
   useEffect(
     () => {

--- a/src/components/Board/Symbol/Symbol.js
+++ b/src/components/Board/Symbol/Symbol.js
@@ -46,6 +46,8 @@ function Symbol(props) {
 
   useEffect(
     () => {
+      let objectUrl = '';
+
       async function getSrc() {
         let image = null;
         if (keyPath) {
@@ -55,13 +57,20 @@ function Symbol(props) {
 
         if (image) {
           const blob = new Blob([image.data], { type: image.type });
-          setSrc(URL.createObjectURL(blob));
+          objectUrl = URL.createObjectURL(blob);
+          setSrc(objectUrl);
         } else if (props.image) {
           setSrc(formatSrc(props.image));
         }
       }
 
       getSrc();
+
+      return () => {
+        if (objectUrl) {
+          URL.revokeObjectURL(objectUrl);
+        }
+      };
     },
     [keyPath, setSrc, props.image]
   );


### PR DESCRIPTION
See first the  #1898 

Address memory leak by revoking object URLs in the cleanup function and streamline image fetching from the indexed DB. Remove unnecessary dependencies from the useEffect hook and improve code legibility using early returns.

close #1901
close #1900 