### PR TITLE
feat: add configurable delay between repeat tile selection (#1326)

### DIFF
--- a/src/components/App/App.reducer.js
+++ b/src/components/App/App.reducer.js
@@ -54,7 +54,9 @@ const initialState = {
     vocalizeFolders: false,
     quietBuilderMode: false,
     liveMode: false,
-    improvePhraseActive: false
+    improvePhraseActive: false,
+    tileCooldownEnabled: false,
+    tileCooldownMs: 2000
   },
   symbolsSettings: {
     arasaacActive: false

--- a/src/components/App/__tests__/App.reducer.test.js
+++ b/src/components/App/__tests__/App.reducer.test.js
@@ -49,7 +49,9 @@ describe('reducer', () => {
         removeOutputActive: false,
         vocalizeFolders: false,
         quietBuilderMode: false,
-        improvePhraseActive: false
+        improvePhraseActive: false,
+        tileCooldownEnabled: false,
+        tileCooldownMs: 2000
       },
       symbolsSettings: {
         arasaacActive: false
@@ -80,7 +82,9 @@ describe('reducer', () => {
         removeOutputActive: false,
         vocalizeFolders: false,
         quietBuilderMode: false,
-        improvePhraseActive: false
+        improvePhraseActive: false,
+        tileCooldownEnabled: false,
+        tileCooldownMs: 2000
       },
       userData: uData
     };

--- a/src/components/Board/Board.component.js
+++ b/src/components/Board/Board.component.js
@@ -222,6 +222,10 @@ export class Board extends Component {
             onFocus={() => {
               this.handleTileFocus(tile.id);
             }}
+            tileCooldownEnabled={
+              this.props.navigationSettings.tileCooldownEnabled
+            }
+            tileCooldownMs={this.props.navigationSettings.tileCooldownMs}
           >
             <Symbol
               image={tile.image}
@@ -270,6 +274,8 @@ export class Board extends Component {
         onFocus={() => {
           this.handleTileFocus(tile.id);
         }}
+        tileCooldownEnabled={this.props.navigationSettings.tileCooldownEnabled}
+        tileCooldownMs={this.props.navigationSettings.tileCooldownMs}
         id={tile.id}
       >
         <Symbol

--- a/src/components/Settings/Navigation/Navigation.component.js
+++ b/src/components/Settings/Navigation/Navigation.component.js
@@ -92,6 +92,18 @@ class Navigation extends React.Component {
       improvePhraseActive: !this.state.improvePhraseActive
     });
   };
+  toggleTileCooldown = () => {
+    this.setState(prev => ({
+      tileCooldownEnabled: !this.state.tileCooldownEnabled
+    }));
+  };
+
+  setTileCooldownSeconds = event => {
+    const seconds = Number(event.target.value);
+    this.setState({
+      tileCooldownMs: seconds * 1000
+    });
+  };
 
   onSubmit = () => {
     const { isLiveMode, changeLiveMode } = this.props;
@@ -264,6 +276,48 @@ class Navigation extends React.Component {
                   />
                 </ListItemSecondaryAction>
               </ListItem>
+              <Divider />
+              <ListItem>
+                <ListItemText
+                  className="Navigation__ListItemText"
+                  primary={<FormattedMessage {...messages.tileCooldown} />}
+                  secondary={
+                    <FormattedMessage {...messages.tileCooldownSecondary} />
+                  }
+                />
+                <ListItemSecondaryAction>
+                  <Switch
+                    checked={this.state.tileCooldownEnabled}
+                    onChange={this.toggleTileCooldown}
+                    value="active"
+                    color="secondary"
+                  />
+                </ListItemSecondaryAction>
+              </ListItem>
+
+              {this.state.tileCooldownEnabled && (
+                <ListItem>
+                  <ListItemText
+                    className="Navigation__ListItemText"
+                    primary={
+                      <FormattedMessage {...messages.tileCooldownDuration} />
+                    }
+                    secondary={null}
+                  />
+                  <ListItemSecondaryAction className="Display__Options">
+                    <Select
+                      value={this.state.tileCooldownMs / 1000}
+                      onChange={this.setTileCooldownSeconds}
+                    >
+                      <MenuItem value={1}>1 second</MenuItem>
+                      <MenuItem value={2}>2 seconds</MenuItem>
+                      <MenuItem value={3}>3 seconds</MenuItem>
+                      <MenuItem value={4}>4 seconds</MenuItem>
+                      <MenuItem value={5}>5 seconds</MenuItem>
+                    </Select>
+                  </ListItemSecondaryAction>
+                </ListItem>
+              )}
               <Divider />
               <ListItem>
                 <ListItemText

--- a/src/components/Settings/Navigation/Navigation.messages.js
+++ b/src/components/Settings/Navigation/Navigation.messages.js
@@ -99,5 +99,18 @@ export default defineMessages({
   onTop: {
     id: 'cboard.components.Settings.Navigation.onTop',
     defaultMessage: 'On top'
+  },
+  tileCooldown: {
+    id: 'settings.tileCooldown',
+    defaultMessage: 'Prevent rapid re-selecting the same tile'
+  },
+  tileCooldownSecondary: {
+    id: 'settings.tileCooldownSecondary',
+    defaultMessage:
+      'Disables clicking the same tile repeatedly for a short period'
+  },
+  tileCooldownDuration: {
+    id: 'settings.tileCooldownDuration',
+    defaultMessage: 'Cooldown duration'
   }
 });


### PR DESCRIPTION
## Summary
Adds an optional tile selection cooldown to prevent rapid repeated activation of the same tile.

## Changes
- Added tile selection cooldown settings under Navigation and Buttons
- New toggle to enable/disable cooldown
- Configurable cooldown duration (1–5 seconds)
- Default behavior remains unchanged (cooldown disabled)

## Implementation Details
- Cooldown state is stored in navigation settings
- Tile selection logic uses a timestamp ref to prevent activation during the cooldown window

## Screenshots
**Navigation and Buttons Settings Menu**
- New toggle to enable tile selection cooldown
- Duration dropdown shown when enabled (1-5 Sec)

<img width="1909" height="961" alt="Screenshot 1" src="https://github.com/user-attachments/assets/9660b32f-df43-4770-8f22-0ef480471ffe" />
<img width="1919" height="955" alt="Screenshot 2" src="https://github.com/user-attachments/assets/a3f403ef-28f3-477a-a219-63bb99835f10" />
<img width="1919" height="958" alt="Screenshot 3" src="https://github.com/user-attachments/assets/dc4c42c3-0187-4f38-ae08-1d14b2752020" />
