### PR TITLE
fix: prevent crash when tile is missing by adding null safety to resolveTileLabel

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -57,7 +57,13 @@ export const resolveBoardName = ({ name, nameKey }, intl) => {
   return '';
 };
 
-export const resolveTileLabel = ({ label, labelKey }, intl) => {
+export const resolveTileLabel = (tile, intl) => {
+  if (!tile) {
+    return '';
+  }
+
+  const { label, labelKey } = tile;
+
   if (label) return label;
   if (labelKey && intl?.messages?.[labelKey]) {
     return intl.formatMessage({ id: labelKey });


### PR DESCRIPTION
Fixes
Prevents app crash when a board contains a tile with missing data by adding a null safety check in `resolveTileLabel`.

Details
- Added a check to ensure tile is not null before destructuring.
- Cleans up previous comment.

Tested
- Ran locally, no crash opening boards with missing tile IDs.

Ready for review! @tomivm 
For any further changes required please mention them 😊