### PR TITLE
Add validation for empty board data in updateApiBoardSuccess

### DIFF
--- a/src/components/Board/Board.actions.js
+++ b/src/components/Board/Board.actions.js
@@ -438,7 +438,12 @@ export function createApiBoardFailure(message) {
 
 export function updateApiBoardSuccess(board) {
   return dispatch => {
-    const { isLocalUpdateNeeded, ...boardData } = board;
+    const { isLocalUpdateNeeded, ...boardData } = board ?? {};
+
+    if (!board || Object.keys(boardData).length === 0) {
+      dispatch(updateApiBoardFailure('No board data to update'));
+      return;
+    }
 
     if (isLocalUpdateNeeded) {
       dispatch({


### PR DESCRIPTION
Implement validation in the `updateApiBoardSuccess` function to handle cases where the board data is empty, ensuring that an appropriate failure action is dispatched.

close #2005
