### PR TITLE
Relocate Rows and Columns Selector Controls from Grid Overlay #1979

### DIFF
--- a/src/components/Board/Board.component.js
+++ b/src/components/Board/Board.component.js
@@ -23,7 +23,6 @@ import EmptyBoard from './EmptyBoard';
 import CommunicatorToolbar from '../Communicator/CommunicatorToolbar';
 import { DISPLAY_SIZE_GRID_COLS } from '../Settings/Display/Display.constants';
 import NavigationButtons from '../NavigationButtons';
-import EditGridButtons from '../EditGridButtons';
 import { DEFAULT_ROWS_NUMBER, DEFAULT_COLUMNS_NUMBER } from './Board.constants';
 
 import { Link } from 'react-router-dom';
@@ -438,6 +437,11 @@ export class Board extends Component {
             onCopyTiles={onCopyTiles}
             onPasteTiles={onPasteTiles}
             copiedTiles={this.props.copiedTiles}
+            active={isFixedBoard && isSelecting && !isSaving ? true : false}
+            columns={board.grid ? board.grid.columns : DEFAULT_COLUMNS_NUMBER}
+            rows={board.grid ? board.grid.rows : DEFAULT_ROWS_NUMBER}
+            onAddRemoveRow={onAddRemoveRow}
+            onAddRemoveColumn={onAddRemoveColumn}
           />
           <div className="BoardSideButtonsContainer">
             {navigationSettings.caBackButtonActive && (
@@ -501,22 +505,6 @@ export class Board extends Component {
                     isNavigationButtonsOnTheSide={isNavigationButtonsOnTheSide}
                   />
                 )}
-
-                <EditGridButtons
-                  active={
-                    isFixedBoard && isSelecting && !isSaving ? true : false
-                  }
-                  columns={
-                    board.grid ? board.grid.columns : DEFAULT_COLUMNS_NUMBER
-                  }
-                  rows={board.grid ? board.grid.rows : DEFAULT_ROWS_NUMBER}
-                  onAddRemoveRow={onAddRemoveRow}
-                  onAddRemoveColumn={onAddRemoveColumn}
-                  moveColsButtonToLeft={
-                    navigationSettings.bigScrollButtonsActive &&
-                    isNavigationButtonsOnTheSide
-                  }
-                />
               </div>
             </Scannable>
 

--- a/src/components/Board/EditToolbar/EditToolbar.component.js
+++ b/src/components/Board/EditToolbar/EditToolbar.component.js
@@ -287,7 +287,7 @@ function EditToolbar({
           )}
         </div>
       </div>
-      {isSelecting && (
+      {isSelecting && isFixed && (
         <div className="EditToolbar__footer EditToolbar__group EditToolbar--selecting">
           {renderButtons(false)}
           {renderButtons(true)}

--- a/src/components/Board/EditToolbar/EditToolbar.component.js
+++ b/src/components/Board/EditToolbar/EditToolbar.component.js
@@ -25,6 +25,7 @@ import './EditToolbar.css';
 import { FormControlLabel } from '@material-ui/core';
 import PremiumFeature from '../../PremiumFeature';
 import { resolveBoardName } from '../../../helpers';
+import EditGridButtons from '../../EditGridButtons/index.js';
 
 EditToolbar.propTypes = {
   /**
@@ -99,7 +100,12 @@ function EditToolbar({
   onBoardTypeChange,
   onCopyTiles,
   onPasteTiles,
-  copiedTiles
+  copiedTiles,
+  active,
+  columns,
+  rows,
+  onAddRemoveRow,
+  onAddRemoveColumn
 }) {
   const isItemsSelected = !!selectedItemsCount;
   const isFixed = !!isFixedBoard;
@@ -119,151 +125,175 @@ function EditToolbar({
     handleCloseDeleteTilesDialog();
   };
 
+  const renderButtons = isVertical => {
+    return (
+      <EditGridButtons
+        isVertical={isVertical}
+        active={active}
+        columns={columns}
+        rows={rows}
+        onAddRemoveRow={onAddRemoveRow}
+        onAddRemoveColumn={onAddRemoveColumn}
+      />
+    );
+  };
+
   return (
-    <div
-      className={classNames('EditToolbar', className, {
-        'EditToolbar--selecting': isSelecting
-      })}
-    >
-      {(isSaving || !isLoggedIn) && (
-        <span className="EditToolbar__BoardTitle">
-          {resolveBoardName(board, intl)}
-        </span>
-      )}
-
-      {!isSaving && isLoggedIn && (
-        <Button
-          className={classNames('EditToolbar__BoardTitle', {
-            'logged-in': isLoggedIn
-          })}
-          onClick={onBoardTitleClick}
-        >
-          {resolveBoardName(board, intl)}
-        </Button>
-      )}
-
-      <div className="EditToolbar__group EditToolbar__group--start">
-        <Button
-          label={intl.formatMessage(
-            messages[isSelecting ? 'cancel' : 'editTilesButton']
-          )}
-          id="edit-board-tiles"
-          aria-label="edit-board-tiles"
-          onClick={onSelectClick}
-          disabled={isSaving}
-          className={'edit__board__ride'}
-        >
-          {isSelecting ? (
-            <DashboardOutlinedIcon className="EditToolbar__group EditToolbar__group--start--button" />
-          ) : (
-            <DashboardIcon className="EditToolbar__group EditToolbar__group--start--button" />
-          )}
-          {!isSelecting ? intl.formatMessage(messages.editTilesButton) : ''}
-        </Button>
-
-        {isSelecting && (
-          <Fragment>
-            <FormControlLabel
-              control={
-                <Switch
-                  checked={isFixed}
-                  onChange={onBoardTypeChange}
-                  name="switchFixedBoard"
-                  color="secondary"
-                />
-              }
-              label={intl.formatMessage(messages.fixedBoard)}
-            />
-          </Fragment>
+    <React.Fragment>
+      <div
+        className={classNames('EditToolbar', className, {
+          'EditToolbar--selecting': isSelecting
+        })}
+      >
+        {(isSaving || !isLoggedIn) && (
+          <span className="EditToolbar__BoardTitle">
+            {resolveBoardName(board, intl)}
+          </span>
         )}
 
-        {isSaving && (
-          <CircularProgress
-            size={24}
-            className="EditToolbar__Spinner"
-            thickness={7}
-          />
+        {!isSaving && isLoggedIn && (
+          <Button
+            className={classNames('EditToolbar__BoardTitle', {
+              'logged-in': isLoggedIn
+            })}
+            onClick={onBoardTitleClick}
+          >
+            {resolveBoardName(board, intl)}
+          </Button>
         )}
-      </div>
-      <div className="EditToolbar__group EditToolbar__group--end">
-        {isSelecting && (
-          <Fragment>
-            <Checkbox checked={isSelectAll} onChange={onSelectAllToggle} />
-            <SelectedCounter
-              count={selectedItemsCount}
-              className="EditToolbar__SelectedCounter"
-            />
-            <IconButton
-              label={intl.formatMessage(messages.deleteTiles)}
-              disabled={!isItemsSelected}
-              onClick={handleOpenDeleteTilesDialog}
-            >
-              <DeleteIcon />
-            </IconButton>
-            <Dialog
-              open={openDeleteTilesDialog}
-              onClose={handleCloseDeleteTilesDialog}
-            >
-              <DialogTitle id="alert-dialog-title">
-                {intl.formatMessage(messages.deleteTileTitle)}
-              </DialogTitle>
-              <DialogContent>
-                {intl.formatMessage(messages.deleteTileDescription)}
-              </DialogContent>
-              <DialogActions>
-                <Button onClick={handleCloseDeleteTilesDialog} color="primary">
-                  {intl.formatMessage(messages.deleteTileCancel)}
-                </Button>
-                <Button
-                  onClick={handleDeleteTilesAccepted}
-                  variant="contained"
-                  color="primary"
-                  autoFocus
-                >
-                  {intl.formatMessage(messages.deleteTileOk)}
-                </Button>
-              </DialogActions>
-            </Dialog>
 
-            <PremiumFeature>
+        <div className="EditToolbar__group EditToolbar__group--start">
+          <Button
+            label={intl.formatMessage(
+              messages[isSelecting ? 'cancel' : 'editTilesButton']
+            )}
+            id="edit-board-tiles"
+            aria-label="edit-board-tiles"
+            onClick={onSelectClick}
+            disabled={isSaving}
+            className={'edit__board__ride'}
+          >
+            {isSelecting ? (
+              <DashboardOutlinedIcon className="EditToolbar__group EditToolbar__group--start--button" />
+            ) : (
+              <DashboardIcon className="EditToolbar__group EditToolbar__group--start--button" />
+            )}
+            {!isSelecting ? intl.formatMessage(messages.editTilesButton) : ''}
+          </Button>
+
+          {isSelecting && (
+            <Fragment>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={isFixed}
+                    onChange={onBoardTypeChange}
+                    name="switchFixedBoard"
+                    color="secondary"
+                  />
+                }
+                label={intl.formatMessage(messages.fixedBoard)}
+              />
+            </Fragment>
+          )}
+
+          {isSaving && (
+            <CircularProgress
+              size={24}
+              className="EditToolbar__Spinner"
+              thickness={7}
+            />
+          )}
+        </div>
+        <div className="EditToolbar__group EditToolbar__group--end">
+          {isSelecting && (
+            <Fragment>
+              <Checkbox checked={isSelectAll} onChange={onSelectAllToggle} />
+              <SelectedCounter
+                count={selectedItemsCount}
+                className="EditToolbar__SelectedCounter"
+              />
               <IconButton
-                label={intl.formatMessage(messages.copyTiles)}
+                label={intl.formatMessage(messages.deleteTiles)}
                 disabled={!isItemsSelected}
-                onClick={onCopyTiles}
+                onClick={handleOpenDeleteTilesDialog}
               >
-                <MdContentCopy />
+                <DeleteIcon />
               </IconButton>
+              <Dialog
+                open={openDeleteTilesDialog}
+                onClose={handleCloseDeleteTilesDialog}
+              >
+                <DialogTitle id="alert-dialog-title">
+                  {intl.formatMessage(messages.deleteTileTitle)}
+                </DialogTitle>
+                <DialogContent>
+                  {intl.formatMessage(messages.deleteTileDescription)}
+                </DialogContent>
+                <DialogActions>
+                  <Button
+                    onClick={handleCloseDeleteTilesDialog}
+                    color="primary"
+                  >
+                    {intl.formatMessage(messages.deleteTileCancel)}
+                  </Button>
+                  <Button
+                    onClick={handleDeleteTilesAccepted}
+                    variant="contained"
+                    color="primary"
+                    autoFocus
+                  >
+                    {intl.formatMessage(messages.deleteTileOk)}
+                  </Button>
+                </DialogActions>
+              </Dialog>
+
+              <PremiumFeature>
+                <IconButton
+                  label={intl.formatMessage(messages.copyTiles)}
+                  disabled={!isItemsSelected}
+                  onClick={onCopyTiles}
+                >
+                  <MdContentCopy />
+                </IconButton>
+                <IconButton
+                  label={intl.formatMessage(messages.pasteTiles)}
+                  disabled={!copiedTiles.length}
+                  onClick={onPasteTiles}
+                >
+                  <MdContentPaste />
+                </IconButton>
+              </PremiumFeature>
               <IconButton
-                label={intl.formatMessage(messages.pasteTiles)}
-                disabled={!copiedTiles.length}
-                onClick={onPasteTiles}
+                label={intl.formatMessage(messages.editTiles)}
+                disabled={!isItemsSelected}
+                onClick={onEditClick}
               >
-                <MdContentPaste />
+                <EditIcon />
               </IconButton>
-            </PremiumFeature>
-            <IconButton
-              label={intl.formatMessage(messages.editTiles)}
-              disabled={!isItemsSelected}
-              onClick={onEditClick}
-            >
-              <EditIcon />
-            </IconButton>
-          </Fragment>
-        )}
-        {!isSelecting && (
-          <div className={'add__board__tile'}>
-            <IconButton
-              label={intl.formatMessage(messages.addTileButton)}
-              onClick={onAddClick}
-              disabled={isSaving}
-              color="inherit"
-            >
-              <AddBoxIcon />
-            </IconButton>
-          </div>
-        )}
+            </Fragment>
+          )}
+          {!isSelecting && (
+            <div className={'add__board__tile'}>
+              <IconButton
+                label={intl.formatMessage(messages.addTileButton)}
+                onClick={onAddClick}
+                disabled={isSaving}
+                color="inherit"
+              >
+                <AddBoxIcon />
+              </IconButton>
+            </div>
+          )}
+        </div>
       </div>
-    </div>
+      {isSelecting && (
+        <div className="EditToolbar__footer EditToolbar__group EditToolbar--selecting">
+          {renderButtons(false)}
+          {renderButtons(true)}
+        </div>
+      )}
+    </React.Fragment>
   );
 }
 

--- a/src/components/Board/EditToolbar/EditToolbar.css
+++ b/src/components/Board/EditToolbar/EditToolbar.css
@@ -18,6 +18,17 @@
   align-items: center;
 }
 
+.EditToolbar__footer {
+  position: fixed;
+  bottom: 0;
+  width: 100%;
+  z-index: 1000;
+  display: flex;
+  justify-content: space-around;
+  color: #fff;
+  white-space: nowrap;
+}
+
 .EditToolbar .EditToolbar__Spinner {
   color: white;
   margin: 0;

--- a/src/components/EditGridButtons/EditGridButtons.component.js
+++ b/src/components/EditGridButtons/EditGridButtons.component.js
@@ -1,99 +1,78 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Button from '@material-ui/core/Button';
-import ButtonGroup from '@material-ui/core/ButtonGroup';
-import KeyboardArrowLeftIcon from '@material-ui/icons/KeyboardArrowLeft';
-import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
-import KeyboardArrowRightIcon from '@material-ui/icons/KeyboardArrowRight';
-import KeyboardArrowUpIcon from '@material-ui/icons/KeyboardArrowUp';
-
+import AddIcon from '@material-ui/icons/Add';
+import RemoveIcon from '@material-ui/icons/Remove';
+import { injectIntl, intlShape } from 'react-intl';
+import messages from './EditGridButtons.messages.js';
 import './EditGridButtons.css';
 
-class EditGridButtons extends React.Component {
-  static propTypes = {
-    active: PropTypes.bool.isRequired,
-    rows: PropTypes.number.isRequired,
-    columns: PropTypes.number.isRequired,
-    onAddRemoveColumn: PropTypes.func.isRequired,
-    onAddRemoveRow: PropTypes.func.isRequired,
-    moveColsButtonToLeft: PropTypes.bool
-  };
-
-  constructor(props) {
-    super(props);
-
-    this.state = {};
+function EditGridButtons({
+  isVertical,
+  active,
+  columns,
+  rows,
+  onAddRemoveRow,
+  onAddRemoveColumn,
+  intl
+}) {
+  const orientation = isVertical
+    ? intl.formatMessage(messages.columns)
+    : intl.formatMessage(messages.rows);
+  const isLeftOrTop = false;
+  if (!active) {
+    return null;
   }
-
-  onAddRemoveColumn(isAdd, isLeftOrTop) {
-    const { onAddRemoveColumn } = this.props;
-    onAddRemoveColumn(isAdd, isLeftOrTop);
-  }
-
-  onAddRemoveRow(isAdd, isLeftOrTop) {
-    const { onAddRemoveRow } = this.props;
-    onAddRemoveRow(isAdd, isLeftOrTop);
-  }
-
-  renderButtons = (isVertical, isLeftOrTop) => {
-    const { rows, columns } = this.props;
-    return (
-      <ButtonGroup
-        orientation={isVertical ? 'vertical' : 'horizontal'}
-        color="primary"
-        aria-label="edit_grid_button_group"
-        fullWidth={true}
-        size="large"
-        variant="contained"
+  return (
+    <div
+      className="EditGridButtons__ButtonGroup"
+      aria-label="edit_grid_button_group"
+    >
+      <span>{orientation}:</span>
+      <Button
+        className="EditGridButtons__roundButton"
+        onClick={
+          isVertical
+            ? () => {
+                onAddRemoveColumn(false, isLeftOrTop);
+              }
+            : () => {
+                onAddRemoveRow(false, isLeftOrTop);
+              }
+        }
+        aria-label="edit_grid_button"
       >
-        <Button
-          onClick={
-            isVertical
-              ? this.onAddRemoveColumn.bind(this, true, isLeftOrTop)
-              : this.onAddRemoveRow.bind(this, true, isLeftOrTop)
-          }
-          aria-label="edit_grid_button"
-        >
-          {isVertical ? <KeyboardArrowRightIcon /> : <KeyboardArrowDownIcon />}
-        </Button>
-        <Button aria-label="edit_grid_value">
-          {isVertical ? columns.toString() : rows.toString()}
-        </Button>
-        <Button
-          onClick={
-            isVertical
-              ? this.onAddRemoveColumn.bind(this, false, isLeftOrTop)
-              : this.onAddRemoveRow.bind(this, false, isLeftOrTop)
-          }
-          aria-label="edit_grid_button"
-        >
-          {isVertical ? <KeyboardArrowLeftIcon /> : <KeyboardArrowUpIcon />}
-        </Button>
-      </ButtonGroup>
-    );
-  };
-
-  render() {
-    const { active, moveColsButtonToLeft } = this.props;
-    if (!active) {
-      return null;
-    }
-
-    return (
-      <React.Fragment>
-        <div
-          className={`EditGridButtons ${
-            moveColsButtonToLeft ? 'left' : 'right'
-          }`}
-        >
-          {this.renderButtons(true, false)}
-        </div>
-        <div className="EditGridButtons bottom">
-          {this.renderButtons(false, false)}
-        </div>
-      </React.Fragment>
-    );
-  }
+        <RemoveIcon />
+      </Button>
+      <div className="EditGridButtons__box" aria-label="edit_grid_value">
+        <span>{isVertical ? columns.toString() : rows.toString()}</span>
+      </div>
+      <Button
+        className="EditGridButtons__roundButton"
+        onClick={
+          isVertical
+            ? () => {
+                onAddRemoveColumn(true, isLeftOrTop);
+              }
+            : () => {
+                onAddRemoveRow(true, isLeftOrTop);
+              }
+        }
+        aria-label="edit_grid_button"
+      >
+        <AddIcon />
+      </Button>
+    </div>
+  );
 }
+EditGridButtons.propTypes = {
+  isVertical: PropTypes.bool.isRequired,
+  active: PropTypes.bool.isRequired,
+  columns: PropTypes.number.isRequired,
+  rows: PropTypes.number.isRequired,
+  onAddRemoveRow: PropTypes.func.isRequired,
+  onAddRemoveColumn: PropTypes.func.isRequired,
+  intl: intlShape.isRequired
+};
 
-export default EditGridButtons;
+export default injectIntl(EditGridButtons);

--- a/src/components/EditGridButtons/EditGridButtons.css
+++ b/src/components/EditGridButtons/EditGridButtons.css
@@ -1,55 +1,29 @@
-.EditGridButtons {
-  position: fixed;
-  z-index: 1000;
-  padding: 8px;
-  background: rgba(40, 158, 255, 0.5);
-  border-radius: 6px;
-  overflow: hidden;
+.EditGridButtons__ButtonGroup {
   display: flex;
+  flex: 1 1;
   align-items: center;
   justify-content: center;
+  padding-top: 8px;
+  padding-bottom: 8px;
 }
 
-.EditGridButtons:hover {
-  background: rgba(40, 158, 255, 0.8);
+.EditGridButtons__roundButton.MuiButton-root {
+  display: flex;
+  margin-left: 6px;
+  margin-right: 6px;
+  padding: 2px;
+  min-width: 0;
+  border-radius: 50%;
+  background-color: rgb(218, 16, 86);
+  color: white;
 }
 
-.EditGridButtons.left {
-  top: 55%;
-  left: 6px;
-  max-width: 4rem;
+.EditGridButtons__roundButton.MuiButton-root:hover {
+  background-color: rgb(157, 5, 58);
 }
 
-.EditGridButtons.right {
-  top: 55%;
-  right: 6px;
-  max-width: 4rem;
-}
-
-.EditGridButtons.right button,
-.EditGridButtons.left button {
-  min-height: 50px;
-  padding-right: 10px;
-  padding-left: 10px;
-}
-
-.EditGridButtons.top {
-  left: 40%;
-  top: 240px;
-}
-
-.EditGridButtons.bottom {
-  left: 50%;
-  margin-right: -50%;
-  transform: translate(-50%);
-  bottom: 6px;
-  max-width: 50%;
-  max-height: 4rem;
-}
-
-@media (max-width: 480px) {
-  .EditGridButtons button svg {
-    width: 100%;
-    height: 100%;
-  }
+.EditGridButtons__box {
+  display: flex;
+  padding: 4px 7px 4px 7px;
+  border: 2px solid rgb(218, 16, 86);
 }

--- a/src/components/EditGridButtons/EditGridButtons.messages.js
+++ b/src/components/EditGridButtons/EditGridButtons.messages.js
@@ -1,0 +1,12 @@
+import { defineMessages } from 'react-intl';
+
+export default defineMessages({
+  rows: {
+    id: 'cboard.components.EditGridButtons.rows',
+    defaultMessage: 'Rows'
+  },
+  columns: {
+    id: 'cboard.components.EditGridButtons.columns',
+    defaultMessage: 'Columns'
+  }
+});

--- a/src/translations/src/cboard.json
+++ b/src/translations/src/cboard.json
@@ -643,6 +643,8 @@
   "cboard.components.LoadBoardEditor.confirmationTitle": "Are you sure you want to change the board this tile opens?",
   "cboard.components.LoadBoardEditor.accept": "Accept",
   "cboard.components.LoadBoardEditor.cancel": "Cancel",
+  "cboard.components.EditGridButtons.rows": "Rows",
+  "cboard.components.EditGridButtons.columns": "Columns",
   "cboard.board.home": "home",
   "cboard.vocalization.myNameIsAmberley": "my name is Amberley",
   "cboard.vocalization.niceToMeetYou": "nice to meet you",


### PR DESCRIPTION
<h3>Description</h3>
This PR relocates the Rows and Columns selector controls from the grid overlay to a more accessible location, addressing Issue #1979.
<h3>Changes Made</h3>

- Implemented the new controls in a modular file structure for better organization.
- Followed the existing code style for function and class definitions.
- Applied the DRY principle to avoid code duplication.
- Internalized the new labels/messages created by me using react-intl so they can be translated by contributing translators.


<h3>Screenshots</h3>

<h2>Before:</h2>
<img width="1913" height="977" alt="Cboard-Before_Changes" src="https://github.com/user-attachments/assets/338a163d-08d8-42a6-ac62-92c12684fd9d" />

<h2>After (Option 2):</h2>
<img width="1915" height="981" alt="Cboard-After_Changes" src="https://github.com/user-attachments/assets/1134413c-7367-4821-9fb6-fc4179252ca5" />

<h2>After (Option 3):</h2>
<img width="1915" height="981" alt="Cboard-After_Changes_Option3" src="https://github.com/user-attachments/assets/6b92825a-7fc3-4516-88e5-0f8b9c4fcf0f" />

<h3>Closes: #1979</h3>
