### PR TITLE
Fix links in SignUp form agreement label

### DIFF
--- a/src/components/Account/SignUp/SignUp.messages.js
+++ b/src/components/Account/SignUp/SignUp.messages.js
@@ -31,7 +31,7 @@ export default defineMessages({
   },
   agreement: {
     id: 'cboard.components.SignUp.agreement',
-    defaultMessage: 'I agree with the {terms} and the {privacy}'
+    defaultMessage: 'I agree to the {terms} and {privacy}'
   },
   termsAndConditions: {
     id: 'cboard.components.SignUp.termsAndConditions',

--- a/src/components/Account/SignUp/SignUp.messages.js
+++ b/src/components/Account/SignUp/SignUp.messages.js
@@ -31,7 +31,7 @@ export default defineMessages({
   },
   agreement: {
     id: 'cboard.components.SignUp.agreement',
-    defaultMessage: 'I agree to the {terms} and {privacy}'
+    defaultMessage: 'I agree with the {terms} and the {privacy}'
   },
   termsAndConditions: {
     id: 'cboard.components.SignUp.termsAndConditions',

--- a/src/translations/en-US.json
+++ b/src/translations/en-US.json
@@ -32,7 +32,7 @@
   "cboard.components.SignUp.confirmYourPassword": "Confirm your password",
   "cboard.components.SignUp.cancel": "Cancel",
   "cboard.components.SignUp.signMeUp": "Sign me up",
-  "cboard.components.SignUp.agreement": "I agree to the :terms and :privacy.",
+  "cboard.components.SignUp.agreement": "I agree to the {terms} and {privacy}.",
   "cboard.components.SignUp.termsAndConditions": "Terms",
   "cboard.components.SignUp.privacy": "Privacy Policy",
   "cboard.components.SignUp.noConnection": "Unable to connect to the server. Please try again later.",


### PR DESCRIPTION
Closes #1969 
The syntax for variables should be wrapping them in curly brackets `{}`, not prepending with a colon `:`.