### PR TITLE
Fix undesired horizontal scroll caused by icon overflow in the toolbar

### DIFF
--- a/src/components/Board/Navbar/Navbar.css
+++ b/src/components/Board/Navbar/Navbar.css
@@ -61,18 +61,13 @@
   color: #fff;
 }
 
-@media (max-width: 768px) {
-  .Navbar__group--end .MuiIconButton-root,
-  .Navbar__group--start .MuiIconButton-root {
-    padding: 6px;
-    color: #fff;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
+.Navbar__group {
+  align-items: center;
+}
 
-  .Navbar__group--end,
-  .Navbar__group--start {
-    align-items: center;
+@media (max-width: 380px) {
+  .Navbar__group button,
+  .Navbar__group a {
+    padding-inline: 8px;
   }
 }

--- a/src/components/Board/Navbar/Navbar.css
+++ b/src/components/Board/Navbar/Navbar.css
@@ -60,3 +60,19 @@
 .Navbar .LoginSignUpButton:focus {
   color: #fff;
 }
+
+@media (max-width: 768px) {
+  .Navbar__group--end .MuiIconButton-root,
+  .Navbar__group--start .MuiIconButton-root {
+    padding: 6px;
+    color: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .Navbar__group--end,
+  .Navbar__group--start {
+    align-items: center;
+  }
+}


### PR DESCRIPTION
Responsive design improvements to the `Navbar` component's CSS, specifically targeting mobile devices. The main change is the addition of a media query to adjust the appearance and alignment of icon buttons and groups when the screen width is 768px or less.

* Added a media query in `Navbar.css` to adjust padding, color, display, and alignment of `.MuiIconButton-root` elements within `.Navbar__group--start` and `.Navbar__group--end` for screens 768px wide or less. Also ensures these groups are centered.

closes #1925 