### PR TITLE
Solve sync problem about fields in boards

### DIFF
--- a/src/components/Board/Board.container.js
+++ b/src/components/Board/Board.container.js
@@ -229,11 +229,22 @@ export class BoardContainer extends Component {
       //downloadImages
     } = this.props;
 
-    // Loggedin user?
     if ('name' in userData && 'email' in userData && window.navigator.onLine) {
-      //synchronize communicator and boards with API
+      if (id) {
+        const urlBoard = boards.find(b => b.id === id);
+        if (urlBoard) {
+          changeBoard(id);
+        }
+      }
+
       this.setState({ isGettingApiObjects: true });
-      getApiObjects().then(() => this.setState({ isGettingApiObjects: false }));
+      try {
+        await getApiObjects();
+      } catch (err) {
+        console.error('Error syncing boards:', err);
+      }
+      this.setState({ isGettingApiObjects: false });
+      return;
     }
 
     let boardExists = null;
@@ -326,8 +337,23 @@ export class BoardContainer extends Component {
     }
   }
 
-  componentDidUpdate(prevProps) {
-    const { board } = this.props;
+  componentDidUpdate(prevProps, prevState) {
+    const {
+      board,
+      history,
+      match: {
+        params: { id }
+      }
+    } = this.props;
+    const { isGettingApiObjects } = this.state;
+
+    if (prevState.isGettingApiObjects && !isGettingApiObjects && board) {
+      if (id !== board.id) {
+        history.replace(`board/${board.id}`);
+      }
+      this.setState({ isFixedBoard: !!board.isFixed });
+    }
+
     if (board && prevProps.board && board.isFixed !== prevProps.board.isFixed) {
       this.setState({ isFixedBoard: board.isFixed });
     }

--- a/src/components/Board/Board.container.js
+++ b/src/components/Board/Board.container.js
@@ -229,22 +229,11 @@ export class BoardContainer extends Component {
       //downloadImages
     } = this.props;
 
+    // Loggedin user?
     if ('name' in userData && 'email' in userData && window.navigator.onLine) {
-      if (id) {
-        const urlBoard = boards.find(b => b.id === id);
-        if (urlBoard) {
-          changeBoard(id);
-        }
-      }
-
+      //synchronize communicator and boards with API
       this.setState({ isGettingApiObjects: true });
-      try {
-        await getApiObjects();
-      } catch (err) {
-        console.error('Error syncing boards:', err);
-      }
-      this.setState({ isGettingApiObjects: false });
-      return;
+      getApiObjects().then(() => this.setState({ isGettingApiObjects: false }));
     }
 
     let boardExists = null;
@@ -337,23 +326,8 @@ export class BoardContainer extends Component {
     }
   }
 
-  componentDidUpdate(prevProps, prevState) {
-    const {
-      board,
-      history,
-      match: {
-        params: { id }
-      }
-    } = this.props;
-    const { isGettingApiObjects } = this.state;
-
-    if (prevState.isGettingApiObjects && !isGettingApiObjects && board) {
-      if (id !== board.id) {
-        history.replace(`board/${board.id}`);
-      }
-      this.setState({ isFixedBoard: !!board.isFixed });
-    }
-
+  componentDidUpdate(prevProps) {
+    const { board } = this.props;
     if (board && prevProps.board && board.isFixed !== prevProps.board.isFixed) {
       this.setState({ isFixedBoard: board.isFixed });
     }

--- a/src/components/Board/Board.reducer.js
+++ b/src/components/Board/Board.reducer.js
@@ -378,27 +378,19 @@ function boardReducer(state = initialState, action) {
         );
         if (!boardIsAlreadyCreatedOnDb) board.shouldCreateBoard = true;
       });
-      const newBoardId = action.board.id;
-      const oldBoardId = action.boardId;
-      const updatedNavHistory = state.navHistory.map(id =>
-        id === oldBoardId ? newBoardId : id
-      );
       return {
         ...state,
         isFetching: false,
         boards: creadBoards.map(board =>
-          board.id === oldBoardId
+          board.id === action.boardId
             ? {
                 ...board,
-                id: newBoardId,
+                id: action.board.id,
                 lastEdited: action.board.lastEdited,
                 syncStatus: SYNC_STATUS.SYNCED
               }
             : board
-        ),
-        activeBoardId:
-          state.activeBoardId === oldBoardId ? newBoardId : state.activeBoardId,
-        navHistory: updatedNavHistory
+        )
       };
     case CREATE_API_BOARD_FAILURE:
       return {

--- a/src/components/Board/Board.reducer.js
+++ b/src/components/Board/Board.reducer.js
@@ -80,21 +80,24 @@ function tileReducer(board, action) {
     case CREATE_TILE:
       return {
         ...board,
-        tiles: [...board.tiles, { ...action.tile }]
+        tiles: [...board.tiles, { ...action.tile }],
         /* some times when a tile folder is created here the last tile change loadBoard to a long Id with no reason
       action tile before this copy has a short ID*/
+        syncStatus: SYNC_STATUS.PENDING
       };
     case DELETE_TILES:
       return {
         ...board,
-        tiles: board.tiles.filter(tile => action.tiles.indexOf(tile.id) === -1)
+        tiles: board.tiles.filter(tile => action.tiles.indexOf(tile.id) === -1),
+        syncStatus: SYNC_STATUS.PENDING
       };
     case EDIT_TILES:
       return {
         ...board,
         tiles: board.tiles.map(
           tile => action.tiles.find(s => s.id === tile.id) || tile
-        )
+        ),
+        syncStatus: SYNC_STATUS.PENDING
       };
     default:
       return board;

--- a/src/components/Board/Board.reducer.js
+++ b/src/components/Board/Board.reducer.js
@@ -375,19 +375,27 @@ function boardReducer(state = initialState, action) {
         );
         if (!boardIsAlreadyCreatedOnDb) board.shouldCreateBoard = true;
       });
