### PR TITLE
Add login comprobation on isSubscriptionRequired

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -28,6 +28,7 @@ export const AZURE_VOICES_BASE_PATH_API =
 
 // AdSense constants
 export const NODE_ENV = process.env.NODE_ENV;
+export const IS_PRODUCTION = NODE_ENV === 'production';
 const HOSTNAME = window.location.hostname;
 export const ADSENSE_ON_PRODUCTION =
   HOSTNAME === 'app.cboard.io' && NODE_ENV === 'production';

--- a/src/providers/SubscriptionProvider/SubscriptionProvider.actions.js
+++ b/src/providers/SubscriptionProvider/SubscriptionProvider.actions.js
@@ -22,6 +22,7 @@ import { isLogged } from '../../components/App/App.selectors';
 import { isAndroid, isIOS } from '../../cordova-util';
 import { formatTitle } from '../../components/Settings/Subscribe/Subscribe.helpers';
 import { updateNavigationSettings } from '../../components/App/App.actions';
+import { IS_PRODUCTION } from '../../constants';
 
 export function updateIsInFreeCountry() {
   return (dispatch, getState) => {
@@ -29,7 +30,9 @@ export function updateIsInFreeCountry() {
     const locationCode = isLogged(state)
       ? state.app.userData?.location?.countryCode
       : state.app.unloggedUserLocation?.countryCode;
-    const isInFreeCountry = !REQUIRING_PREMIUM_COUNTRIES.includes(locationCode);
+    const isInFreeCountry = locationCode
+      ? !REQUIRING_PREMIUM_COUNTRIES.includes(locationCode)
+      : !IS_PRODUCTION;
     dispatch(
       updateSubscription({
         isInFreeCountry

--- a/src/providers/SubscriptionProvider/SubscriptionProvider.selectors.js
+++ b/src/providers/SubscriptionProvider/SubscriptionProvider.selectors.js
@@ -1,4 +1,10 @@
+import { isLogged } from '../../components/App/App.selectors';
+
 export const isSubscriptionRequired = state => {
+  if (!isLogged(state)) {
+    return false;
+  }
+
   const { isInFreeCountry, isSubscribed, isOnTrialPeriod } = state.subscription;
   return !isInFreeCountry && !isSubscribed && !isOnTrialPeriod;
 };


### PR DESCRIPTION
Introduce an `IS_PRODUCTION` constant to streamline the logic for determining if a user is in a free country. Refactor the subscription requirement check to return early if the user is not logged in.