### PR TITLE
Improve userData handling and clean up Language Redux actions

### DIFF
--- a/src/components/App/App.reducer.js
+++ b/src/components/App/App.reducer.js
@@ -167,7 +167,7 @@ function appReducer(state = initialState, action) {
     case UPDATE_USER_DATA:
       return {
         ...state,
-        userData: getKeysFromApiUserDataResponse(action.userData)
+        userData: action.userData ? getKeysFromApiUserDataResponse(action.userData) : state.userData
       };
     case SET_UNLOGGED_USER_LOCATION:
       return {

--- a/src/providers/LanguageProvider/LanguageProvider.actions.js
+++ b/src/providers/LanguageProvider/LanguageProvider.actions.js
@@ -3,10 +3,8 @@ import {
   SET_LANGS,
   SET_DOWNLOADING_LANG
 } from './LanguageProvider.constants';
-import { updateUserData } from '../../components/App/App.actions';
 
 export function changeLang(lang, isNewVoiceAvailable = false) {
-  updateUserData();
   return {
     type: CHANGE_LANG,
     lang,


### PR DESCRIPTION
- Retain existing userData state when no new data is provided for updateUser reducer. Close #1933 
- Removes a line where a Redux action creator was called without being dispatched. Calling an action creator without dispatch does not affect the Redux store or trigger any side effects, as action creators are pure functions that only return action objects or thunks. Removing this unused call improves code clarity and eliminates unnecessary function executions. Close #1934 
