### PR TITLE
feat(pdf): add optional tile borders to PDF export (#1954)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- [**feature**] Added optional border for tiles when exporting boards as PDF. Users can now toggle "Show borders around tiles in PDF" in the export settings. [#1954](https://github.com/cboard-org/cboard/issues/1954)
+
+
 ## 1.7.1 (23/12/2020)
 
 #### Bug Fixes:

--- a/src/components/Settings/Export/Export.component.js
+++ b/src/components/Settings/Export/Export.component.js
@@ -14,6 +14,9 @@ import InputLabel from '@material-ui/core/InputLabel';
 import FormControl from '@material-ui/core/FormControl';
 import Divider from '@material-ui/core/Divider';
 
+import Checkbox from '@material-ui/core/Checkbox';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+
 import FullScreenDialog from '../../UI/FullScreenDialog';
 import messages from './Export.messages';
 
@@ -49,7 +52,8 @@ class Export extends React.Component {
       singleBoard: '',
       loadingSingle: false,
       loadingAll: false,
-      boardError: false
+      boardError: false,
+      showTileBorders: false,
     };
   }
 
@@ -65,6 +69,12 @@ class Export extends React.Component {
     this.setState({
       boardError: false,
       singleBoard: event.target.value
+    });
+  };
+
+  handleTileBordersChange = event => {
+    this.setState({
+      showTileBorders: event.target.checked
     });
   };
 
@@ -121,7 +131,8 @@ class Export extends React.Component {
           this.state.exportSingleBoard,
           this.state.singleBoard,
           this.state.labelFontSize,
-          doneCallback
+          doneCallback,
+          this.state.showTileBorders
         );
       }
     );
@@ -357,6 +368,16 @@ class Export extends React.Component {
                     </FormControl>
                   </div>
                 </ListItemSecondaryAction>
+                <FormControlLabel
+                  control={
+                      <Checkbox
+                        checked={this.state.showTileBorders}
+                        onChange={this.handleTileBorderToggle}
+                        color="primary"
+                      />
+                    }
+                    label={intl.formatMessage({ defaultMessage: "Show borders around tiles in PDF" })}
+                  />
               </ListItem>
             </List>
           </Paper>

--- a/src/components/Settings/Export/Export.container.js
+++ b/src/components/Settings/Export/Export.container.js
@@ -20,7 +20,8 @@ export class ExportContainer extends PureComponent {
     type = 'cboard',
     singleBoard = '',
     labelFontSize = '',
-    doneCallback
+    doneCallback,
+    showTileBorders = false
   ) => {
     const exportConfig = EXPORT_CONFIG_BY_TYPE[type];
     const EXPORT_HELPERS = await import('./Export.helpers');
@@ -45,7 +46,8 @@ export class ExportContainer extends PureComponent {
             [singleBoard],
             labelFontSize,
             intl,
-            true
+            true,
+            showTileBorders
           );
         } else {
           const currentBoard = boards.filter(
@@ -62,14 +64,18 @@ export class ExportContainer extends PureComponent {
         await EXPORT_HELPERS[exportConfig.callback](
           boards,
           labelFontSize,
-          intl
+          intl,
+          false,
+          showTileBorders
         );
       } else {
         if (singleBoard) {
           await EXPORT_HELPERS[exportConfig.callback](
             [singleBoard],
             labelFontSize,
-            intl
+            intl,
+            false,
+            showTileBorders
           );
         } else {
           const currentBoard = boards.filter(
@@ -78,7 +84,9 @@ export class ExportContainer extends PureComponent {
           await EXPORT_HELPERS[exportConfig.callback](
             currentBoard,
             labelFontSize,
-            intl
+            intl,
+            false,
+            showTileBorders
           );
         }
       }

--- a/src/components/Settings/Export/Export.helpers.js
+++ b/src/components/Settings/Export/Export.helpers.js
@@ -379,7 +379,8 @@ async function generatePDFBoard(
   intl,
   breakPage = true,
   picsee = false,
-  labelFontSize
+  labelFontSize,
+  showTileBorders = false
 ) {
   const header = {
     absolutePosition: { x: 0, y: 5 },
@@ -387,7 +388,16 @@ async function generatePDFBoard(
     alignment: 'center',
     fontSize: 8
   };
-
+  const tileRect = {
+    type: 'rect',
+    x: tileX,
+    y: tileY,
+    w: tileWidth,
+    h: tileHeight,
+    lineWidth: showTileBorders ? 1 : 0,
+    lineColor: showTileBorders ? 'black' : undefined
+  };
+  canvas.push(tileRect);
   const columns =
     board.isFixed && board.grid ? board.grid.columns : CBOARD_COLUMNS;
   const rows = board.isFixed && board.grid ? board.grid.rows : CBOARD_ROWS;
@@ -892,7 +902,8 @@ export async function pdfExportAdapter(
   boards = [],
   labelFontSize,
   intl,
-  picsee = false
+  picsee = false,
+  showTileBorders = false
 ) {
   const font = definePDFfont(intl);
   const docDefinition = {
@@ -973,7 +984,8 @@ export async function pdfExportAdapter(
       intl,
       breakPage,
       picsee,
-      labelFontSize
+      labelFontSize,
+      showTileBorders
     );
     return prevContent.concat(boardPDFData);
   }, Promise.resolve([]));


### PR DESCRIPTION
***Add optional tile borders to PDF export (#1954)***

This PR adds an option to show borders around tiles when exporting boards as PDF.

- Adds a checkbox in the Export UI for "Show borders around tiles in PDF".
- Passes the option through the export container and helpers.
- Updates the PDF export code to draw a border around each tile if selected.
- Updates the changelog.

Fixes #1954

**Screenshots (if applicable):**
(Add screenshot of the new checkbox if you have one)