### PR TITLE
Fix label position rendering when image is not present

### DIFF
--- a/src/components/Board/Symbol/Symbol.js
+++ b/src/components/Board/Symbol/Symbol.js
@@ -139,11 +139,11 @@ function Symbol(props) {
         props.labelpos !== 'Hidden' && (
           <Typography className="Symbol__label">{label}</Typography>
         )}
-      {src && (
-        <div className="Symbol__image-container">
-          <img className="Symbol__image" src={src} alt="" />
-        </div>
-      )}
+
+      <div className="Symbol__image-container">
+        {src && <img className="Symbol__image" src={src} alt="" />}
+      </div>
+
       {props.type !== 'live' &&
         props.labelpos === 'Below' &&
         props.labelpos !== 'Hidden' && (


### PR DESCRIPTION
### Summary
This PR fixes the label alignment issue when the image is missing in the `Symbol` component. Earlier, the label would always appear below regardless of the `labelpos` prop. Now, `Above` and `Below` positions are respected even if no image is provided.

### Fix
Wrapped the image container in a div and conditionally rendered the `<img>` tag. No CSS changes required.

### Linked Issue
Fixes #1975 

### Reviewer
Hi @martinbedouret, this PR addresses the alignment issue for the label when no image is present. Let me know if anything needs to be adjusted.
