### PR TITLE
Solves problems in "Fix OBF export not respecting grid size for fixed boards (#1772)" PR

### DIFF
--- a/src/components/Settings/Export/Export.helpers.js
+++ b/src/components/Settings/Export/Export.helpers.js
@@ -22,18 +22,18 @@ import {
   PICSEEPAL_IMAGES_WIDTH,
   PDF_IMAGES_WIDTH,
   SMALL_FONT_SIZE,
-  LARGE_FONT_SIZE
+  LARGE_FONT_SIZE,
 } from './Export.constants';
 import {
   LABEL_POSITION_ABOVE,
-  LABEL_POSITION_BELOW
+  LABEL_POSITION_BELOW,
 } from '../Display/Display.constants';
 import {
   isAndroid,
   isCordova,
   isIOS,
   requestCvaWritePermissions,
-  writeCvaFile
+  writeCvaFile,
 } from '../../../cordova-util';
 import { getStore } from '../../../store';
 import * as _ from 'lodash';
@@ -46,15 +46,15 @@ pdfMake.vfs = pdfFonts.pdfMake.vfs;
 const imageElement = new Image();
 
 function toSnakeCase(str) {
-  const value = str.replace(/([A-Z])/g, $1 => '_' + $1.toLowerCase());
+  const value = str.replace(/([A-Z])/g, ($1) => '_' + $1.toLowerCase());
   return value.startsWith('_') ? value.slice(1) : value;
 }
 
 function getOBFButtonProps(tile = {}, intl) {
   const button = {};
 
-  const tileExtProps = CBOARD_EXT_PROPERTIES.filter(key => !!tile[key]);
-  tileExtProps.forEach(key => {
+  const tileExtProps = CBOARD_EXT_PROPERTIES.filter((key) => !!tile[key]);
+  tileExtProps.forEach((key) => {
     const keyWithPrefix = `${CBOARD_EXT_PREFIX}${toSnakeCase(key)}`;
     button[keyWithPrefix] = tile[key];
   });
@@ -96,7 +96,7 @@ function getBase64Image(base64Str = '') {
   return {
     ab,
     data: base64Str,
-    content_type: contentType
+    content_type: contentType,
   };
 }
 
@@ -105,22 +105,22 @@ export async function getDataUri(url) {
     const result = await axios({
       method: 'get',
       url,
-      responseType: 'arraybuffer'
+      responseType: 'arraybuffer',
     });
 
     // Convert the array buffer to a Base64-encoded string.
     const encodedImage = btoa(
       new Uint8Array(result.data).reduce(
         (data, byte) => data + String.fromCharCode(byte),
-        ''
-      )
+        '',
+      ),
     );
     const contentType = result.headers['content-type'];
 
     return {
       ab: result.data,
       content_type: contentType,
-      data: `data:${contentType};base64,${encodedImage}`
+      data: `data:${contentType};base64,${encodedImage}`,
     };
   } catch (e) {
     console.error(`Failed to get image at ${url}.`, e);
@@ -148,24 +148,24 @@ async function boardToOBF(boardsMap, board = {}, intl, { embed = false }) {
 
   const images = {};
   const fetchedImages = {};
-  const grid = board.isFixed
-    ? board.grid.order
-    : new Array(Math.ceil(board.tiles.length / columns));
+  const grid =
+    board.isFixed && board.grid?.order
+      ? board.grid.order
+      : new Array(Math.ceil(board.tiles.length / columns));
   let currentRow = 0;
   const buttons = await Promise.all(
     board.tiles.map(async (tile, i) => {
-      currentRow =
-        i >= (currentRow + 1) * columns ? currentRow + 1 : currentRow;
-
       if (tile) {
         if (!board.isFixed) {
+          currentRow =
+            i >= (currentRow + 1) * columns ? currentRow + 1 : currentRow;
           grid[currentRow] = grid[currentRow] || [];
           grid[currentRow].push(tile.id);
         }
 
         const button = {
           id: tile.id,
-          ...getOBFButtonProps(tile, intl)
+          ...getOBFButtonProps(tile, intl),
         };
 
         if (tile.image && tile.image.length) {
@@ -183,7 +183,7 @@ async function boardToOBF(boardsMap, board = {}, intl, { embed = false }) {
             const components = [
               'custom',
               board.name || board.nameKey,
-              tile.label || tile.labelKey || tile.id
+              tile.label || tile.labelKey || tile.id,
             ];
             const extension = mime.extension(imageResponse['content_type']);
             return `/${_.join(components, '/')}.${extension}`;
@@ -192,10 +192,10 @@ async function boardToOBF(boardsMap, board = {}, intl, { embed = false }) {
           const path = image.startsWith('data:')
             ? getCustomImagePath()
             : isCordova()
-            ? ''
-            : image.startsWith('/')
-            ? image
-            : `/${image}`;
+              ? ''
+              : image.startsWith('/')
+                ? image
+                : `/${image}`;
 
           if (imageResponse) {
             const imageID = new mongoose.Types.ObjectId().toString();
@@ -209,7 +209,7 @@ async function boardToOBF(boardsMap, board = {}, intl, { embed = false }) {
               data: embed ? imageResponse.data : undefined,
               content_type: imageResponse['content_type'],
               width: 300,
-              height: 300
+              height: 300,
             };
           }
         }
@@ -220,16 +220,16 @@ async function boardToOBF(boardsMap, board = {}, intl, { embed = false }) {
             name: loadBoardData.nameKey
               ? intl.formatMessage({ id: loadBoardData.nameKey })
               : '',
-            path: `boards/${tile.loadBoard}.obf`
+            path: `boards/${tile.loadBoard}.obf`,
           };
         }
 
         return button;
       }
-    })
+    }),
   );
 
-  if (grid.length >= 1) {
+  if (grid.length >= 1 && Array.isArray(grid[grid.length - 1])) {
     const lastGridRowDiff = columns - grid[grid.length - 1].length;
     if (lastGridRowDiff > 0) {
       const emptyButtons = new Array(lastGridRowDiff).map(() => null);
@@ -249,17 +249,17 @@ async function boardToOBF(boardsMap, board = {}, intl, { embed = false }) {
       grid: {
         rows: grid.length,
         columns: columns,
-        order: grid
+        order: grid,
       },
       description_html: board.nameKey
         ? intl.formatMessage({ id: board.nameKey })
-        : ''
+        : '',
     };
 
     const boardExtProps = CBOARD_EXT_PROPERTIES.filter(
-      key => typeof board[key] !== 'undefined'
+      (key) => typeof board[key] !== 'undefined',
     );
-    boardExtProps.forEach(key => {
+    boardExtProps.forEach((key) => {
       const keyWithPrefix = `${CBOARD_EXT_PREFIX}${toSnakeCase(key)}`;
       obf[keyWithPrefix] = board[key];
     });
@@ -275,14 +275,14 @@ function getPDFTileData(tile, intl) {
   return {
     label: label.length ? intl.formatMessage({ id: label }) : label,
     image: tile.image || '',
-    backgroundColor: tile.backgroundColor || ''
+    backgroundColor: tile.backgroundColor || '',
   };
 }
 
 async function toDataURL(url, styles = {}, outputFormat = 'image/jpeg') {
   return new Promise((resolve, reject) => {
     imageElement.crossOrigin = 'Anonymous';
-    imageElement.onload = function() {
+    imageElement.onload = function () {
       const canvas = document.createElement('CANVAS');
       const ctx = canvas.getContext('2d');
       const backgroundColor =
@@ -315,7 +315,7 @@ async function toDataURL(url, styles = {}, outputFormat = 'image/jpeg') {
         0,
         0,
         this.naturalWidth * widthFix,
-        this.naturalHeight * heightFix
+        this.naturalHeight * heightFix,
       );
 
       if (borderColor) {
@@ -326,7 +326,7 @@ async function toDataURL(url, styles = {}, outputFormat = 'image/jpeg') {
       const dataURL = canvas.toDataURL(outputFormat);
       resolve(dataURL);
     };
-    imageElement.onerror = function() {
+    imageElement.onerror = function () {
       reject(new Error('Getting remote image failed'));
     };
     // Cordova path cannot be absolute
@@ -349,25 +349,25 @@ async function toDataURL(url, styles = {}, outputFormat = 'image/jpeg') {
 
 pdfMake.tableLayouts = {
   pdfGridLayout: {
-    hLineWidth: function(i, node) {
+    hLineWidth: function (i, node) {
       return PDF_BORDER_WIDTH;
     },
-    vLineWidth: function(i) {
+    vLineWidth: function (i) {
       return PDF_BORDER_WIDTH;
     },
-    hLineColor: function(i) {
+    hLineColor: function (i) {
       return '#ffffff';
     },
-    vLineColor: function(i) {
+    vLineColor: function (i) {
       return '#ffffff';
     },
-    paddingLeft: function(i) {
+    paddingLeft: function (i) {
       return 0;
     },
-    paddingRight: function(i, node) {
+    paddingRight: function (i, node) {
       return 0;
-    }
-  }
+    },
+  },
 };
 
 function getCellWidths(columns, picsee = false) {
@@ -382,13 +382,13 @@ async function generatePDFBoard(
   intl,
   breakPage = true,
   picsee = false,
-  labelFontSize
+  labelFontSize,
 ) {
   const header = {
     absolutePosition: { x: 0, y: 5 },
     text: board.name || '',
     alignment: 'center',
-    fontSize: 8
+    fontSize: 8,
   };
 
   const columns =
@@ -400,9 +400,9 @@ async function generatePDFBoard(
   const table = {
     table: {
       widths: cellWidths,
-      body: [{}]
+      body: [{}],
     },
-    layout: 'pdfGridLayout'
+    layout: 'pdfGridLayout',
   };
 
   if (breakPage) {
@@ -420,7 +420,7 @@ async function generatePDFBoard(
         columns,
         intl,
         picsee,
-        labelFontSize
+        labelFontSize,
       )
     : await generateNonFixedBoard(
         board,
@@ -428,7 +428,7 @@ async function generatePDFBoard(
         columns,
         intl,
         picsee,
-        labelFontSize
+        labelFontSize,
       );
 
   const lastGridRowDiff = columns - grid[grid.length - 2].length; // labels row
@@ -460,7 +460,7 @@ async function generateFixedBoard(
   columns,
   intl,
   picsee = false,
-  labelFontSize
+  labelFontSize,
 ) {
   let currentRow = 0;
   let cont = 0;
@@ -469,7 +469,7 @@ async function generateFixedBoard(
     label: '',
     labelKey: '',
     image: '',
-    backgroundColor: '#d9d9d9'
+    backgroundColor: '#d9d9d9',
   };
 
   const itemsPerPage = rows * columns;
@@ -482,7 +482,7 @@ async function generateFixedBoard(
       columns,
       rows,
       order: board.grid.order,
-      items
+      items,
     });
     for (let rowIndex = 0; rowIndex < order.length; rowIndex++) {
       for (
@@ -491,7 +491,7 @@ async function generateFixedBoard(
         columnIndex++
       ) {
         const tileId = order[rowIndex][columnIndex];
-        let tile = board.tiles.find(tile => tile.id === tileId);
+        let tile = board.tiles.find((tile) => tile.id === tileId);
         if (tile === undefined) {
           tile = defaultTile;
         }
@@ -517,7 +517,7 @@ async function generateFixedBoard(
           currentRow,
           pageBreak,
           picsee,
-          labelFontSize
+          labelFontSize,
         );
         cont++;
       }
@@ -532,7 +532,7 @@ async function generateNonFixedBoard(
   columns,
   intl,
   picsee = false,
-  labelFontSize
+  labelFontSize,
 ) {
   // Do a grid with 2n rows
   const grid = new Array(Math.ceil(board.tiles.length / columns) * 2);
@@ -563,7 +563,7 @@ async function generateNonFixedBoard(
       currentRow,
       pageBreak,
       picsee,
-      labelFontSize
+      labelFontSize,
     );
   }, Promise.resolve());
   return grid;
@@ -578,7 +578,7 @@ const addTileToGrid = async (
   currentRow,
   pageBreak = false,
   picsee = false,
-  labelFontSize
+  labelFontSize,
 ) => {
   const { label, image } = getPDFTileData(tile, intl);
   const fixedRow = currentRow * 2;
@@ -605,13 +605,13 @@ const addTileToGrid = async (
     }
   }
 
-  const rgbToHex = rgbBackgroundColor => {
+  const rgbToHex = (rgbBackgroundColor) => {
     return (
       '#' +
       rgbBackgroundColor
         .slice(4, -1)
         .split(',')
-        .map(x => (+x).toString(16).padStart(2, 0))
+        .map((x) => (+x).toString(16).padStart(2, 0))
         .join('')
     );
   };
@@ -630,7 +630,7 @@ const addTileToGrid = async (
     alignment: 'center',
     width: '100',
     fillColor: hexBackgroundColor,
-    border: PDF_GRID_BORDER[labelPosition].imageData
+    border: PDF_GRID_BORDER[labelPosition].imageData,
   };
 
   const labelData = {
@@ -638,7 +638,7 @@ const addTileToGrid = async (
     alignment: 'center',
     fontSize: labelFontSize,
     fillColor: hexBackgroundColor,
-    border: PDF_GRID_BORDER[labelPosition].labelData
+    border: PDF_GRID_BORDER[labelPosition].labelData,
   };
 
   const IMG_WIDTH = picsee ? PICSEEPAL_IMAGES_WIDTH : PDF_IMAGES_WIDTH;
@@ -693,7 +693,7 @@ const addTileToGrid = async (
 const getDisplaySettings = () => {
   const store = getStore();
   const {
-    app: { displaySettings }
+    app: { displaySettings },
   } = store.getState();
 
   return displaySettings;
@@ -721,10 +721,10 @@ export async function openboardExportAdapter(boardOrBoards, intl) {
 
 export async function openboardExportOneAdapter(board, intl) {
   const { obf } = await boardToOBF({ [board.id]: board }, board, intl, {
-    embed: true
+    embed: true,
   });
   const content = new Blob([JSON.stringify(obf, null, 2)], {
-    type: 'application/json'
+    type: 'application/json',
   });
 
   if (content) {
@@ -754,7 +754,7 @@ export async function openboardExportManyAdapter(boards = [], intl) {
     const board = boards[i];
     const boardMapFilename = `boards/${board.id}.obf`;
     const { obf, images } = await boardToOBF(boardsMap, board, intl, {
-      embed: false
+      embed: false,
     });
 
     if (!obf) {
@@ -764,7 +764,7 @@ export async function openboardExportManyAdapter(boards = [], intl) {
     zip.file(boardMapFilename, JSON.stringify(obf, null, 2));
 
     const imagesKeys = Object.keys(images);
-    imagesKeys.forEach(key => {
+    imagesKeys.forEach((key) => {
       const image = images[key];
       const imageFilename = `images/${image.path}`;
       zip.file(imageFilename, image.ab);
@@ -783,13 +783,13 @@ export async function openboardExportManyAdapter(boards = [], intl) {
     root,
     paths: {
       boards: boardsForManifest,
-      images: imagesMap
-    }
+      images: imagesMap,
+    },
   };
 
   zip.file('manifest.json', JSON.stringify(manifest, null, 2));
 
-  zip.generateAsync(CBOARD_ZIP_OPTIONS).then(content => {
+  zip.generateAsync(CBOARD_ZIP_OPTIONS).then((content) => {
     if (content) {
       let prefix = getDatetimePrefix();
       if (boards.length === 1) {
@@ -826,7 +826,7 @@ export async function openboardExportManyAdapter(boards = [], intl) {
  * @returns {Array<Object>} The board and its subfolders.
  */
 function getNestedBoards(allBoards, rootBoardId) {
-  const boardsMap = _.fromPairs(_.map(allBoards, b => [b.id, b]));
+  const boardsMap = _.fromPairs(_.map(allBoards, (b) => [b.id, b]));
 
   const unseen = [rootBoardId];
   const nestedBoardIds = [rootBoardId];
@@ -834,7 +834,7 @@ function getNestedBoards(allBoards, rootBoardId) {
   while (!_.isEmpty(unseen)) {
     const curr = unseen.pop();
     const tiles = _.get(boardsMap[curr], 'tiles');
-    _.forEach(tiles, tile => {
+    _.forEach(tiles, (tile) => {
       const id = tile.loadBoard;
       // The second check is necessary to handle cycles (for example,
       // A -> B -> A).
@@ -845,14 +845,14 @@ function getNestedBoards(allBoards, rootBoardId) {
     });
   }
 
-  return _.map(nestedBoardIds, id => boardsMap[id]);
+  return _.map(nestedBoardIds, (id) => boardsMap[id]);
 }
 
 export async function cboardExportAdapter(allBoards = [], board) {
   const boards = board ? getNestedBoards(allBoards, board.id) : allBoards;
 
   const jsonData = new Blob([JSON.stringify(boards)], {
-    type: 'text/json;charset=utf-8;'
+    type: 'text/json;charset=utf-8;',
   });
 
   if (jsonData) {
@@ -865,7 +865,7 @@ export async function cboardExportAdapter(allBoards = [], board) {
     if (isAndroid() || isIOS()) {
       requestCvaWritePermissions();
       const name = 'Download/' + prefix + EXPORT_CONFIG_BY_TYPE.cboard.filename;
-      writeCvaFile(name, jsonData).catch(error => {
+      writeCvaFile(name, jsonData).catch((error) => {
         console.error(error);
       });
     }
@@ -874,7 +874,7 @@ export async function cboardExportAdapter(allBoards = [], board) {
     if (navigator.msSaveBlob) {
       navigator.msSaveBlob(
         jsonData,
-        prefix + EXPORT_CONFIG_BY_TYPE.cboard.filename
+        prefix + EXPORT_CONFIG_BY_TYPE.cboard.filename,
       );
     } else {
       // In FF link must be added to DOM to be clicked
@@ -882,7 +882,7 @@ export async function cboardExportAdapter(allBoards = [], board) {
       link.href = window.URL.createObjectURL(jsonData);
       link.setAttribute(
         'download',
-        prefix + EXPORT_CONFIG_BY_TYPE.cboard.filename
+        prefix + EXPORT_CONFIG_BY_TYPE.cboard.filename,
       );
       document.body.appendChild(link);
       link.click();
@@ -895,7 +895,7 @@ export async function pdfExportAdapter(
   boards = [],
   labelFontSize,
   intl,
-  picsee = false
+  picsee = false,
 ) {
   const font = definePDFfont(intl);
   const docDefinition = {
@@ -904,11 +904,11 @@ export async function pdfExportAdapter(
     pageMargins: [20, 20],
     content: [],
     defaultStyle: {
-      font: font
-    }
+      font: font,
+    },
   };
   if (picsee) {
-    docDefinition.background = function() {
+    docDefinition.background = function () {
       return {
         stack: [
           {
@@ -917,9 +917,9 @@ export async function pdfExportAdapter(
               {
                 text: '\nPicseePal compatible PDF',
                 fontSize: 18,
-                alignment: 'center'
-              }
-            ]
+                alignment: 'center',
+              },
+            ],
           },
           {
             absolutePosition: { x: 0, y: 48 },
@@ -932,7 +932,7 @@ export async function pdfExportAdapter(
                 w: 567,
                 h: 374.22,
                 r: 5,
-                lineColor: 'black'
+                lineColor: 'black',
               },
               {
                 // dashed line rectangle to cut
@@ -943,25 +943,25 @@ export async function pdfExportAdapter(
                 h: 447,
                 r: 55,
                 dash: { length: 5 },
-                lineColor: 'black'
-              }
-            ]
+                lineColor: 'black',
+              },
+            ],
           },
           {
             absolutePosition: {
               x: 0,
-              y: 500
+              y: 500,
             },
             text: [
               {
                 text: `\nPlease print on A4 / US Letter paper at 100% scale.
                           Cut along dashed line before inserting into PicseePal device.`,
                 fontSize: 15,
-                alignment: 'center'
-              }
-            ]
-          }
-        ]
+                alignment: 'center',
+              },
+            ],
+          },
+        ],
       };
     };
 
@@ -976,7 +976,7 @@ export async function pdfExportAdapter(
       intl,
       breakPage,
       picsee,
-      labelFontSize
+      labelFontSize,
     );
     return prevContent.concat(boardPDFData);
   }, Promise.resolve([]));
@@ -993,8 +993,8 @@ export async function pdfExportAdapter(
     }
     if (isAndroid() || isIOS()) {
       requestCvaWritePermissions();
-      const getBuffer = callback => {
-        pdfObj.getBuffer(buffer => {
+      const getBuffer = (callback) => {
+        pdfObj.getBuffer((buffer) => {
           var blob = new Blob([buffer], { type: 'application/pdf' });
           const name =
             'Download/' + prefix + EXPORT_CONFIG_BY_TYPE.pdf.filename;
@@ -1005,7 +1005,7 @@ export async function pdfExportAdapter(
       await generatePDF(getBuffer);
     } else {
       // On a browser simply use download!
-      const dowloadPDF = callback =>
+      const dowloadPDF = (callback) =>
         pdfObj.download(prefix + EXPORT_CONFIG_BY_TYPE.pdf.filename, callback);
       await generatePDF(dowloadPDF);
     }
@@ -1073,7 +1073,7 @@ function definePDFfont(intl) {
 const exportHelpers = {
   openboardExportAdapter,
   cboardExportAdapter,
-  pdfExportAdapter
+  pdfExportAdapter,
 };
 
 export default exportHelpers;

--- a/src/components/Settings/Export/Export.helpers.js
+++ b/src/components/Settings/Export/Export.helpers.js
@@ -143,21 +143,24 @@ async function boardToOBF(boardsMap, board = {}, intl, { embed = false }) {
   if (!board.tiles || board.tiles.length < 1) {
     return { obf: null, images: null };
   }
+  const columns =
+    board.isFixed && board.grid ? board.grid.columns : CBOARD_COLUMNS;
 
   const images = {};
   const fetchedImages = {};
-  const grid = new Array(Math.ceil(board.tiles.length / CBOARD_COLUMNS));
+  const grid = board.isFixed
+    ? board.grid.order
+    : new Array(Math.ceil(board.tiles.length / columns));
   let currentRow = 0;
   const buttons = await Promise.all(
     board.tiles.map(async (tile, i) => {
       currentRow =
-        i >= (currentRow + 1) * CBOARD_COLUMNS ? currentRow + 1 : currentRow;
+        i >= (currentRow + 1) * columns ? currentRow + 1 : currentRow;
 
       if (tile) {
-        if (grid[currentRow]) {
+        if (!board.isFixed) {
+          grid[currentRow] = grid[currentRow] || [];
           grid[currentRow].push(tile.id);
-        } else {
-          grid[currentRow] = [tile.id];
         }
 
         const button = {
@@ -227,7 +230,7 @@ async function boardToOBF(boardsMap, board = {}, intl, { embed = false }) {
   );
 
   if (grid.length >= 1) {
-    const lastGridRowDiff = CBOARD_COLUMNS - grid[grid.length - 1].length;
+    const lastGridRowDiff = columns - grid[grid.length - 1].length;
     if (lastGridRowDiff > 0) {
       const emptyButtons = new Array(lastGridRowDiff).map(() => null);
       grid[grid.length - 1] = grid[grid.length - 1].concat(emptyButtons);
@@ -245,7 +248,7 @@ async function boardToOBF(boardsMap, board = {}, intl, { embed = false }) {
       sounds: [],
       grid: {
         rows: grid.length,
-        columns: CBOARD_COLUMNS,
+        columns: columns,
         order: grid
       },
       description_html: board.nameKey

--- a/src/components/Settings/Export/Export.helpers.js
+++ b/src/components/Settings/Export/Export.helpers.js
@@ -22,18 +22,18 @@ import {
   PICSEEPAL_IMAGES_WIDTH,
   PDF_IMAGES_WIDTH,
   SMALL_FONT_SIZE,
-  LARGE_FONT_SIZE,
+  LARGE_FONT_SIZE
 } from './Export.constants';
 import {
   LABEL_POSITION_ABOVE,
-  LABEL_POSITION_BELOW,
+  LABEL_POSITION_BELOW
 } from '../Display/Display.constants';
 import {
   isAndroid,
   isCordova,
   isIOS,
   requestCvaWritePermissions,
-  writeCvaFile,
+  writeCvaFile
 } from '../../../cordova-util';
 import { getStore } from '../../../store';
 import * as _ from 'lodash';
@@ -46,15 +46,15 @@ pdfMake.vfs = pdfFonts.pdfMake.vfs;
 const imageElement = new Image();
 
 function toSnakeCase(str) {
-  const value = str.replace(/([A-Z])/g, ($1) => '_' + $1.toLowerCase());
+  const value = str.replace(/([A-Z])/g, $1 => '_' + $1.toLowerCase());
   return value.startsWith('_') ? value.slice(1) : value;
 }
 
 function getOBFButtonProps(tile = {}, intl) {
   const button = {};
 
-  const tileExtProps = CBOARD_EXT_PROPERTIES.filter((key) => !!tile[key]);
-  tileExtProps.forEach((key) => {
+  const tileExtProps = CBOARD_EXT_PROPERTIES.filter(key => !!tile[key]);
+  tileExtProps.forEach(key => {
     const keyWithPrefix = `${CBOARD_EXT_PREFIX}${toSnakeCase(key)}`;
     button[keyWithPrefix] = tile[key];
   });
@@ -96,7 +96,7 @@ function getBase64Image(base64Str = '') {
   return {
     ab,
     data: base64Str,
-    content_type: contentType,
+    content_type: contentType
   };
 }
 
@@ -105,22 +105,22 @@ export async function getDataUri(url) {
     const result = await axios({
       method: 'get',
       url,
-      responseType: 'arraybuffer',
+      responseType: 'arraybuffer'
     });
 
     // Convert the array buffer to a Base64-encoded string.
     const encodedImage = btoa(
       new Uint8Array(result.data).reduce(
         (data, byte) => data + String.fromCharCode(byte),
-        '',
-      ),
+        ''
+      )
     );
     const contentType = result.headers['content-type'];
 
     return {
       ab: result.data,
       content_type: contentType,
-      data: `data:${contentType};base64,${encodedImage}`,
+      data: `data:${contentType};base64,${encodedImage}`
     };
   } catch (e) {
     console.error(`Failed to get image at ${url}.`, e);
@@ -149,7 +149,7 @@ async function boardToOBF(boardsMap, board = {}, intl, { embed = false }) {
   const images = {};
   const fetchedImages = {};
   const grid =
-    board.isFixed && board.grid?.order
+    board.isFixed && board.grid && board.grid.order
       ? board.grid.order
       : new Array(Math.ceil(board.tiles.length / columns));
   let currentRow = 0;
@@ -165,7 +165,7 @@ async function boardToOBF(boardsMap, board = {}, intl, { embed = false }) {
 
         const button = {
           id: tile.id,
-          ...getOBFButtonProps(tile, intl),
+          ...getOBFButtonProps(tile, intl)
         };
 
         if (tile.image && tile.image.length) {
@@ -183,7 +183,7 @@ async function boardToOBF(boardsMap, board = {}, intl, { embed = false }) {
             const components = [
               'custom',
               board.name || board.nameKey,
-              tile.label || tile.labelKey || tile.id,
+              tile.label || tile.labelKey || tile.id
             ];
             const extension = mime.extension(imageResponse['content_type']);
             return `/${_.join(components, '/')}.${extension}`;
@@ -192,10 +192,10 @@ async function boardToOBF(boardsMap, board = {}, intl, { embed = false }) {
           const path = image.startsWith('data:')
             ? getCustomImagePath()
             : isCordova()
-              ? ''
-              : image.startsWith('/')
-                ? image
-                : `/${image}`;
+            ? ''
+            : image.startsWith('/')
+            ? image
+            : `/${image}`;
 
           if (imageResponse) {
             const imageID = new mongoose.Types.ObjectId().toString();
@@ -209,7 +209,7 @@ async function boardToOBF(boardsMap, board = {}, intl, { embed = false }) {
               data: embed ? imageResponse.data : undefined,
               content_type: imageResponse['content_type'],
               width: 300,
-              height: 300,
+              height: 300
             };
           }
         }
@@ -220,13 +220,13 @@ async function boardToOBF(boardsMap, board = {}, intl, { embed = false }) {
             name: loadBoardData.nameKey
               ? intl.formatMessage({ id: loadBoardData.nameKey })
               : '',
-            path: `boards/${tile.loadBoard}.obf`,
+            path: `boards/${tile.loadBoard}.obf`
           };
         }
 
         return button;
       }
-    }),
+    })
   );
 
   if (grid.length >= 1 && Array.isArray(grid[grid.length - 1])) {
@@ -249,17 +249,17 @@ async function boardToOBF(boardsMap, board = {}, intl, { embed = false }) {
       grid: {
         rows: grid.length,
         columns: columns,
-        order: grid,
+        order: grid
       },
       description_html: board.nameKey
         ? intl.formatMessage({ id: board.nameKey })
-        : '',
+        : ''
     };
 
     const boardExtProps = CBOARD_EXT_PROPERTIES.filter(
-      (key) => typeof board[key] !== 'undefined',
+      key => typeof board[key] !== 'undefined'
     );
-    boardExtProps.forEach((key) => {
+    boardExtProps.forEach(key => {
       const keyWithPrefix = `${CBOARD_EXT_PREFIX}${toSnakeCase(key)}`;
       obf[keyWithPrefix] = board[key];
     });
@@ -275,14 +275,14 @@ function getPDFTileData(tile, intl) {
   return {
     label: label.length ? intl.formatMessage({ id: label }) : label,
     image: tile.image || '',
-    backgroundColor: tile.backgroundColor || '',
+    backgroundColor: tile.backgroundColor || ''
   };
 }
 
 async function toDataURL(url, styles = {}, outputFormat = 'image/jpeg') {
   return new Promise((resolve, reject) => {
     imageElement.crossOrigin = 'Anonymous';
-    imageElement.onload = function () {
+    imageElement.onload = function() {
       const canvas = document.createElement('CANVAS');
       const ctx = canvas.getContext('2d');
       const backgroundColor =
@@ -315,7 +315,7 @@ async function toDataURL(url, styles = {}, outputFormat = 'image/jpeg') {
         0,
         0,
         this.naturalWidth * widthFix,
-        this.naturalHeight * heightFix,
+        this.naturalHeight * heightFix
       );
 
       if (borderColor) {
@@ -326,7 +326,7 @@ async function toDataURL(url, styles = {}, outputFormat = 'image/jpeg') {
       const dataURL = canvas.toDataURL(outputFormat);
       resolve(dataURL);
     };
-    imageElement.onerror = function () {
+    imageElement.onerror = function() {
       reject(new Error('Getting remote image failed'));
     };
     // Cordova path cannot be absolute
@@ -349,25 +349,25 @@ async function toDataURL(url, styles = {}, outputFormat = 'image/jpeg') {
 
 pdfMake.tableLayouts = {
   pdfGridLayout: {
-    hLineWidth: function (i, node) {
+    hLineWidth: function(i, node) {
       return PDF_BORDER_WIDTH;
     },
-    vLineWidth: function (i) {
+    vLineWidth: function(i) {
       return PDF_BORDER_WIDTH;
     },
-    hLineColor: function (i) {
+    hLineColor: function(i) {
       return '#ffffff';
     },
-    vLineColor: function (i) {
+    vLineColor: function(i) {
       return '#ffffff';
     },
-    paddingLeft: function (i) {
+    paddingLeft: function(i) {
       return 0;
     },
-    paddingRight: function (i, node) {
+    paddingRight: function(i, node) {
       return 0;
-    },
-  },
+    }
+  }
 };
 
 function getCellWidths(columns, picsee = false) {
@@ -382,13 +382,13 @@ async function generatePDFBoard(
   intl,
   breakPage = true,
   picsee = false,
-  labelFontSize,
+  labelFontSize
 ) {
   const header = {
     absolutePosition: { x: 0, y: 5 },
     text: board.name || '',
     alignment: 'center',
-    fontSize: 8,
+    fontSize: 8
   };
 
   const columns =
@@ -400,9 +400,9 @@ async function generatePDFBoard(
   const table = {
     table: {
       widths: cellWidths,
-      body: [{}],
+      body: [{}]
     },
-    layout: 'pdfGridLayout',
+    layout: 'pdfGridLayout'
   };
 
   if (breakPage) {
@@ -420,7 +420,7 @@ async function generatePDFBoard(
         columns,
         intl,
         picsee,
-        labelFontSize,
+        labelFontSize
       )
     : await generateNonFixedBoard(
         board,
@@ -428,7 +428,7 @@ async function generatePDFBoard(
         columns,
         intl,
         picsee,
-        labelFontSize,
+        labelFontSize
       );
 
   const lastGridRowDiff = columns - grid[grid.length - 2].length; // labels row
@@ -460,7 +460,7 @@ async function generateFixedBoard(
   columns,
   intl,
   picsee = false,
-  labelFontSize,
+  labelFontSize
 ) {
   let currentRow = 0;
   let cont = 0;
@@ -469,7 +469,7 @@ async function generateFixedBoard(
     label: '',
     labelKey: '',
     image: '',
-    backgroundColor: '#d9d9d9',
+    backgroundColor: '#d9d9d9'
   };
 
   const itemsPerPage = rows * columns;
@@ -482,7 +482,7 @@ async function generateFixedBoard(
       columns,
       rows,
       order: board.grid.order,
-      items,
+      items
     });
     for (let rowIndex = 0; rowIndex < order.length; rowIndex++) {
       for (
@@ -491,7 +491,7 @@ async function generateFixedBoard(
         columnIndex++
       ) {
         const tileId = order[rowIndex][columnIndex];
-        let tile = board.tiles.find((tile) => tile.id === tileId);
+        let tile = board.tiles.find(tile => tile.id === tileId);
         if (tile === undefined) {
           tile = defaultTile;
         }
@@ -517,7 +517,7 @@ async function generateFixedBoard(
           currentRow,
           pageBreak,
           picsee,
-          labelFontSize,
+          labelFontSize
         );
         cont++;
       }
@@ -532,7 +532,7 @@ async function generateNonFixedBoard(
   columns,
   intl,
   picsee = false,
-  labelFontSize,
+  labelFontSize
 ) {
   // Do a grid with 2n rows
   const grid = new Array(Math.ceil(board.tiles.length / columns) * 2);
@@ -563,7 +563,7 @@ async function generateNonFixedBoard(
       currentRow,
       pageBreak,
       picsee,
-      labelFontSize,
+      labelFontSize
     );
   }, Promise.resolve());
   return grid;
@@ -578,7 +578,7 @@ const addTileToGrid = async (
   currentRow,
   pageBreak = false,
   picsee = false,
-  labelFontSize,
+  labelFontSize
 ) => {
   const { label, image } = getPDFTileData(tile, intl);
   const fixedRow = currentRow * 2;
@@ -605,13 +605,13 @@ const addTileToGrid = async (
     }
   }
 
-  const rgbToHex = (rgbBackgroundColor) => {
+  const rgbToHex = rgbBackgroundColor => {
     return (
       '#' +
       rgbBackgroundColor
         .slice(4, -1)
         .split(',')
-        .map((x) => (+x).toString(16).padStart(2, 0))
+        .map(x => (+x).toString(16).padStart(2, 0))
         .join('')
     );
   };
@@ -630,7 +630,7 @@ const addTileToGrid = async (
     alignment: 'center',
     width: '100',
     fillColor: hexBackgroundColor,
-    border: PDF_GRID_BORDER[labelPosition].imageData,
+    border: PDF_GRID_BORDER[labelPosition].imageData
   };
 
   const labelData = {
@@ -638,7 +638,7 @@ const addTileToGrid = async (
     alignment: 'center',
     fontSize: labelFontSize,
     fillColor: hexBackgroundColor,
-    border: PDF_GRID_BORDER[labelPosition].labelData,
+    border: PDF_GRID_BORDER[labelPosition].labelData
   };
 
   const IMG_WIDTH = picsee ? PICSEEPAL_IMAGES_WIDTH : PDF_IMAGES_WIDTH;
@@ -693,7 +693,7 @@ const addTileToGrid = async (
 const getDisplaySettings = () => {
   const store = getStore();
   const {
-    app: { displaySettings },
+    app: { displaySettings }
   } = store.getState();
 
   return displaySettings;
@@ -721,10 +721,10 @@ export async function openboardExportAdapter(boardOrBoards, intl) {
 
 export async function openboardExportOneAdapter(board, intl) {
   const { obf } = await boardToOBF({ [board.id]: board }, board, intl, {
-    embed: true,
+    embed: true
   });
   const content = new Blob([JSON.stringify(obf, null, 2)], {
-    type: 'application/json',
+    type: 'application/json'
   });
 
   if (content) {
@@ -754,7 +754,7 @@ export async function openboardExportManyAdapter(boards = [], intl) {
     const board = boards[i];
     const boardMapFilename = `boards/${board.id}.obf`;
     const { obf, images } = await boardToOBF(boardsMap, board, intl, {
-      embed: false,
+      embed: false
     });
 
     if (!obf) {
@@ -764,7 +764,7 @@ export async function openboardExportManyAdapter(boards = [], intl) {
     zip.file(boardMapFilename, JSON.stringify(obf, null, 2));
 
     const imagesKeys = Object.keys(images);
-    imagesKeys.forEach((key) => {
+    imagesKeys.forEach(key => {
       const image = images[key];
       const imageFilename = `images/${image.path}`;
       zip.file(imageFilename, image.ab);
@@ -783,13 +783,13 @@ export async function openboardExportManyAdapter(boards = [], intl) {
     root,
     paths: {
       boards: boardsForManifest,
-      images: imagesMap,
-    },
+      images: imagesMap
+    }
   };
 
   zip.file('manifest.json', JSON.stringify(manifest, null, 2));
 
-  zip.generateAsync(CBOARD_ZIP_OPTIONS).then((content) => {
+  zip.generateAsync(CBOARD_ZIP_OPTIONS).then(content => {
     if (content) {
       let prefix = getDatetimePrefix();
       if (boards.length === 1) {
@@ -826,7 +826,7 @@ export async function openboardExportManyAdapter(boards = [], intl) {
  * @returns {Array<Object>} The board and its subfolders.
  */
 function getNestedBoards(allBoards, rootBoardId) {
-  const boardsMap = _.fromPairs(_.map(allBoards, (b) => [b.id, b]));
+  const boardsMap = _.fromPairs(_.map(allBoards, b => [b.id, b]));
 
   const unseen = [rootBoardId];
   const nestedBoardIds = [rootBoardId];
@@ -834,7 +834,7 @@ function getNestedBoards(allBoards, rootBoardId) {
   while (!_.isEmpty(unseen)) {
     const curr = unseen.pop();
     const tiles = _.get(boardsMap[curr], 'tiles');
-    _.forEach(tiles, (tile) => {
+    _.forEach(tiles, tile => {
       const id = tile.loadBoard;
       // The second check is necessary to handle cycles (for example,
       // A -> B -> A).
@@ -845,14 +845,14 @@ function getNestedBoards(allBoards, rootBoardId) {
     });
   }
 
-  return _.map(nestedBoardIds, (id) => boardsMap[id]);
+  return _.map(nestedBoardIds, id => boardsMap[id]);
 }
 
 export async function cboardExportAdapter(allBoards = [], board) {
   const boards = board ? getNestedBoards(allBoards, board.id) : allBoards;
 
   const jsonData = new Blob([JSON.stringify(boards)], {
-    type: 'text/json;charset=utf-8;',
+    type: 'text/json;charset=utf-8;'
   });
 
   if (jsonData) {
@@ -865,7 +865,7 @@ export async function cboardExportAdapter(allBoards = [], board) {
     if (isAndroid() || isIOS()) {
       requestCvaWritePermissions();
       const name = 'Download/' + prefix + EXPORT_CONFIG_BY_TYPE.cboard.filename;
-      writeCvaFile(name, jsonData).catch((error) => {
+      writeCvaFile(name, jsonData).catch(error => {
         console.error(error);
       });
     }
@@ -874,7 +874,7 @@ export async function cboardExportAdapter(allBoards = [], board) {
     if (navigator.msSaveBlob) {
       navigator.msSaveBlob(
         jsonData,
-        prefix + EXPORT_CONFIG_BY_TYPE.cboard.filename,
+        prefix + EXPORT_CONFIG_BY_TYPE.cboard.filename
       );
     } else {
       // In FF link must be added to DOM to be clicked
@@ -882,7 +882,7 @@ export async function cboardExportAdapter(allBoards = [], board) {
       link.href = window.URL.createObjectURL(jsonData);
       link.setAttribute(
         'download',
-        prefix + EXPORT_CONFIG_BY_TYPE.cboard.filename,
+        prefix + EXPORT_CONFIG_BY_TYPE.cboard.filename
       );
       document.body.appendChild(link);
       link.click();
@@ -895,7 +895,7 @@ export async function pdfExportAdapter(
   boards = [],
   labelFontSize,
   intl,
-  picsee = false,
+  picsee = false
 ) {
   const font = definePDFfont(intl);
   const docDefinition = {
@@ -904,11 +904,11 @@ export async function pdfExportAdapter(
     pageMargins: [20, 20],
     content: [],
     defaultStyle: {
-      font: font,
-    },
+      font: font
+    }
   };
   if (picsee) {
-    docDefinition.background = function () {
+    docDefinition.background = function() {
       return {
         stack: [
           {
@@ -917,9 +917,9 @@ export async function pdfExportAdapter(
               {
                 text: '\nPicseePal compatible PDF',
                 fontSize: 18,
-                alignment: 'center',
-              },
-            ],
+                alignment: 'center'
+              }
+            ]
           },
           {
             absolutePosition: { x: 0, y: 48 },
@@ -932,7 +932,7 @@ export async function pdfExportAdapter(
                 w: 567,
                 h: 374.22,
                 r: 5,
-                lineColor: 'black',
+                lineColor: 'black'
               },
               {
                 // dashed line rectangle to cut
@@ -943,25 +943,25 @@ export async function pdfExportAdapter(
                 h: 447,
                 r: 55,
                 dash: { length: 5 },
-                lineColor: 'black',
-              },
-            ],
+                lineColor: 'black'
+              }
+            ]
           },
           {
             absolutePosition: {
               x: 0,
-              y: 500,
+              y: 500
             },
             text: [
               {
                 text: `\nPlease print on A4 / US Letter paper at 100% scale.
                           Cut along dashed line before inserting into PicseePal device.`,
                 fontSize: 15,
-                alignment: 'center',
-              },
-            ],
-          },
-        ],
+                alignment: 'center'
+              }
+            ]
+          }
+        ]
       };
     };
 
@@ -976,7 +976,7 @@ export async function pdfExportAdapter(
       intl,
       breakPage,
       picsee,
-      labelFontSize,
+      labelFontSize
     );
     return prevContent.concat(boardPDFData);
   }, Promise.resolve([]));
@@ -993,8 +993,8 @@ export async function pdfExportAdapter(
     }
     if (isAndroid() || isIOS()) {
       requestCvaWritePermissions();
-      const getBuffer = (callback) => {
-        pdfObj.getBuffer((buffer) => {
+      const getBuffer = callback => {
+        pdfObj.getBuffer(buffer => {
           var blob = new Blob([buffer], { type: 'application/pdf' });
           const name =
             'Download/' + prefix + EXPORT_CONFIG_BY_TYPE.pdf.filename;
@@ -1005,7 +1005,7 @@ export async function pdfExportAdapter(
       await generatePDF(getBuffer);
     } else {
       // On a browser simply use download!
-      const dowloadPDF = (callback) =>
+      const dowloadPDF = callback =>
         pdfObj.download(prefix + EXPORT_CONFIG_BY_TYPE.pdf.filename, callback);
       await generatePDF(dowloadPDF);
     }
@@ -1073,7 +1073,7 @@ function definePDFfont(intl) {
 const exportHelpers = {
   openboardExportAdapter,
   cboardExportAdapter,
-  pdfExportAdapter,
+  pdfExportAdapter
 };
 
 export default exportHelpers;


### PR DESCRIPTION
Improve the safety and code quality of the OBF export functionality for fixed boards on PR #2053

 **Changes Made**
1. Improved Null Safety with Optional Chaining
2. Added Grid Array Validation
3. Optimized currentRow Calculation

**Testing**
Tested by:
1. Creating a fixed board with custom grid size (e.g., 3×4)
2. Exporting to OBF format
3. Verifying the exported file contains correct grid dimensions
5. Re-importing and confirming grid size is preserved

Fixes #2053
Closes #1772
