### PR TITLE
Migrate storage from localStorage to IndexedDB using localForage

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "jszip": "^3.10.1",
     "jszip-utils": "^0.1.0",
     "keycode": "^2.2.1",
+    "localforage": "1.10.0",
     "lodash": "^4.17.21",
     "mathjs": "7.6.0",
     "microsoft-cognitiveservices-speech-sdk": "^1.43.0",

--- a/src/__test__/reducers.test.js
+++ b/src/__test__/reducers.test.js
@@ -1,7 +1,109 @@
-import createReducer from '../reducers';
+import createReducer, { createMigratingStorage } from '../reducers';
+
 describe('reducers', () => {
   it('should create Reducer', () => {
     const red = createReducer();
-    expect(red).toBeDefined;
+    expect(red).toBeDefined();
+  });
+});
+
+const createMockStorage = () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn()
+});
+
+describe('createMigratingStorage', () => {
+  let oldStorage, newStorage, storage;
+
+  beforeEach(() => {
+    oldStorage = createMockStorage();
+    newStorage = createMockStorage();
+    storage = createMigratingStorage(oldStorage, newStorage);
+  });
+
+  describe('getItem', () => {
+    it('returns value from new storage when it exists, without touching old storage', async () => {
+      newStorage.getItem.mockResolvedValue('new-data');
+
+      const result = await storage.getItem('persist:root');
+
+      expect(result).toBe('new-data');
+      expect(oldStorage.getItem).not.toHaveBeenCalled();
+      expect(oldStorage.removeItem).not.toHaveBeenCalled();
+    });
+
+    it('migrates from old to new storage when only old has the key', async () => {
+      newStorage.getItem.mockResolvedValue(null);
+      oldStorage.getItem.mockResolvedValue('legacy-data');
+      newStorage.setItem.mockResolvedValue(undefined);
+      oldStorage.removeItem.mockResolvedValue(undefined);
+
+      const result = await storage.getItem('persist:root');
+
+      expect(result).toBe('legacy-data');
+      expect(newStorage.setItem).toHaveBeenCalledWith(
+        'persist:root',
+        'legacy-data'
+      );
+      expect(oldStorage.removeItem).toHaveBeenCalledWith('persist:root');
+    });
+
+    it('returns null when neither storage has the key', async () => {
+      newStorage.getItem.mockResolvedValue(null);
+      oldStorage.getItem.mockResolvedValue(null);
+
+      const result = await storage.getItem('persist:root');
+
+      expect(result).toBeNull();
+    });
+
+    it('falls back to old storage when new storage read fails', async () => {
+      newStorage.getItem.mockRejectedValue(new Error('IndexedDB error'));
+      oldStorage.getItem.mockResolvedValue('legacy-data');
+      newStorage.setItem.mockResolvedValue(undefined);
+      oldStorage.removeItem.mockResolvedValue(undefined);
+
+      const result = await storage.getItem('persist:root');
+
+      expect(result).toBe('legacy-data');
+      expect(newStorage.setItem).toHaveBeenCalledWith(
+        'persist:root',
+        'legacy-data'
+      );
+    });
+
+    it('returns old value but does not remove from old storage when migration write fails', async () => {
+      newStorage.getItem.mockResolvedValue(null);
+      oldStorage.getItem.mockResolvedValue('legacy-data');
+      newStorage.setItem.mockRejectedValue(new Error('write failed'));
+
+      const result = await storage.getItem('persist:root');
+
+      expect(result).toBe('legacy-data');
+      expect(oldStorage.removeItem).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('setItem', () => {
+    it('delegates to new storage only', async () => {
+      newStorage.setItem.mockResolvedValue(undefined);
+
+      await storage.setItem('persist:root', 'data');
+
+      expect(newStorage.setItem).toHaveBeenCalledWith('persist:root', 'data');
+      expect(oldStorage.setItem).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('removeItem', () => {
+    it('delegates to new storage only', async () => {
+      newStorage.removeItem.mockResolvedValue(undefined);
+
+      await storage.removeItem('persist:root');
+
+      expect(newStorage.removeItem).toHaveBeenCalledWith('persist:root');
+      expect(oldStorage.removeItem).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -68,6 +68,10 @@ export const createMigratingStorage = (oldStorage, newStorage) => ({
           });
           await oldStorage.removeItem(key);
           console.log(`Cboard: Cleaned up ${key} from localStorage`);
+          appInsights.trackEvent({
+            name: 'StorageMigration_Cleanup',
+            properties: { key }
+          });
         } catch (writeErr) {
           console.warn('Cboard: Migration write failed', writeErr);
           appInsights.trackException({

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -77,7 +77,7 @@ const createMigratingStorage = (oldStorage, newStorage) => ({
 
   /**
    * Removes a value from storage.
-   * Called by redux-persist when purging state (e.g., logout).
+   * Called by redux-persist when purging state.
    */
   async removeItem(key) {
     return await newStorage.removeItem(key);

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -29,7 +29,7 @@ localForage.config({
  * @param {Object} newStorage - The new storage engine (localForage/IndexedDB)
  * @returns {Object} A storage engine compatible with redux-persist
  */
-const createMigratingStorage = (oldStorage, newStorage) => ({
+export const createMigratingStorage = (oldStorage, newStorage) => ({
   /**
    * Retrieves a value from storage, migrating from old to new if necessary.
    * Called by redux-persist on app initialization.

--- a/yarn.lock
+++ b/yarn.lock
@@ -9613,6 +9613,13 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+lie@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lie/-/lie-3.1.1.tgz#9a436b2cc7746ca59de7a41fa469b3efb76bd87e"
+  integrity sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==
+  dependencies:
+    immediate "~3.0.5"
+
 lie@~3.3.0:
   version "3.3.0"
   resolved "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz"
@@ -9699,6 +9706,13 @@ loader-utils@^3.2.0:
   version "3.3.1"
   resolved "https://registry.npmjs.org/loader-utils/-/loader-utils-3.3.1.tgz"
   integrity sha512-FMJTLMXfCLMLfJxcX9PFqX5qD88Z5MRGaZCVzfuqeZSPsyiBzs+pahDQjbIWz2QIzPZz0NX9Zy4FX3lmK6YHIg==
+
+localforage@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/localforage/-/localforage-1.10.0.tgz#5c465dc5f62b2807c3a84c0c6a1b1b3212781dd4"
+  integrity sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==
+  dependencies:
+    lie "3.1.1"
 
 locate-path@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
# Storage Migration: localStorage to IndexedDB

## Overview

This document describes the storage migration implemented in Cboard to move from `localStorage` to `IndexedDB` for persisting Redux state.

## Problem

Users with many boards were encountering `QuotaExceededError` because localStorage has a strict ~5-10MB limit per origin. When users created many boards with images and tiles, they would exceed this limit and lose the ability to save new data.

## Solution

Migrate to IndexedDB via [localForage](https://localforage.github.io/localForage/), which supports gigabytes of storage depending on the browser.

| Aspect | localStorage | IndexedDB |
|--------|-------------|-----------|
| Storage limit | ~5-10MB | Gigabytes (browser-dependent) |
| API | Synchronous (blocks main thread) | Asynchronous (non-blocking) |
| Data types | Strings only | Structured data, blobs, files |
| Browser support | All browsers | All modern browsers |

## Implementation

The migration is implemented in [src/reducers.js](../src/reducers.js) using a **storage wrapper pattern**.

### How It Works

```
┌─────────────────────────────────────────────────────────────────┐
│                     APP INITIALIZATION                          │
└─────────────────────────────────────────────────────────────────┘
                              │
                              ▼
┌─────────────────────────────────────────────────────────────────┐
│  redux-persist calls getItem('persist:root')                    │
└─────────────────────────────────────────────────────────────────┘
                              │
                              ▼
┌─────────────────────────────────────────────────────────────────┐
│  Check IndexedDB for 'persist:root'                             │
│  ┌─────────────────┐                                            │
│  │  Data found?    │─── YES ──▶ Return data (already migrated)  │
│  └─────────────────┘                                            │
│          │ NO                                                   │
│          ▼                                                      │
│  ┌─────────────────┐                                            │
│  │ Check localStorage│                                          │
│  └─────────────────┘                                            │
│          │                                                      │
│          ▼                                                      │
│  ┌─────────────────┐                                            │
│  │  Data found?    │─── NO ───▶ Return null (new user)          │
│  └─────────────────┘                                            │
│          │ YES                                                  │
│          ▼                                                      │
│  ┌─────────────────────────────────────────────┐                │
│  │ MIGRATION: Copy localStorage → IndexedDB    │                │
│  │ Log: "Migrating persist:root..."            │                │
│  └─────────────────────────────────────────────┘                │
│          │                                                      │
│          ▼                                                      │
│  Return data (migration complete)                               │
└─────────────────────────────────────────────────────────────────┘
                              │
                              ▼
┌─────────────────────────────────────────────────────────────────┐
│  App loads with user's boards                                   │
└─────────────────────────────────────────────────────────────────┘
                              │
                              ▼
┌─────────────────────────────────────────────────────────────────┐
│  User makes changes → setItem() → Saved to IndexedDB            │
│  (No more quota errors!)                                        │
└─────────────────────────────────────────────────────────────────┘
```

### Storage Wrapper

The migration uses a custom storage wrapper that implements the redux-persist storage interface:

```javascript
const createMigratingStorage = (oldStorage, newStorage) => ({
  async getItem(key) { ... },   // Read with migration fallback
  async setItem(key, value) { ... },  // Write to localForage
  async removeItem(key) { ... }  // Remove from localForage
});
```

#### `getItem(key)`
1. Try to read from localForage (new storage)
2. If not found, try localStorage (old storage)
3. If found in localStorage, copy to localForage and remove from localStorage
4. Return the data

#### `setItem(key, value)`
1. Write to localForage (which internally uses IndexedDB, or falls back to localStorage if unavailable)

#### `removeItem(key)`
1. Remove from localForage

## Persisted Keys

The app persists two separate keys:

| Key | Description |
|-----|-------------|
| `persist:root` | Main app state (boards, communicator, app settings, etc.) |
| `persist:language` | Language settings (current language, available languages) |

Both keys are migrated automatically by the storage wrapper.

## Edge Cases Handled

### Safari Private Browsing Mode
IndexedDB is not persistent in Safari private mode. localForage automatically detects this and uses localStorage as its driver.

### New Users
For new users (no data in either storage), `getItem` returns `null` and redux-persist initializes with default state.

### Already Migrated Users
On subsequent visits, data is found in IndexedDB immediately. localStorage is never checked, so there's no performance overhead.

### Cordova/Mobile App
localForage works in Cordova environments and automatically selects the best available storage backend.

### Multi-Tab Usage
IndexedDB is designed for multi-tab access. Data is consistent across tabs.

## Verifying the Migration

### Check IndexedDB in DevTools

1. Open Chrome DevTools
2. Go to **Application** tab
3. Expand **IndexedDB** in the sidebar
4. Look for **cboard** → **cboard_store**
5. You should see `persist:root` and `persist:language` keys

### Console Messages

During migration, you'll see these messages in the console:

```
Cboard: Migrating persist:root from localStorage to IndexedDB...
Cboard: Successfully migrated persist:root
Cboard: Migrating persist:language from localStorage to IndexedDB...
Cboard: Successfully migrated persist:language
Cboard: Cleaned up persist:root from localStorage
Cboard: Migrating persist:language from localStorage to IndexedDB...
Cboard: Successfully migrated persist:language
Cboard: Cleaned up persist:language from localStorage
```

After migration, these messages won't appear on subsequent page loads.

## Rollback

If issues are discovered, revert to localStorage by changing the storage config in `src/reducers.js`:

```javascript
const config = {
  key: 'root',
  storage: storage,  // Change from migratingStorage to storage
  // ...
};

const languagePersistConfig = {
  key: 'language',
  storage: storage,  // Change from migratingStorage to storage
  // ...
};
```

Note: After migration, old localStorage data is cleaned up. Users who have already migrated will have their data in localForage (IndexedDB) only.

## Dependencies

- [localForage](https://www.npmjs.com/package/localforage) - IndexedDB wrapper with localStorage-like API

## References

- [redux-persist GitHub](https://github.com/rt2zz/redux-persist)
- [redux-persist Issue #806 - Storage Migration](https://github.com/rt2zz/redux-persist/issues/806)
- [redux-persist Issue #264 - Safari Private Mode](https://github.com/rt2zz/redux-persist/issues/264)
- [localForage Documentation](https://localforage.github.io/localForage/)
- [MDN IndexedDB API](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API)

## Related Issues

close #1514