### PR TITLE
Solves ElevenLabs voices not showing up after login on new devices or browsers

### DIFF
--- a/src/components/Account/Login/Login.actions.js
+++ b/src/components/Account/Login/Login.actions.js
@@ -114,7 +114,9 @@ export function login({ email, password, activatedData }, type = 'local') {
           appLanguageCode === userVoiceLanguageCode &&
           uris.includes(userVoiceUri)
         ) {
-          dispatch(changeVoice(userVoiceUri, userVoiceLanguage));
+          if (userVoiceUri !== deviceVoiceUri) {
+            dispatch(changeVoice(userVoiceUri, userVoiceLanguage));
+          }
           if (loginData.settings.speech.pitch) {
             dispatch(changePitch(loginData.settings.speech.pitch));
           }

--- a/src/components/Account/Login/Login.actions.js
+++ b/src/components/Account/Login/Login.actions.js
@@ -5,7 +5,8 @@ import {
   changeVoice,
   changePitch,
   changeRate,
-  changeElevenLabsApiKey
+  changeElevenLabsApiKey,
+  getVoices
 } from '../../../providers/SpeechProvider/SpeechProvider.actions';
 import {
   disableTour,
@@ -74,7 +75,15 @@ function logoutSuccess() {
 }
 
 export function login({ email, password, activatedData }, type = 'local') {
-  const setAVoice = ({ loginData, dispatch, getState }) => {
+  const setAVoice = async ({ loginData, dispatch, getState }) => {
+    if (loginData?.settings?.speech?.elevenLabsApiKey) {
+      dispatch(
+        changeElevenLabsApiKey(loginData.settings.speech.elevenLabsApiKey)
+      );
+      tts.initElevenLabsInstance(loginData.settings.speech.elevenLabsApiKey);
+      await dispatch(getVoices());
+    }
+
     const {
       language: { lang: appLang },
       speech: {
@@ -91,15 +100,6 @@ export function login({ email, password, activatedData }, type = 'local') {
         return v.voiceURI;
       });
 
-      //if redux state have a defined voiceUri. Set it By default
-      if (
-        deviceVoiceUri &&
-        deviceVoiceLanguageCode === appLanguageCode &&
-        uris.includes(deviceVoiceUri)
-      ) {
-        return;
-      }
-      //if not Try to use API stored Voice
       if (loginData.settings?.speech) {
         const userVoiceUri = loginData.settings.speech.voiceURI; //ATENTION speech options on DB is under Speech directly. on state is under options
 
@@ -121,16 +121,16 @@ export function login({ email, password, activatedData }, type = 'local') {
           if (loginData.settings.speech.rate) {
             dispatch(changeRate(loginData.settings.speech.rate));
           }
-          if (loginData?.settings?.speech?.elevenLabsApiKey) {
-            dispatch(
-              changeElevenLabsApiKey(loginData.settings.speech.elevenLabsApiKey)
-            );
-            tts.initElevenLabsInstance(
-              loginData.settings.speech.elevenLabsApiKey
-            );
-          }
           return;
         }
+      }
+
+      if (
+        deviceVoiceUri &&
+        deviceVoiceLanguageCode === appLanguageCode &&
+        uris.includes(deviceVoiceUri)
+      ) {
+        return;
       }
 
       const defaultVoiceUri = getVoiceURI(appLang, voices);
@@ -207,7 +207,7 @@ export function login({ email, password, activatedData }, type = 'local') {
         );
       }
       dispatch(loginSuccess(loginData));
-      setAVoice({ loginData, dispatch, getState });
+      await setAVoice({ loginData, dispatch, getState });
     } catch (e) {
       if (e.response != null) {
         return Promise.reject(e.response.data);

--- a/src/components/Account/Login/Login.actions.js
+++ b/src/components/Account/Login/Login.actions.js
@@ -76,11 +76,11 @@ function logoutSuccess() {
 
 export function login({ email, password, activatedData }, type = 'local') {
   const setAVoice = async ({ loginData, dispatch, getState }) => {
-    if (loginData?.settings?.speech?.elevenLabsApiKey) {
-      dispatch(
-        changeElevenLabsApiKey(loginData.settings.speech.elevenLabsApiKey)
-      );
-      tts.initElevenLabsInstance(loginData.settings.speech.elevenLabsApiKey);
+    const elevenLabsApiKey = loginData?.settings?.speech?.elevenLabsApiKey;
+
+    if (elevenLabsApiKey) {
+      dispatch(changeElevenLabsApiKey(elevenLabsApiKey));
+      tts.initElevenLabsInstance(elevenLabsApiKey);
       await dispatch(getVoices());
     }
 


### PR DESCRIPTION
Refactored the login flow to improve how user voice settings and ElevenLabs API integration are handled during first login in other devices or browsers. The main changes ensure that the ElevenLabs API key is set and voices are fetched asynchronously, and the logic for selecting the user's voice is reordered for clarity and reliability.

Changes:
* The `setAVoice` function is now asynchronous to ensure voice settings are properly initialized on login process and, if an ElevenLabs API key is present in the user's settings, dispatches `changeElevenLabsApiKey`, initializes the ElevenLabs instance, and fetches available voices before proceeding.
* The `getVoices` action is now imported and dispatched during login when an ElevenLabs API key is detected.

Voice selection logic reordering:
* The logic for selecting the user's voice has been restructured: now, the API-stored voice is prioritized, and the check for the device's voice URI is performed after attempting to set the user's voice from the API.

Closes #2039 