### PR TITLE
Logout functionality to clear ElevenLabs settings and voices

### DIFF
--- a/src/providers/SpeechProvider/SpeechProvider.reducer.js
+++ b/src/providers/SpeechProvider/SpeechProvider.reducer.js
@@ -26,7 +26,10 @@ import {
   standardizeLanguageCode
 } from '../../i18n';
 import { CHANGE_LANG } from '../LanguageProvider/LanguageProvider.constants';
-import { LOGIN_SUCCESS } from '../../components/Account/Login/Login.constants';
+import {
+  LOGIN_SUCCESS,
+  LOGOUT
+} from '../../components/Account/Login/Login.constants';
 import { DEFAULT_LANG } from '../../components/App/App.constants';
 
 const initialState = {
@@ -335,6 +338,37 @@ function speechProviderReducer(state = initialState, action) {
         },
         elevenLabsVoiceSettings: resetElevenLabsVoiceSettings(state)
       };
+    case LOGOUT: {
+      const nonElevenLabsVoices = state.voices.filter(
+        voice => voice.voiceSource !== ELEVEN_LABS
+      );
+
+      const currentVoice = state.voices.find(
+        v => v.voiceURI === state.options.voiceURI
+      );
+      const isCurrentVoiceElevenLabs =
+        currentVoice?.voiceSource === ELEVEN_LABS;
+
+      return {
+        ...state,
+        elevenLabsApiKey: '',
+        elevenLabsCache: {
+          voices: [],
+          timestamp: null,
+          ttl: 24 * 60 * 60 * 1000
+        },
+        elevenLabsVoiceSettings: {},
+        voices: nonElevenLabsVoices,
+        options: {
+          ...state.options,
+          voiceURI: isCurrentVoiceElevenLabs ? null : state.options.voiceURI,
+          isCloud: isCurrentVoiceElevenLabs ? null : state.options.isCloud,
+          elevenLabsStability: 0.5,
+          elevenLabsSimilarity: 0.75,
+          elevenLabsStyle: 0.0
+        }
+      };
+    }
     default:
       return state;
   }

