### PR TITLE
Fix: Initialize voices as array instead of object in _getPlatformVoices

### DIFF
--- a/src/providers/SpeechProvider/tts.js
+++ b/src/providers/SpeechProvider/tts.js
@@ -150,15 +150,21 @@ const tts = {
 
   // Get voices depending on platform (browser/cordova)
   _getPlatformVoices() {
-    let voices = {};
+    let voices = [];
+  
     try {
-      voices = synth.getVoices();
+      voices = synth.getVoices() || [];
     } catch (err) {
       console.log(err.message);
       synth = window.speechSynthesis;
+      voices = synth.getVoices() || [];
     }
-    // On Cordova, voice results are under `._list`
-    return voices._list || voices;
+  
+    //voices might be { _list: [...] }
+    const list = voices._list || voices;
+  
+    //guaranteed to always return an array
+    return Array.isArray(list) ? list : [];
   },
 
   async getVoices() {


### PR DESCRIPTION
- Changed voices initialization from {} to []
- Added || [] fallbacks for synth.getVoices()
- Added Array.isArray() check to guarantee array return
- Prevents TypeError on .concat() calls

Fixes #2047