### PR TITLE
fix: replace return with continue in updateApiMarkedBoards loop

### DIFF
--- a/src/components/Board/Board.actions.js
+++ b/src/components/Board/Board.actions.js
@@ -762,7 +762,7 @@ export function updateApiMarkedBoards() {
     const allBoards = [...getState().board.boards];
     for await (const board of allBoards) {
       const boardsIds = getState().board.boards?.map(board => board.id);
-      if (!boardsIds.includes(board.id)) return;
+      if (!boardsIds.includes(board.id)) continue;
 
       if (
         board.id.length > 14 &&


### PR DESCRIPTION
Closes #2130

## Problem
In `updateApiMarkedBoards` (`src/components/Board/Board.actions.js`), 
the guard inside the `for await` loop used `return` instead of `continue`:

if (!boardsIds.includes(board.id)) return;

This exits the entire async function when a board is missing from state, 
silently abandoning all remaining boards that have `markToUpdate: true`.

## Fix
Changed `return` to `continue` so the loop skips the removed board 
and processes the remaining ones.

## Changes
- 1 line changed in `src/components/Board/Board.actions.js`