### PR TITLE
Add UPDATE_BOARDS_AFTER_RECONCILE action and improve board synchronization

### DIFF
--- a/src/components/Board/Board.actions.js
+++ b/src/components/Board/Board.actions.js
@@ -45,7 +45,8 @@ import {
   SHORT_ID_MAX_LENGTH,
   SYNC_BOARDS_STARTED,
   SYNC_BOARDS_SUCCESS,
-  SYNC_BOARDS_FAILURE
+  SYNC_BOARDS_FAILURE,
+  UPDATE_BOARDS_AFTER_RECONCILE
 } from './Board.constants';
 
 import API from '../../api';
@@ -614,12 +615,16 @@ export function syncBoardsStarted() {
   return { type: SYNC_BOARDS_STARTED };
 }
 
-export function syncBoardsSuccess(boards) {
-  return { type: SYNC_BOARDS_SUCCESS, boards };
+export function syncBoardsSuccess() {
+  return { type: SYNC_BOARDS_SUCCESS };
 }
 
 export function syncBoardsFailure(error) {
   return { type: SYNC_BOARDS_FAILURE, error: error.message || error };
+}
+
+export function updateBoardsAfterReconcile(boards) {
+  return { type: UPDATE_BOARDS_AFTER_RECONCILE, boards };
 }
 
 /**
@@ -646,7 +651,7 @@ export function mergeRemoteBoards(remoteBoards) {
       }
     }
 
-    dispatch(syncBoardsSuccess(mergedBoards));
+    dispatch(updateBoardsAfterReconcile(mergedBoards));
     return mergedBoards;
   };
 }

--- a/src/components/Board/Board.constants.js
+++ b/src/components/Board/Board.constants.js
@@ -44,6 +44,8 @@ export const DOWNLOAD_IMAGE_FAILURE = 'cboard/Board/DOWNLOAD_IMAGE_FAILURE';
 export const SYNC_BOARDS_STARTED = 'cboard/Board/SYNC_BOARDS_STARTED';
 export const SYNC_BOARDS_SUCCESS = 'cboard/Board/SYNC_BOARDS_SUCCESS';
 export const SYNC_BOARDS_FAILURE = 'cboard/Board/SYNC_BOARDS_FAILURE';
+export const UPDATE_BOARDS_AFTER_RECONCILE =
+  'cboard/Board/UPDATE_BOARDS_AFTER_RECONCILE';
 export const DEFAULT_ROWS_NUMBER = 5;
 export const DEFAULT_COLUMNS_NUMBER = 5;
 export const SHORT_ID_MAX_LENGTH = 14;

--- a/src/components/Board/Board.reducer.js
+++ b/src/components/Board/Board.reducer.js
@@ -41,7 +41,8 @@ import {
   SHORT_ID_MAX_LENGTH,
   SYNC_BOARDS_STARTED,
   SYNC_BOARDS_SUCCESS,
-  SYNC_BOARDS_FAILURE
+  SYNC_BOARDS_FAILURE,
+  UPDATE_BOARDS_AFTER_RECONCILE
 } from './Board.constants';
 import { LOGOUT, LOGIN_SUCCESS } from '../Account/Login/Login.constants';
 
@@ -448,10 +449,14 @@ function boardReducer(state = initialState, action) {
         isSyncing: true,
         syncError: null
       };
+    case UPDATE_BOARDS_AFTER_RECONCILE:
+      return {
+        ...state,
+        boards: action.boards
+      };
     case SYNC_BOARDS_SUCCESS:
       return {
         ...state,
-        boards: action.boards,
         isSyncing: false,
         syncError: null
       };

--- a/src/components/Board/__tests__/Board.actions.test.js
+++ b/src/components/Board/__tests__/Board.actions.test.js
@@ -484,12 +484,10 @@ describe('syncBoardsStarted', () => {
 
 describe('syncBoardsSuccess', () => {
   it('should create an action to SYNC_BOARDS_SUCCESS', () => {
-    const boards = [{ id: '123' }];
     const expectedAction = {
-      type: types.SYNC_BOARDS_SUCCESS,
-      boards
+      type: types.SYNC_BOARDS_SUCCESS
     };
-    expect(actions.syncBoardsSuccess(boards)).toEqual(expectedAction);
+    expect(actions.syncBoardsSuccess()).toEqual(expectedAction);
   });
 });
 
@@ -545,11 +543,11 @@ describe('reconcileBoardsByTimestamp', () => {
   });
 });
 
-describe('mergeBoards', () => {
+describe('reconcileAndMergeBoards', () => {
   it('should add new remote boards to local', () => {
     const localBoards = [{ id: '1', name: 'Local Board' }];
     const remoteBoards = [{ id: '2', name: 'Remote Board' }];
-    const result = actions.mergeBoards(localBoards, remoteBoards);
+    const result = actions.reconcileAndMergeBoards(localBoards, remoteBoards);
 
     expect(result.mergedBoards).toHaveLength(2);
     expect(result.mergedBoards).toContainEqual({
@@ -570,7 +568,7 @@ describe('mergeBoards', () => {
     const remoteBoards = [
       { id: '1', name: 'Remote', lastEdited: '2024-01-02T00:00:00Z' }
     ];
-    const result = actions.mergeBoards(localBoards, remoteBoards);
+    const result = actions.reconcileAndMergeBoards(localBoards, remoteBoards);
 
     expect(result.mergedBoards).toHaveLength(1);
     expect(result.mergedBoards[0].name).toBe('Remote');
@@ -584,7 +582,7 @@ describe('mergeBoards', () => {
     const remoteBoards = [
       { id: '1', name: 'Remote', lastEdited: '2024-01-01T00:00:00Z' }
     ];
-    const result = actions.mergeBoards(localBoards, remoteBoards);
+    const result = actions.reconcileAndMergeBoards(localBoards, remoteBoards);
 
     expect(result.mergedBoards).toHaveLength(1);
     expect(result.mergedBoards[0].name).toBe('Local');
@@ -594,7 +592,7 @@ describe('mergeBoards', () => {
 });
 
 describe('getModifiedLocalBoards', () => {
-  it('should return modified boards that exist locally but not remotely', () => {
+  it('should return local-only boards that exist locally but not remotely', () => {
     const userEmail = 'user@example.com';
     const localBoards = [
       { id: 'short123', email: 'user@example.com' },
@@ -646,5 +644,16 @@ describe('getModifiedLocalBoards', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe('short123');
+  });
+});
+
+describe('updateBoardsAfterReconcile', () => {
+  it('should create an action to UPDATE_BOARDS_AFTER_RECONCILE', () => {
+    const boards = [{ id: '123' }];
+    const expectedAction = {
+      type: types.UPDATE_BOARDS_AFTER_RECONCILE,
+      boards
+    };
+    expect(actions.updateBoardsAfterReconcile(boards)).toEqual(expectedAction);
   });
 });

--- a/src/components/Board/__tests__/Board.reducer.test.js
+++ b/src/components/Board/__tests__/Board.reducer.test.js
@@ -574,14 +574,12 @@ describe('reducer', () => {
   });
   it('should handle syncBoardsSuccess', () => {
     const syncBoardsSuccess = {
-      type: SYNC_BOARDS_SUCCESS,
-      boards: [mockBoard]
+      type: SYNC_BOARDS_SUCCESS
     };
     expect(
       boardReducer({ ...initialState, isSyncing: true }, syncBoardsSuccess)
     ).toEqual({
       ...initialState,
-      boards: [mockBoard],
       isSyncing: false,
       syncError: null
     });


### PR DESCRIPTION
Introduce the `UPDATE_BOARDS_AFTER_RECONCILE` action to enhance board synchronization logic. Refactor function names for clarity and update related tests to reflect these changes.