+      const newBoardId = action.board.id;
+      const oldBoardId = action.boardId;
+      const updatedNavHistory = state.navHistory.map(id =>
+        id === oldBoardId ? newBoardId : id
+      );
       return {
         ...state,
         isFetching: false,
         boards: creadBoards.map(board =>
-          board.id === action.boardId
+          board.id === oldBoardId
             ? {
                 ...board,
-                id: action.board.id,
+                id: newBoardId,
                 lastEdited: action.board.lastEdited,
                 syncStatus: SYNC_STATUS.SYNCED
               }
             : board
-        )
+        ),
+        activeBoardId:
+          state.activeBoardId === oldBoardId ? newBoardId : state.activeBoardId,
+        navHistory: updatedNavHistory
       };
     case CREATE_API_BOARD_FAILURE:
       return {

--- a/src/components/Board/__tests__/Board.actions.test.js
+++ b/src/components/Board/__tests__/Board.actions.test.js
@@ -907,8 +907,8 @@ describe('pushLocalChangesToApi', () => {
     expect(actionTypes).not.toContain(types.CREATE_API_BOARD_STARTED);
   });
 
-  it('should transform and push PENDING core boards (support@cboard.io)', async () => {
-    const coreBoard = {
+  it('should transform and push PENDING default boards (support@cboard.io)', async () => {
+    const defaultBoard = {
       ...mockBoard,
       id: '12345678901234567890',
       email: 'support@cboard.io',
@@ -916,7 +916,7 @@ describe('pushLocalChangesToApi', () => {
     };
     const storeWithBoards = mockStore({
       ...initialState,
-      board: { ...initialState.board, boards: [coreBoard] }
+      board: { ...initialState.board, boards: [defaultBoard] }
     });
 
     await storeWithBoards.dispatch(actions.pushLocalChangesToApi());

--- a/src/components/Board/__tests__/Board.actions.test.js
+++ b/src/components/Board/__tests__/Board.actions.test.js
@@ -907,8 +907,8 @@ describe('pushLocalChangesToApi', () => {
     expect(actionTypes).not.toContain(types.CREATE_API_BOARD_STARTED);
   });
 
-  it('should not push PENDING default boards (support@cboard.io)', async () => {
-    const defaultBoard = {
+  it('should transform and push PENDING core boards (support@cboard.io)', async () => {
+    const coreBoard = {
       ...mockBoard,
       id: '12345678901234567890',
       email: 'support@cboard.io',
@@ -916,17 +916,24 @@ describe('pushLocalChangesToApi', () => {
     };
     const storeWithBoards = mockStore({
       ...initialState,
-      board: { ...initialState.board, boards: [defaultBoard] }
+      board: { ...initialState.board, boards: [coreBoard] }
     });
 
     await storeWithBoards.dispatch(actions.pushLocalChangesToApi());
-    const actionTypes = storeWithBoards.getActions().map(a => a.type);
+    const allActions = storeWithBoards.getActions();
+    const actionTypes = allActions.map(a => a.type);
 
-    expect(actionTypes).not.toContain(types.UPDATE_API_BOARD_STARTED);
-    expect(actionTypes).not.toContain(types.CREATE_API_BOARD_STARTED);
+    // Should transform the board (update local state with user's email)
+    expect(actionTypes).toContain(types.UPDATE_BOARD);
+    const updateAction = allActions.find(a => a.type === types.UPDATE_BOARD);
+    expect(updateAction.boardData.email).toBe('asd@qwe.com');
+    expect(updateAction.boardData.isPublic).toBe(false);
+
+    // Should push to API (long ID = update, not create)
+    expect(actionTypes).toContain(types.UPDATE_API_BOARD_STARTED);
   });
 
-  it('should not push PENDING boards with empty email (created while logged out)', async () => {
+  it('should transform and push PENDING boards with empty email (created while logged out)', async () => {
     const offlineBoard = {
       ...mockBoard,
       id: '12345678901234567890',
@@ -939,10 +946,16 @@ describe('pushLocalChangesToApi', () => {
     });
 
     await storeWithBoards.dispatch(actions.pushLocalChangesToApi());
-    const actionTypes = storeWithBoards.getActions().map(a => a.type);
+    const allActions = storeWithBoards.getActions();
+    const actionTypes = allActions.map(a => a.type);
 
-    expect(actionTypes).not.toContain(types.UPDATE_API_BOARD_STARTED);
-    expect(actionTypes).not.toContain(types.CREATE_API_BOARD_STARTED);
+    // Should transform the board (update local state with user's email)
+    expect(actionTypes).toContain(types.UPDATE_BOARD);
+    const updateAction = allActions.find(a => a.type === types.UPDATE_BOARD);
+    expect(updateAction.boardData.email).toBe('asd@qwe.com');
+
+    // Should push to API
+    expect(actionTypes).toContain(types.UPDATE_API_BOARD_STARTED);
   });
 });
 

--- a/src/components/Board/__tests__/Board.reducer.test.js
+++ b/src/components/Board/__tests__/Board.reducer.test.js
@@ -374,7 +374,10 @@ describe('reducer', () => {
       )
     ).toEqual({
       ...initialState,
-      boards: [...initialState.boards, mockBoard]
+      boards: [
+        ...initialState.boards,
+        { ...mockBoard, syncStatus: SYNC_STATUS.PENDING }
+      ]
     });
   });
   it('should handle createTile', () => {
@@ -403,7 +406,8 @@ describe('reducer', () => {
               loadBoard: '123'
             },
             { id: '456' }
-          ]
+          ],
+          syncStatus: SYNC_STATUS.PENDING
         }
       ]
     });
@@ -428,7 +432,8 @@ describe('reducer', () => {
         ...initialState.boards,
         {
           ...mockBoard,
-          tiles: []
+          tiles: [],
+          syncStatus: SYNC_STATUS.PENDING
         }
       ]
     });


### PR DESCRIPTION
Improvements to the board synchronization logic around handling core boards and boards created offline, as well as updates to the reducer and tests to ensure correct sync status and navigation. The most significant changes are grouped below.

**Synchronization and Board Transformation Logic:**

* Boards with a `PENDING` sync status that are either core boards (`support@cboard.io`) or have an empty email are now transformed to belong to the current user before being synced. This includes updating their `email`, `author`, and `name` fields. These boards are then pushed to the API as the user's own boards.

**Reducer and Sync Status Updates:**
* Any tile operation (create, delete, edit) now marks the board's `syncStatus` as `PENDING`, ensuring that changes are recognized and queued for synchronization.
* Corresponding updates in the reducer tests verify that the `syncStatus` is properly set to `PENDING` after tile operations and board creation.