### PR TITLE
Add TS files to Prettier formatting - Issue #1896

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -10,5 +10,5 @@
   "endOfLine": "auto",
   "jsxSingleQuote": false,
   "proseWrap": "preserve",
-  "jsxBracketSameLine": false
+  "bracketSameLine": false
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,14 @@
 {
   "printWidth": 80,
-  "singleQuote": true
+  "singleQuote": true,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "trailingComma": "none",
+  "bracketSpacing": true,
+  "arrowParens": "avoid",
+  "endOfLine": "auto",
+  "jsxSingleQuote": false,
+  "proseWrap": "preserve",
+  "jsxBracketSameLine": false
 }

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "jest-mock-axios": "^3.2.0",
     "lint-staged": "^10.0.3",
     "node-polyfill-webpack-plugin": "^2.0.1",
-    "prettier": "1.15.3",
+    "prettier": "^3.5.3",
     "react-scripts": "5.0.1",
     "react-test-renderer": "^17.0.2",
     "redux-mock-store": "^1.5.4",
@@ -118,9 +118,8 @@
     }
   },
   "lint-staged": {
-    "*.{js,json,css}": [
-      "prettier --write",
-      "git add"
+    "*.{js,ts,tsx,json,css}": [
+      "prettier --write"
     ]
   },
   "jest": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10278,10 +10278,10 @@ prepend-http@^1.0.1:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha512-PhmXi5XmoyKw1Un4E+opM2KcsJInDvKyuOumcjjw3waw86ZNjHwVUOOWLc4bCzLdcKNaWBH9e99sbWzDQsVaYg==
 
-prettier@1.15.3:
-  version "1.15.3"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.15.3.tgz#1feaac5bdd181237b54dbe65d874e02a1472786a"
-  integrity sha512-gAU9AGAPMaKb3NNSUUuhhFAS7SCO4ALTN4nRIn6PJ075Qd28Yn2Ig2ahEJWdJwJmlEBTUfC7mMUSFy8MwsOCfg==
+prettier@^3.5.3:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.5.3.tgz#4fc2ce0d657e7a02e602549f053b239cb7dfe1b5"
+  integrity sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==
 
 pretty-bytes@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
Per discussion in #1896 this update enables Prettier on `.ts` and `.tsx` files.
The previous version of Prettier was quite outdated so this update bumps that version, and removes the redundant `git add` from the `lint-staged` hook that hasn't been needed since v10.
As I [mentioned in the issue](https://github.com/cboard-org/cboard/issues/1896#issuecomment-2969034466), I can also introduce some rules in `.prettierrc` to approximate previous behavior and reduce the number of changes when committing updates moving forward, if desired.