### PR TITLE
Fix redirect behavior in AuthScreen when closing WelcomeScreen (Fixes #1949)

### DIFF
--- a/src/components/AuthScreen/AuthScreen.component.js
+++ b/src/components/AuthScreen/AuthScreen.component.js
@@ -18,7 +18,9 @@ class AuthScreen extends Component {
           heading={intl.formatMessage(messages.heading)}
           text={intl.formatMessage(messages.text)}
           onClose={() => {
-            history.action === 'PUSH' ? history.goBack() : history.push('/');
+            history.action === 'PUSH'
+              ? history.goBack()
+              : history.push('/board/root');
           }}
         />
       </div>

--- a/src/components/AuthScreen/AuthScreen.component.test.js
+++ b/src/components/AuthScreen/AuthScreen.component.test.js
@@ -24,12 +24,146 @@ jest.mock('./AuthScreen.messages', () => {
     skipForNow: {
       id: 'cboard.components.WelcomeScreen.skipForNow',
       defaultMessage: 'Skip for now'
+    },
+    heading: {
+      id: 'cboard.components.AuthScreenInformation.heading',
+      defaultMessage: 'Cboard'
+    },
+    text: {
+      id: 'cboard.components.AuthScreenInformation.text',
+      defaultMessage: 'Sign up to sync your settings!'
     }
   };
 });
 
+// Mock WelcomeScreen to test onClose behavior
+jest.mock('../WelcomeScreen', () => {
+  return function MockWelcomeScreen({ onClose }) {
+    return (
+      <div data-testid="welcome-screen">
+        <button data-testid="close-button" onClick={onClose}>
+          Close
+        </button>
+      </div>
+    );
+  };
+});
+
 describe('AuthScreen tests', () => {
+  const mockIntl = {
+    formatMessage: jest.fn(({ id }) => id)
+  };
+
   test('default renderer', () => {
-    shallowMatchSnapshot(<AuthScreen history={{ goBack: () => {} }} />);
+    const mockHistory = { goBack: jest.fn(), push: jest.fn() };
+    shallowMatchSnapshot(<AuthScreen history={mockHistory} intl={mockIntl} />);
+  });
+
+  describe('Close button behavior', () => {
+    test('should call history.goBack() when history.action is PUSH', () => {
+      const mockGoBack = jest.fn();
+      const mockPush = jest.fn();
+      const mockHistory = {
+        action: 'PUSH',
+        goBack: mockGoBack,
+        push: mockPush
+      };
+
+      const wrapper = mount(
+        <AuthScreen history={mockHistory} intl={mockIntl} />
+      );
+
+      // Find and click the close button
+      const closeButton = wrapper.find('[data-testid="close-button"]');
+      closeButton.simulate('click');
+
+      // Should call goBack, not push
+      expect(mockGoBack).toHaveBeenCalledTimes(1);
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+
+    test('should redirect to /board/root when history.action is not PUSH (no browsing history)', () => {
+      const mockGoBack = jest.fn();
+      const mockPush = jest.fn();
+      const mockHistory = {
+        action: 'POP', // or 'REPLACE' - any non-PUSH action
+        goBack: mockGoBack,
+        push: mockPush
+      };
+
+      const wrapper = mount(
+        <AuthScreen history={mockHistory} intl={mockIntl} />
+      );
+
+      // Find and click the close button
+      const closeButton = wrapper.find('[data-testid="close-button"]');
+      closeButton.simulate('click');
+
+      // Should call push with /board/root, not goBack
+      expect(mockPush).toHaveBeenCalledTimes(1);
+      expect(mockPush).toHaveBeenCalledWith('/board/root');
+      expect(mockGoBack).not.toHaveBeenCalled();
+    });
+
+    test('should redirect to /board/root when history.action is undefined (new user, no history)', () => {
+      const mockGoBack = jest.fn();
+      const mockPush = jest.fn();
+      const mockHistory = {
+        action: undefined, // No history action
+        goBack: mockGoBack,
+        push: mockPush
+      };
+
+      const wrapper = mount(
+        <AuthScreen history={mockHistory} intl={mockIntl} />
+      );
+
+      // Find and click the close button
+      const closeButton = wrapper.find('[data-testid="close-button"]');
+      closeButton.simulate('click');
+
+      // Should call push with /board/root
+      expect(mockPush).toHaveBeenCalledTimes(1);
+      expect(mockPush).toHaveBeenCalledWith('/board/root');
+      expect(mockGoBack).not.toHaveBeenCalled();
+    });
+
+    test('should redirect to /board/root when history.action is REPLACE', () => {
+      const mockGoBack = jest.fn();
+      const mockPush = jest.fn();
+      const mockHistory = {
+        action: 'REPLACE',
+        goBack: mockGoBack,
+        push: mockPush
+      };
+
+      const wrapper = mount(
+        <AuthScreen history={mockHistory} intl={mockIntl} />
+      );
+
+      const closeButton = wrapper.find('[data-testid="close-button"]');
+      closeButton.simulate('click');
+
+      expect(mockPush).toHaveBeenCalledWith('/board/root');
+      expect(mockGoBack).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Integration with WelcomeScreen', () => {
+    test('should pass onClose handler to WelcomeScreen', () => {
+      const mockHistory = {
+        action: 'POP',
+        goBack: jest.fn(),
+        push: jest.fn()
+      };
+
+      const wrapper = mount(
+        <AuthScreen history={mockHistory} intl={mockIntl} />
+      );
+
+      // Verify WelcomeScreen receives onClose prop
+      const welcomeScreen = wrapper.find('[data-testid="welcome-screen"]');
+      expect(welcomeScreen.exists()).toBe(true);
+    });
   });
 });

--- a/src/components/AuthScreen/__snapshots__/AuthScreen.component.test.js.snap
+++ b/src/components/AuthScreen/__snapshots__/AuthScreen.component.test.js.snap
@@ -4,7 +4,8 @@ exports[`AuthScreen tests default renderer 1`] = `
 <AuthScreen
   history={
     Object {
-      "goBack": [Function],
+      "goBack": [MockFunction],
+      "push": [MockFunction],
     }
   }
   intl={


### PR DESCRIPTION
This PR fixes the incorrect redirect behavior in the AuthScreen component.
Previously, closing the WelcomeScreen component without a prior navigation history caused the app to navigate to /, which resulted in a broken or blank experience.

Root Cause:
The logic inside onClose attempted:

          history.action === 'PUSH' ? history.goBack() : history.push('/');

For users entering the app directly (no prior push state), history.push('/') sent them to the base route, which does not render the board UI.

To fix this, the fallback routes was redone and routing logic was changed to accomodate for this fix.

Unit tests were also added to AuthScreen.component.test.js to cover:
     - Redirecting with a populated history stack
     - Redirecting without a history stack (new behavior)
     - Verifying that /board/root is the fallback route
     - Ensuring no regression in existing render behavior