### PR TITLE
AuthScreen redirects to root board on close

### DIFF
--- a/src/components/AuthScreen/AuthScreen.component.js
+++ b/src/components/AuthScreen/AuthScreen.component.js
@@ -6,7 +6,7 @@ import './AuthScreen.css';
 
 class AuthScreen extends Component {
   static propTypes = {
-    intl: intlShape.isRequired
+    intl: intlShape.isRequired,
   };
 
   render() {
@@ -17,7 +17,7 @@ class AuthScreen extends Component {
         <WelcomeScreen
           heading={intl.formatMessage(messages.heading)}
           text={intl.formatMessage(messages.text)}
-          onClose={history.goBack}
+          onClose={() => history.replace('/board/root')}
         />
       </div>
     );

--- a/src/components/AuthScreen/AuthScreen.component.js
+++ b/src/components/AuthScreen/AuthScreen.component.js
@@ -6,7 +6,7 @@ import './AuthScreen.css';
 
 class AuthScreen extends Component {
   static propTypes = {
-    intl: intlShape.isRequired,
+    intl: intlShape.isRequired
   };
 
   render() {
@@ -17,7 +17,9 @@ class AuthScreen extends Component {
         <WelcomeScreen
           heading={intl.formatMessage(messages.heading)}
           text={intl.formatMessage(messages.text)}
-          onClose={() => history.replace('/board/root')}
+          onClose={() => {
+            history.action === 'PUSH' ? history.goBack() : history.push('/');
+          }}
         />
       </div>
     );


### PR DESCRIPTION
This fixes #1902 so that when the `AuthScreen` component (`/login-signup`) is closed via the close (X) button, the user is taken to the root board.
To do this I've replaced the WelcomeScreen onClose prop with `history.replace('/board/root')` instead of `history.goBack`.