### PR TITLE
Fix offline boards history

### DIFF
--- a/src/components/Board/Board.actions.js
+++ b/src/components/Board/Board.actions.js
@@ -653,6 +653,7 @@ export function applyRemoteChangesToState({
  */
 export function pushLocalChangesToApi(remoteBoards = []) {
   return async (dispatch, getState) => {
+    const userEmail = getState().app?.userData?.email;
     const { boards, activeBoardId } = getState().board;
 
     // Boards explicitly marked PENDING by the sync system.

--- a/src/components/Board/Board.actions.js
+++ b/src/components/Board/Board.actions.js
@@ -651,7 +651,7 @@ export function applyRemoteChangesToState({
  */
 export function pushLocalChangesToApi() {
   return async (dispatch, getState) => {
-    const { boards } = getState().board;
+    const { boards, activeBoardId } = getState().board;
 
     // Separate boards to sync vs boards to delete
     const boardsToSync = boards.filter(
@@ -663,7 +663,13 @@ export function pushLocalChangesToApi() {
     for (const board of boardsToSync) {
       try {
         if (board.id.length < SHORT_ID_MAX_LENGTH) {
-          await dispatch(updateApiObjectsNoChild(board, true));
+          const newBoardId = await dispatch(
+            updateApiObjectsNoChild(board, true)
+          );
+          dispatch(replaceBoard(board, { ...board, id: newBoardId }));
+          if (activeBoardId === board.id) {
+            replaceHistoryWithActiveBoardId(getState);
+          }
         } else {
           await dispatch(updateApiBoard(board));
         }


### PR DESCRIPTION
Improves how board synchronization and navigation are handled in the application. The main changes include better error handling during board synchronization, ensuring the UI reflects the correct board state after API updates, and keeping navigation history consistent when board IDs change.

**Board synchronization and error handling:**

* Improved the `BoardContainer` component to handle errors gracefully when synchronizing boards with the API, and to ensure the correct board is selected if accessed via a URL (`src/components/Board/Board.container.js`).

**Navigation and state consistency:**

* Updated the `componentDidUpdate` lifecycle method in `BoardContainer` to synchronize the URL and UI state with the current board after API objects are fetched, and to update the `isFixedBoard` state accordingly.
* Enhanced the `boardReducer` to update `boards`, `activeBoardId`, and `navHistory` when a board's ID changes after being created via the API, ensuring navigation and state remain consistent.