### PR TITLE
Adds support for variant boards

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,18 +136,18 @@ workflows:
             - build
           filters:
             branches:
-              only: master
+              only: expo-ortopedica
       - deploy:
           context: azure
           requires:
             - image
           filters:
             branches:
-              only: master
+              only: expo-ortopedica
       - e2e:
           context: azure
           requires:
             - deploy
           filters:
             branches:
-              only: master
+              only: expo-ortopedica

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,18 +136,18 @@ workflows:
             - build
           filters:
             branches:
-              only: expo-ortopedica
+              only: master
       - deploy:
           context: azure
           requires:
             - image
           filters:
             branches:
-              only: expo-ortopedica
+              only: master
       - e2e:
           context: azure
           requires:
             - deploy
           filters:
             branches:
-              only: expo-ortopedica
+              only: master

--- a/src/components/Board/Board.component.js
+++ b/src/components/Board/Board.component.js
@@ -330,7 +330,8 @@ export class Board extends Component {
       totalRows,
       changeDefaultBoard,
       improvedPhrase,
-      speak
+      speak,
+      isVariantBoard
     } = this.props;
 
     const tiles = this.renderTiles(board.tiles);
@@ -360,6 +361,7 @@ export class Board extends Component {
             disableTour={disableTour}
             intl={intl}
             onDefaultBoardOptionClick={changeDefaultBoard}
+            isVariantBoard={isVariantBoard}
           />
           <Scannable>
             <div

--- a/src/components/Board/Board.container.js
+++ b/src/components/Board/Board.container.js
@@ -15,7 +15,6 @@ import DialogContent from '@material-ui/core/DialogContent';
 import DialogContentText from '@material-ui/core/DialogContentText';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import Slide from '@material-ui/core/Slide';
-import { useSearchParams } from 'react-router-dom';
 import {
   showNotification,
   hideNotification
@@ -197,7 +196,7 @@ export class BoardContainer extends Component {
     tileEditorOpen: false,
     isGettingApiObjects: false,
     copyPublicBoard: false,
-    //copyVariantBoard: false,
+    isVariantBoard: false,
     blockedPrivateBoard: false,
     isFixedBoard: false,
     copiedTiles: [],
@@ -1601,6 +1600,7 @@ export class BoardContainer extends Component {
           changeDefaultBoard={this.props.changeDefaultBoard}
           improvedPhrase={improvedPhrase}
           speak={speak}
+          isVariantBoard={this.state.isVariantBoard}
         />
         <Dialog
           open={!!this.state.copyPublicBoard && !isPremiumRequiredModalOpen}

--- a/src/components/Board/Board.container.js
+++ b/src/components/Board/Board.container.js
@@ -1365,9 +1365,10 @@ export class BoardContainer extends Component {
   handleRootBoardTourEnabled = () => {
     if (this.state.isVariantBoard) {
       // If the board is a variant, we don't want to show the root board tour
-      disableTour({ isRootBoardTourEnabled: false });
+      return false;
+    } else {
+      return this.props.isRootBoardTourEnabled;
     }
-    return this.props.disableTour;
   };
 
   handleCopyTiles = () => {
@@ -1569,7 +1570,7 @@ export class BoardContainer extends Component {
           isSelecting={this.state.isSelecting}
           isSelectAll={this.state.isSelectAll}
           isFixedBoard={this.state.isFixedBoard}
-          isRootBoardTourEnabled={this.props.isRootBoardTourEnabled}
+          isRootBoardTourEnabled={this.handleRootBoardTourEnabled}
           isUnlockedTourEnabled={this.props.isUnlockedTourEnabled}
           //updateBoard={this.handleUpdateBoard}
           onAddClick={this.handleAddClick}
@@ -1598,7 +1599,7 @@ export class BoardContainer extends Component {
           onAddRemoveRow={this.handleAddRemoveRow}
           onTileDrop={this.handleTileDrop}
           onLayoutChange={this.handleLayoutChange}
-          disableTour={this.handleRootBoardTourEnabled}
+          disableTour={this.props.disableTour}
           onCopyTiles={this.handleCopyTiles}
           onPasteTiles={this.handlePasteTiles}
           copiedTiles={this.state.copiedTiles}

--- a/src/components/Board/Board.container.js
+++ b/src/components/Board/Board.container.js
@@ -15,6 +15,7 @@ import DialogContent from '@material-ui/core/DialogContent';
 import DialogContentText from '@material-ui/core/DialogContentText';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import Slide from '@material-ui/core/Slide';
+import { useSearchParams } from 'react-router-dom';
 import {
   showNotification,
   hideNotification
@@ -196,7 +197,7 @@ export class BoardContainer extends Component {
     tileEditorOpen: false,
     isGettingApiObjects: false,
     copyPublicBoard: false,
-    isVariantBoard: false,
+    //copyVariantBoard: false,
     blockedPrivateBoard: false,
     isFixedBoard: false,
     copiedTiles: [],
@@ -383,7 +384,7 @@ export class BoardContainer extends Component {
         : await API.getBoard(boardId);
 
       if (isVariantBoard) {
-        this.setState({ isVariantBoard: true });
+        //this.setState({ copyVariantBoard: remoteBoard });
         this.handleCopyRemoteBoard(remoteBoard);
         return null;
       }
@@ -1345,7 +1346,6 @@ export class BoardContainer extends Component {
     if (isSaving) return;
     this.setState({
       copyPublicBoard: false,
-      isVariantBoard: false,
       blockedPrivateBoard: false,
       isCbuilderBoard: false
     });
@@ -1360,15 +1360,6 @@ export class BoardContainer extends Component {
     const processedBoard = this.updateIfFeaturedBoard(newBoard);
     updateBoard(processedBoard);
     this.saveApiBoardOperation(processedBoard);
-  };
-
-  handleRootBoardTourEnabled = () => {
-    if (this.state.isVariantBoard) {
-      // If the board is a variant, we don't want to show the root board tour
-      return false;
-    } else {
-      return this.props.isRootBoardTourEnabled;
-    }
   };
 
   handleCopyTiles = () => {
@@ -1570,7 +1561,7 @@ export class BoardContainer extends Component {
           isSelecting={this.state.isSelecting}
           isSelectAll={this.state.isSelectAll}
           isFixedBoard={this.state.isFixedBoard}
-          isRootBoardTourEnabled={this.handleRootBoardTourEnabled}
+          isRootBoardTourEnabled={this.props.isRootBoardTourEnabled}
           isUnlockedTourEnabled={this.props.isUnlockedTourEnabled}
           //updateBoard={this.handleUpdateBoard}
           onAddClick={this.handleAddClick}

--- a/src/components/Board/Board.container.js
+++ b/src/components/Board/Board.container.js
@@ -15,7 +15,6 @@ import DialogContent from '@material-ui/core/DialogContent';
 import DialogContentText from '@material-ui/core/DialogContentText';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import Slide from '@material-ui/core/Slide';
-import { useSearchParams } from 'react-router-dom';
 import {
   showNotification,
   hideNotification
@@ -197,7 +196,7 @@ export class BoardContainer extends Component {
     tileEditorOpen: false,
     isGettingApiObjects: false,
     copyPublicBoard: false,
-    //copyVariantBoard: false,
+    isVariantBoard: false,
     blockedPrivateBoard: false,
     isFixedBoard: false,
     copiedTiles: [],
@@ -384,7 +383,7 @@ export class BoardContainer extends Component {
         : await API.getBoard(boardId);
 
       if (isVariantBoard) {
-        //this.setState({ copyVariantBoard: remoteBoard });
+        this.setState({ isVariantBoard: true });
         this.handleCopyRemoteBoard(remoteBoard);
         return null;
       }
@@ -1346,6 +1345,7 @@ export class BoardContainer extends Component {
     if (isSaving) return;
     this.setState({
       copyPublicBoard: false,
+      isVariantBoard: false,
       blockedPrivateBoard: false,
       isCbuilderBoard: false
     });
@@ -1360,6 +1360,15 @@ export class BoardContainer extends Component {
     const processedBoard = this.updateIfFeaturedBoard(newBoard);
     updateBoard(processedBoard);
     this.saveApiBoardOperation(processedBoard);
+  };
+
+  handleRootBoardTourEnabled = () => {
+    if (this.state.isVariantBoard) {
+      // If the board is a variant, we don't want to show the root board tour
+      return false;
+    } else {
+      return this.props.isRootBoardTourEnabled;
+    }
   };
 
   handleCopyTiles = () => {
@@ -1561,7 +1570,7 @@ export class BoardContainer extends Component {
           isSelecting={this.state.isSelecting}
           isSelectAll={this.state.isSelectAll}
           isFixedBoard={this.state.isFixedBoard}
-          isRootBoardTourEnabled={this.props.isRootBoardTourEnabled}
+          isRootBoardTourEnabled={this.handleRootBoardTourEnabled}
           isUnlockedTourEnabled={this.props.isUnlockedTourEnabled}
           //updateBoard={this.handleUpdateBoard}
           onAddClick={this.handleAddClick}

--- a/src/components/Board/Board.container.js
+++ b/src/components/Board/Board.container.js
@@ -1365,10 +1365,9 @@ export class BoardContainer extends Component {
   handleRootBoardTourEnabled = () => {
     if (this.state.isVariantBoard) {
       // If the board is a variant, we don't want to show the root board tour
-      return false;
-    } else {
-      return this.props.isRootBoardTourEnabled;
+      disableTour({ isRootBoardTourEnabled: false });
     }
+    return this.props.disableTour;
   };
 
   handleCopyTiles = () => {
@@ -1570,7 +1569,7 @@ export class BoardContainer extends Component {
           isSelecting={this.state.isSelecting}
           isSelectAll={this.state.isSelectAll}
           isFixedBoard={this.state.isFixedBoard}
-          isRootBoardTourEnabled={this.handleRootBoardTourEnabled}
+          isRootBoardTourEnabled={this.props.isRootBoardTourEnabled}
           isUnlockedTourEnabled={this.props.isUnlockedTourEnabled}
           //updateBoard={this.handleUpdateBoard}
           onAddClick={this.handleAddClick}
@@ -1599,7 +1598,7 @@ export class BoardContainer extends Component {
           onAddRemoveRow={this.handleAddRemoveRow}
           onTileDrop={this.handleTileDrop}
           onLayoutChange={this.handleLayoutChange}
-          disableTour={this.props.disableTour}
+          disableTour={this.handleRootBoardTourEnabled}
           onCopyTiles={this.handleCopyTiles}
           onPasteTiles={this.handlePasteTiles}
           copiedTiles={this.state.copiedTiles}

--- a/src/components/Board/BoardTour/BoardTour.js
+++ b/src/components/Board/BoardTour/BoardTour.js
@@ -12,7 +12,8 @@ const propTypes = {
   isRootBoardTourEnabled: PropTypes.bool,
   isUnlockedTourEnabled: PropTypes.bool,
   isLocked: PropTypes.bool,
-  disableTour: PropTypes.func.isRequired
+  disableTour: PropTypes.func.isRequired,
+  isVariantBoard: PropTypes.bool
 };
 
 const joyRideStyles = {
@@ -48,7 +49,8 @@ function BoardTour({
   isLocked,
   disableTour,
   intl,
-  onDefaultBoardOptionClick
+  onDefaultBoardOptionClick,
+  isVariantBoard
 }) {
   const unlockedHelpSteps = [
     {
@@ -111,13 +113,17 @@ function BoardTour({
           <h2>
             <FormattedMessage {...messages.walkthroughWelcome} />
           </h2>
-          <p>
-            <FormattedMessage {...messages.walkthroughChooseABoard} />
-          </p>
-          <DefaultBoardsGallery
-            intl={intl}
-            onOptionClick={onDefaultBoardOptionClick}
-          />
+          {!isVariantBoard && (
+            <p>
+              <FormattedMessage {...messages.walkthroughChooseABoard} />
+            </p>
+          )}
+          {!isVariantBoard && (
+            <DefaultBoardsGallery
+              intl={intl}
+              onOptionClick={onDefaultBoardOptionClick}
+            />
+          )}
         </>
       )
     },
@@ -127,6 +133,7 @@ function BoardTour({
       content: <FormattedMessage {...messages.walkthroughUnlock} />
     }
   ];
+
   return (
     <div>
       {isLocked && isRootBoardTourEnabled && (


### PR DESCRIPTION
Adds the ability to create and display variant boards using a URL parameter.

- Introduces a `variant` query parameter to distinguish variant boards.
- Modifies board loading logic to handle variant boards, copying them as needed.
- Conditionally displays the default board gallery in the board tour based on whether the board is a variant.