### PR TITLE
Adds authentication to board report API

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -400,9 +400,19 @@ class API {
   }
 
   async boardReport(reportedBoardData) {
+    const authToken = getAuthToken();
+    if (!(authToken && authToken.length)) {
+      throw new Error('Need to be authenticated to perform this request');
+    }
+
+    const headers = {
+      Authorization: `Bearer ${authToken}`
+    };
+
     const { data } = await this.axiosInstance.post(
       `/board/report`,
-      reportedBoardData
+      reportedBoardData,
+      { headers }
     );
     return data;
   }

--- a/src/components/Communicator/CommunicatorDialog/CommunicatorDialogBoardItem.component.js
+++ b/src/components/Communicator/CommunicatorDialog/CommunicatorDialogBoardItem.component.js
@@ -856,6 +856,7 @@ class CommunicatorDialogBoardItem extends React.Component {
                     <InfoIcon />
                   </IconButton>
                   <IconButton
+                    disabled={userData && !userData.authToken}
                     label={intl.formatMessage(messages.boardReport)}
                     onClick={this.handleBoardReportOpen.bind(this)}
                   >


### PR DESCRIPTION
Ensures only authenticated users can report boards.
This prevents unauthorized access and potential abuse
of the reporting functionality.
Also, disables the report button if the user is not authenticated.