--- a/src/providers/SpeechProvider/SpeechProvider.reducer.js
+++ b/src/providers/SpeechProvider/SpeechProvider.reducer.js
@@ -349,19 +349,15 @@ function speechProviderReducer(state = initialState, action) {
       const isCurrentVoiceElevenLabs =
         currentVoice?.voiceSource === ELEVEN_LABS;
 
-      const logoutVoiceURI = isCurrentVoiceElevenLabs
+      const newVoiceURI = isCurrentVoiceElevenLabs
         ? getVoiceURI(state.options.lang, nonElevenLabsVoices)
         : state.options.voiceURI;
 
-      const logoutVoice = isCurrentVoiceElevenLabs
-        ? nonElevenLabsVoices.find(v => v.voiceURI === logoutVoiceURI)
-        : null;
+      const newVoice = isCurrentVoiceElevenLabs
+        ? nonElevenLabsVoices.find(v => v.voiceURI === newVoiceURI)
+        : currentVoice;
 
-      const logoutIsCloud = isCurrentVoiceElevenLabs
-        ? logoutVoice
-          ? logoutVoice.voiceSource === 'cloud'
-          : null
-        : state.options.isCloud;
+      const newVoiceIsCloud = newVoice?.voiceSource === 'cloud' ? true : null;
 
       return {
         ...state,
@@ -369,17 +365,17 @@ function speechProviderReducer(state = initialState, action) {
         elevenLabsCache: {
           voices: [],
           timestamp: null,
-          ttl: 24 * 60 * 60 * 1000
+          ttl: initialState.elevenLabsCache.ttl
         },
         elevenLabsVoiceSettings: {},
         voices: nonElevenLabsVoices,
         options: {
           ...state.options,
-          voiceURI: logoutVoiceURI,
-          isCloud: logoutIsCloud,
-          elevenLabsStability: 0.5,
-          elevenLabsSimilarity: 0.75,
-          elevenLabsStyle: 0.0
+          voiceURI: newVoiceURI,
+          isCloud: newVoiceIsCloud,
+          elevenLabsStability: initialState.options.elevenLabsStability,
+          elevenLabsSimilarity: initialState.options.elevenLabsSimilarity,
+          elevenLabsStyle: initialState.options.elevenLabsStyle
         }
       };
     }

--- a/src/providers/SpeechProvider/SpeechProvider.reducer.js
+++ b/src/providers/SpeechProvider/SpeechProvider.reducer.js
@@ -349,6 +349,18 @@ function speechProviderReducer(state = initialState, action) {
       const isCurrentVoiceElevenLabs =
         currentVoice?.voiceSource === ELEVEN_LABS;
 
+      const logoutVoiceURI = isCurrentVoiceElevenLabs
+        ? getVoiceURI(state.options.lang, nonElevenLabsVoices)
+        : state.options.voiceURI;
+
+      const logoutVoice = isCurrentVoiceElevenLabs
+        ? nonElevenLabsVoices.find(v => v.voiceURI === logoutVoiceURI)
+        : null;
+
+      const logoutIsCloud = isCurrentVoiceElevenLabs
+        ? logoutVoice?.voiceSource === 'cloud' ?? null
+        : state.options.isCloud;
+
       return {
         ...state,
         elevenLabsApiKey: '',
@@ -361,10 +373,8 @@ function speechProviderReducer(state = initialState, action) {
         voices: nonElevenLabsVoices,
         options: {
           ...state.options,
-          voiceURI: isCurrentVoiceElevenLabs
-            ? getVoiceURI(state.options.lang, nonElevenLabsVoices)
-            : state.options.voiceURI,
-          isCloud: isCurrentVoiceElevenLabs ? null : state.options.isCloud,
+          voiceURI: logoutVoiceURI,
+          isCloud: logoutIsCloud,
           elevenLabsStability: 0.5,
           elevenLabsSimilarity: 0.75,
           elevenLabsStyle: 0.0

--- a/src/providers/SpeechProvider/SpeechProvider.reducer.js
+++ b/src/providers/SpeechProvider/SpeechProvider.reducer.js
@@ -361,7 +361,9 @@ function speechProviderReducer(state = initialState, action) {
         voices: nonElevenLabsVoices,
         options: {
           ...state.options,
-          voiceURI: isCurrentVoiceElevenLabs ? null : state.options.voiceURI,
+          voiceURI: isCurrentVoiceElevenLabs
+            ? getVoiceURI(state.options.lang, nonElevenLabsVoices)
+            : state.options.voiceURI,
           isCloud: isCurrentVoiceElevenLabs ? null : state.options.isCloud,
           elevenLabsStability: 0.5,
           elevenLabsSimilarity: 0.75,

--- a/src/providers/SpeechProvider/SpeechProvider.reducer.js
+++ b/src/providers/SpeechProvider/SpeechProvider.reducer.js
@@ -358,7 +358,9 @@ function speechProviderReducer(state = initialState, action) {
         : null;
 
       const logoutIsCloud = isCurrentVoiceElevenLabs
-        ? logoutVoice?.voiceSource === 'cloud' ?? null
+        ? logoutVoice
+          ? logoutVoice.voiceSource === 'cloud'
+          : null
         : state.options.isCloud;
 
       return {


### PR DESCRIPTION
Added logic to the `speechProviderReducer` to handle user logout events by cleaning up state related to ElevenLabs voices and settings. This ensures that sensitive information and cached data are cleared when a user logs out.

Changes:

* Added a new case for the `LOGOUT` action in `speechProviderReducer` that:
  * Clears the `elevenLabsApiKey` and resets the `elevenLabsCache` and `elevenLabsVoiceSettings`.
  * Removes all ElevenLabs voices from the `voices` array.
  * Resets ElevenLabs-specific options and clears the selected voice if it was an ElevenLabs voice.
* Updated imports in `SpeechProvider.reducer.js` to include the `LOGOUT` constant from `Login.constants`.


Closes #2041 