### PR TITLE
Pin to unlock communicator

### DIFF
--- a/src/components/App/App.reducer.js
+++ b/src/components/App/App.reducer.js
@@ -54,7 +54,9 @@ const initialState = {
     vocalizeFolders: false,
     quietBuilderMode: false,
     liveMode: false,
-    improvePhraseActive: false
+    improvePhraseActive: false,
+    pinLockEnabled: false,
+    pinCode: ''
   },
   symbolsSettings: {
     arasaacActive: false

--- a/src/components/App/__tests__/App.reducer.test.js
+++ b/src/components/App/__tests__/App.reducer.test.js
@@ -49,7 +49,9 @@ describe('reducer', () => {
         removeOutputActive: false,
         vocalizeFolders: false,
         quietBuilderMode: false,
-        improvePhraseActive: false
+        improvePhraseActive: false,
+        pinLockEnabled: false,
+        pinCode: ''
       },
       symbolsSettings: {
         arasaacActive: false
@@ -80,7 +82,9 @@ describe('reducer', () => {
         removeOutputActive: false,
         vocalizeFolders: false,
         quietBuilderMode: false,
-        improvePhraseActive: false
+        improvePhraseActive: false,
+        pinLockEnabled: false,
+        pinCode: ''
       },
       userData: uData
     };

--- a/src/components/Board/Board.container.js
+++ b/src/components/Board/Board.container.js
@@ -73,6 +73,7 @@ import {
   IS_BROWSING_FROM_SAFARI
 } from '../../constants';
 import LoadingIcon from '../UI/LoadingIcon';
+import PinDialog from '../UI/PinDialog';
 import { resolveTileLabel } from '../../helpers';
 //import { isAndroid } from '../../cordova-util';
 
@@ -204,7 +205,10 @@ export class BoardContainer extends Component {
     copiedTiles: [],
     isScroll: false,
     totalRows: null,
-    isCbuilderBoard: false
+    isCbuilderBoard: false,
+    pinDialogOpen: false,
+    pinAttempt: '',
+    pinError: false
   };
   constructor(props) {
     super(props);
@@ -787,6 +791,23 @@ export class BoardContainer extends Component {
 
   handleLockClick = () => {
     const { showPremiumRequired, isSubscriptionRequired } = this.props;
+    const { pinLockEnabled, pinCode } = this.props.navigationSettings || {};
+
+    if (
+      pinLockEnabled &&
+      pinCode &&
+      pinCode.length === 4 &&
+      this.state.isLocked
+    ) {
+      if (!this.state.pinDialogOpen) {
+        this.setState({
+          pinDialogOpen: true,
+          pinAttempt: '',
+          pinError: false
+        });
+      }
+      return;
+    }
 
     this.setState(
       prevState => ({
@@ -914,13 +935,27 @@ export class BoardContainer extends Component {
 
   handleLockNotify = countdown => {
     const { intl, showNotification, hideNotification } = this.props;
-    const quickUnlockActive = this.props.navigationSettings?.quickUnlockActive;
+    const { quickUnlockActive, pinLockEnabled, pinCode } =
+      this.props.navigationSettings || {};
 
     if (quickUnlockActive) {
       hideNotification();
       this.handleLockClick();
       return;
     }
+
+    if (pinLockEnabled && pinCode && pinCode.length === 4) {
+      if (!this.state.pinDialogOpen) {
+        hideNotification();
+        this.setState({
+          pinDialogOpen: true,
+          pinAttempt: '',
+          pinError: false
+        });
+      }
+      return;
+    }
+
     if (countdown > 3) {
       return;
     }
@@ -939,6 +974,49 @@ export class BoardContainer extends Component {
     setTimeout(() => {
       showNotification(clicksToUnlock);
     });
+  };
+
+  handlePinDialogClose = () => {
+    this.setState({
+      pinDialogOpen: false,
+      pinAttempt: '',
+      pinError: false
+    });
+  };
+
+  handlePinChange = value => {
+    this.setState({
+      pinAttempt: value,
+      pinError: false
+    });
+  };
+
+  handlePinSubmit = () => {
+    const { showPremiumRequired, isSubscriptionRequired } = this.props;
+    const { pinCode } = this.props.navigationSettings || {};
+    if (this.state.pinAttempt === pinCode) {
+      this.setState(
+        {
+          pinDialogOpen: false,
+          pinAttempt: '',
+          pinError: false,
+          isLocked: false,
+          isSaving: false,
+          isSelecting: false,
+          selectedTileIds: []
+        },
+        () => {
+          if (isSubscriptionRequired) {
+            showPremiumRequired({ showTryPeriodFinishedMessages: true });
+          }
+        }
+      );
+    } else {
+      this.setState({
+        pinError: true,
+        pinAttempt: ''
+      });
+    }
   };
 
   handleScannerStrategyNotification = () => {
@@ -1716,6 +1794,14 @@ export class BoardContainer extends Component {
           onAddApiBoard={this.handleAddApiBoard}
           isSymbolSearchTourEnabled={this.props.isSymbolSearchTourEnabled}
           disableTour={this.props.disableTour}
+        />
+        <PinDialog
+          open={this.state.pinDialogOpen}
+          onClose={this.handlePinDialogClose}
+          onSubmit={this.handlePinSubmit}
+          error={this.state.pinError}
+          value={this.state.pinAttempt}
+          onChange={this.handlePinChange}
         />
       </Fragment>
     );

--- a/src/components/Board/Board.container.js
+++ b/src/components/Board/Board.container.js
@@ -793,17 +793,15 @@ export class BoardContainer extends Component {
     const { showPremiumRequired, isSubscriptionRequired } = this.props;
     const { pinLockEnabled, pinCode } = this.props.navigationSettings || {};
 
-    if (
-      pinLockEnabled &&
-      pinCode &&
-      pinCode.length === 4 &&
-      this.state.isLocked
-    ) {
+    const hasValidPinCode =
+      typeof pinCode === 'string' && /^\d{4}$/.test(pinCode);
+
+    if (pinLockEnabled && this.state.isLocked) {
       if (!this.state.pinDialogOpen) {
         this.setState({
           pinDialogOpen: true,
           pinAttempt: '',
-          pinError: false
+          pinError: !hasValidPinCode
         });
       }
       return;

--- a/src/components/Settings/Navigation/Navigation.component.js
+++ b/src/components/Settings/Navigation/Navigation.component.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
 import Switch from '@material-ui/core/Switch';
 import Paper from '@material-ui/core/Paper';
 import List from '@material-ui/core/List';
@@ -8,6 +8,11 @@ import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
 import Divider from '@material-ui/core/Divider';
+import TextField from '@material-ui/core/TextField';
+import InputAdornment from '@material-ui/core/InputAdornment';
+import IconButton from '@material-ui/core/IconButton';
+import Visibility from '@material-ui/icons/Visibility';
+import VisibilityOff from '@material-ui/icons/VisibilityOff';
 import FullScreenDialog from '../../UI/FullScreenDialog';
 import messages from './Navigation.messages';
 import MenuItem from '@material-ui/core/MenuItem';
@@ -27,7 +32,8 @@ const propTypes = {
   updateNavigationSettings: PropTypes.func.isRequired,
   navigationSettings: PropTypes.object.isRequired,
   isLiveMode: PropTypes.bool,
-  changeLiveMode: PropTypes.func.isRequired
+  changeLiveMode: PropTypes.func.isRequired,
+  intl: intlShape.isRequired
 };
 
 class Navigation extends React.Component {
@@ -35,9 +41,16 @@ class Navigation extends React.Component {
     super(props);
 
     this.state = {
-      ...props.navigationSettings
+      ...props.navigationSettings,
+      pinCodeVisible: false
     };
   }
+
+  togglePinCodeVisibility = () => {
+    this.setState(prevState => ({
+      pinCodeVisible: !prevState.pinCodeVisible
+    }));
+  };
 
   toggleCABackButton = () => {
     this.setState({
@@ -55,6 +68,17 @@ class Navigation extends React.Component {
     this.setState({
       quickUnlockActive: !this.state.quickUnlockActive
     });
+  };
+
+  togglePinLock = () => {
+    this.setState(prevState => ({
+      pinLockEnabled: !prevState.pinLockEnabled
+    }));
+  };
+
+  handlePinCodeChange = event => {
+    const value = event.target.value.replace(/\D/g, '').slice(0, 4);
+    this.setState({ pinCode: value });
   };
 
   toggleShareShow = () => {
@@ -98,7 +122,8 @@ class Navigation extends React.Component {
     if (!this.state.liveMode && isLiveMode) {
       changeLiveMode();
     }
-    this.props.updateNavigationSettings(this.state);
+    const { pinCodeVisible, ...navigationSettings } = this.state;
+    this.props.updateNavigationSettings(navigationSettings);
   };
 
   onNavigationSettingsChange(navigationSetting, event) {
@@ -265,6 +290,88 @@ class Navigation extends React.Component {
                 </ListItemSecondaryAction>
               </ListItem>
               <Divider />
+              <ListItem disabled={this.state.quickUnlockActive}>
+                <ListItemText
+                  className="Navigation__ListItemText"
+                  primary={<FormattedMessage {...messages.pinLock} />}
+                  secondary={
+                    <FormattedMessage {...messages.pinLockSecondary} />
+                  }
+                />
+                <ListItemSecondaryAction>
+                  <Switch
+                    disabled={this.state.quickUnlockActive}
+                    checked={this.state.pinLockEnabled || false}
+                    onChange={this.togglePinLock}
+                    value="active"
+                    color="secondary"
+                  />
+                </ListItemSecondaryAction>
+              </ListItem>
+              <ListItem
+                disabled={
+                  !this.state.pinLockEnabled || this.state.quickUnlockActive
+                }
+              >
+                <ListItemText
+                  className="Navigation__ListItemText"
+                  primary={<FormattedMessage {...messages.pinCodeLabel} />}
+                />
+                <ListItemSecondaryAction>
+                  <TextField
+                    disabled={
+                      !this.state.pinLockEnabled || this.state.quickUnlockActive
+                    }
+                    type={this.state.pinCodeVisible ? 'text' : 'password'}
+                    inputProps={{
+                      maxLength: 4,
+                      pattern: '[0-9]*',
+                      inputMode: 'numeric',
+                      style: { textAlign: 'center', width: '80px' }
+                    }}
+                    InputProps={{
+                      endAdornment: (
+                        <InputAdornment position="end">
+                          <IconButton
+                            aria-label="toggle pin visibility"
+                            onClick={this.togglePinCodeVisibility}
+                            edge="end"
+                            size="small"
+                            disabled={
+                              !this.state.pinLockEnabled ||
+                              this.state.quickUnlockActive
+                            }
+                          >
+                            {this.state.pinCodeVisible ? (
+                              <Visibility fontSize="small" />
+                            ) : (
+                              <VisibilityOff fontSize="small" />
+                            )}
+                          </IconButton>
+                        </InputAdornment>
+                      )
+                    }}
+                    value={this.state.pinCode || ''}
+                    onChange={this.handlePinCodeChange}
+                    error={
+                      this.state.pinLockEnabled &&
+                      this.state.pinCode?.length > 0 &&
+                      this.state.pinCode?.length < 4
+                    }
+                    helperText={
+                      this.state.pinLockEnabled &&
+                      this.state.pinCode?.length > 0 &&
+                      this.state.pinCode?.length < 4 ? (
+                        <FormattedMessage {...messages.pinCodeError} />
+                      ) : (
+                        ''
+                      )
+                    }
+                    placeholder="****"
+                  />
+                </ListItemSecondaryAction>
+              </ListItem>
+              <Divider />
               <ListItem>
                 <ListItemText
                   className="Navigation__ListItemText"
@@ -354,4 +461,4 @@ class Navigation extends React.Component {
 
 Navigation.propTypes = propTypes;
 
-export default Navigation;
+export default injectIntl(Navigation);

--- a/src/components/Settings/Navigation/Navigation.component.js
+++ b/src/components/Settings/Navigation/Navigation.component.js
@@ -123,7 +123,11 @@ class Navigation extends React.Component {
       changeLiveMode();
     }
     const { pinCodeVisible, ...navigationSettings } = this.state;
-    this.props.updateNavigationSettings(navigationSettings);
+    const hasValidPinCode = /^\d{4}$/.test(navigationSettings.pinCode || '');
+    this.props.updateNavigationSettings({
+      ...navigationSettings,
+      pinLockEnabled: navigationSettings.pinLockEnabled && hasValidPinCode
+    });
   };
 
   onNavigationSettingsChange(navigationSetting, event) {
@@ -333,7 +337,9 @@ class Navigation extends React.Component {
                       endAdornment: (
                         <InputAdornment position="end">
                           <IconButton
-                            aria-label="toggle pin visibility"
+                            aria-label={this.props.intl.formatMessage(
+                              messages.togglePinVisibility
+                            )}
                             onClick={this.togglePinCodeVisibility}
                             edge="end"
                             size="small"

--- a/src/components/Settings/Navigation/Navigation.messages.js
+++ b/src/components/Settings/Navigation/Navigation.messages.js
@@ -22,6 +22,23 @@ export default defineMessages({
     id: 'cboard.components.Settings.Navigation.quickUnlockSecondary',
     defaultMessage: 'Unlocks the settings with a single click'
   },
+  pinLock: {
+    id: 'cboard.components.Settings.Navigation.pinLock',
+    defaultMessage: 'Enable PIN lock'
+  },
+  pinLockSecondary: {
+    id: 'cboard.components.Settings.Navigation.pinLockSecondary',
+    defaultMessage:
+      'Requires a 4-digit PIN to unlock settings instead of multiple clicks'
+  },
+  pinCodeLabel: {
+    id: 'cboard.components.Settings.Navigation.pinCodeLabel',
+    defaultMessage: 'Enter 4-digit PIN'
+  },
+  pinCodeError: {
+    id: 'cboard.components.Settings.Navigation.pinCodeError',
+    defaultMessage: 'PIN must be exactly 4 digits'
+  },
   shareShow: {
     id: 'cboard.components.Settings.Navigation.shareShow',
     defaultMessage: 'Show the share phrase button'

--- a/src/components/Settings/Navigation/Navigation.messages.js
+++ b/src/components/Settings/Navigation/Navigation.messages.js
@@ -116,5 +116,9 @@ export default defineMessages({
   onTop: {
     id: 'cboard.components.Settings.Navigation.onTop',
     defaultMessage: 'On top'
+  },
+  togglePinVisibility: {
+    id: 'cboard.components.Settings.Navigation.togglePinVisibility',
+    defaultMessage: 'Toggle PIN visibility'
   }
 });

--- a/src/components/Settings/Navigation/Navigation.test.js
+++ b/src/components/Settings/Navigation/Navigation.test.js
@@ -31,7 +31,9 @@ const INITIAL_NAVIGATION_SETTINGS = {
   quickUnlockActive: false,
   removeOutputActive: false,
   vocalizeFolders: false,
-  quietBuilderMode: false
+  quietBuilderMode: false,
+  pinLockEnabled: false,
+  pinCode: ''
 };
 
 let navigationSettings = INITIAL_NAVIGATION_SETTINGS;
@@ -52,7 +54,7 @@ describe('Navigation tests', () => {
   });
 
   test('switchs behavior', () => {
-    const wrapper = shallow(<Navigation {...COMPONENT_PROPS} />);
+    const wrapper = shallow(<Navigation {...COMPONENT_PROPS} />).dive();
     let tree = toJson(wrapper);
     expect(tree).toMatchSnapshot();
 
@@ -80,7 +82,7 @@ describe('Navigation tests', () => {
     expect(tree).toMatchSnapshot();
   });
   test('switch behavior', () => {
-    const wrapper = shallow(<Navigation {...COMPONENT_PROPS} />);
+    const wrapper = shallow(<Navigation {...COMPONENT_PROPS} />).dive();
 
     const state = wrapper.state();
 

--- a/src/components/Settings/Navigation/Navigation.test.js
+++ b/src/components/Settings/Navigation/Navigation.test.js
@@ -18,6 +18,10 @@ jest.mock('./Navigation.messages', () => {
     enableSecondary: {
       id: 'cboard.components.Settings.Navigation.enableSecondary',
       defaultMessage: 'some text secondary'
+    },
+    togglePinVisibility: {
+      id: 'cboard.components.Settings.Navigation.togglePinVisibility',
+      defaultMessage: 'Toggle PIN visibility'
     }
   };
 });

--- a/src/components/UI/PinDialog/PinDialog.css
+++ b/src/components/UI/PinDialog/PinDialog.css
@@ -1,0 +1,9 @@
+.PinDialog__input {
+  margin-top: 16px;
+}
+
+.PinDialog__input input {
+  text-align: center;
+  font-size: 24px;
+  letter-spacing: 8px;
+}

--- a/src/components/UI/PinDialog/PinDialog.js
+++ b/src/components/UI/PinDialog/PinDialog.js
@@ -1,0 +1,135 @@
+import React, { useRef, useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import TextField from '@material-ui/core/TextField';
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  InputAdornment,
+  IconButton
+} from '@material-ui/core';
+import { Visibility, VisibilityOff } from '@material-ui/icons';
+
+import messages from './PinDialog.messages';
+import './PinDialog.css';
+
+const propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  error: PropTypes.bool,
+  value: PropTypes.string,
+  onChange: PropTypes.func.isRequired
+};
+
+const defaultProps = {
+  error: false,
+  value: ''
+};
+
+const PinDialog = ({ open, onClose, onSubmit, error, value, onChange }) => {
+  const inputRef = useRef(null);
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(
+    () => {
+      if (open && inputRef.current) {
+        setTimeout(() => {
+          inputRef.current.focus();
+        }, 100);
+      }
+      if (open) {
+        setIsVisible(false);
+      }
+    },
+    [open]
+  );
+
+  const toggleVisibility = () => {
+    setIsVisible(!isVisible);
+  };
+
+  const handleKeyPress = event => {
+    if (event.key === 'Enter' && value.length === 4) {
+      onSubmit();
+    }
+  };
+
+  const handleChange = event => {
+    const newValue = event.target.value.replace(/\D/g, '').slice(0, 4);
+    onChange(newValue);
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      aria-labelledby="pin-dialog-title"
+      aria-describedby="pin-dialog-description"
+    >
+      <DialogTitle id="pin-dialog-title">
+        <FormattedMessage {...messages.title} />
+      </DialogTitle>
+      <DialogContent>
+        <DialogContentText id="pin-dialog-description">
+          <FormattedMessage {...messages.description} />
+        </DialogContentText>
+        <TextField
+          inputRef={inputRef}
+          autoFocus
+          fullWidth
+          type={isVisible ? 'text' : 'password'}
+          inputProps={{
+            maxLength: 4,
+            pattern: '[0-9]*',
+            inputMode: 'numeric'
+          }}
+          InputProps={{
+            endAdornment: (
+              <InputAdornment position="end">
+                <IconButton
+                  aria-label="toggle pin visibility"
+                  onClick={toggleVisibility}
+                  edge="end"
+                >
+                  {isVisible ? <Visibility /> : <VisibilityOff />}
+                </IconButton>
+              </InputAdornment>
+            )
+          }}
+          className="PinDialog__input"
+          value={value}
+          onChange={handleChange}
+          onKeyPress={handleKeyPress}
+          error={error}
+          helperText={
+            error ? <FormattedMessage {...messages.incorrectPin} /> : ''
+          }
+          placeholder="****"
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} color="primary">
+          <FormattedMessage {...messages.cancel} />
+        </Button>
+        <Button
+          onClick={onSubmit}
+          color="primary"
+          variant="contained"
+          disabled={value.length !== 4}
+        >
+          <FormattedMessage {...messages.unlock} />
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+PinDialog.propTypes = propTypes;
+PinDialog.defaultProps = defaultProps;
+
+export default PinDialog;

--- a/src/components/UI/PinDialog/PinDialog.js
+++ b/src/components/UI/PinDialog/PinDialog.js
@@ -1,6 +1,6 @@
 import React, { useRef, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
 import TextField from '@material-ui/core/TextField';
 import {
   Button,
@@ -23,7 +23,8 @@ const propTypes = {
   onSubmit: PropTypes.func.isRequired,
   error: PropTypes.bool,
   value: PropTypes.string,
-  onChange: PropTypes.func.isRequired
+  onChange: PropTypes.func.isRequired,
+  intl: intlShape.isRequired
 };
 
 const defaultProps = {
@@ -31,20 +32,38 @@ const defaultProps = {
   value: ''
 };
 
-const PinDialog = ({ open, onClose, onSubmit, error, value, onChange }) => {
+const PinDialog = ({
+  open,
+  onClose,
+  onSubmit,
+  error,
+  value,
+  onChange,
+  intl
+}) => {
   const inputRef = useRef(null);
   const [isVisible, setIsVisible] = useState(false);
 
   useEffect(
     () => {
+      let focusTimeoutId;
+
       if (open && inputRef.current) {
-        setTimeout(() => {
-          inputRef.current.focus();
+        focusTimeoutId = setTimeout(() => {
+          if (inputRef.current) {
+            inputRef.current.focus();
+          }
         }, 100);
       }
       if (open) {
         setIsVisible(false);
       }
+
+      return () => {
+        if (focusTimeoutId) {
+          clearTimeout(focusTimeoutId);
+        }
+      };
     },
     [open]
   );
@@ -92,7 +111,7 @@ const PinDialog = ({ open, onClose, onSubmit, error, value, onChange }) => {
             endAdornment: (
               <InputAdornment position="end">
                 <IconButton
-                  aria-label="toggle pin visibility"
+                  aria-label={intl.formatMessage(messages.togglePinVisibility)}
                   onClick={toggleVisibility}
                   edge="end"
                 >
@@ -132,4 +151,4 @@ const PinDialog = ({ open, onClose, onSubmit, error, value, onChange }) => {
 PinDialog.propTypes = propTypes;
 PinDialog.defaultProps = defaultProps;
 
-export default PinDialog;
+export default injectIntl(PinDialog);

--- a/src/components/UI/PinDialog/PinDialog.messages.js
+++ b/src/components/UI/PinDialog/PinDialog.messages.js
@@ -1,0 +1,24 @@
+import { defineMessages } from 'react-intl';
+
+export default defineMessages({
+  title: {
+    id: 'cboard.components.PinDialog.title',
+    defaultMessage: 'Enter PIN'
+  },
+  description: {
+    id: 'cboard.components.PinDialog.description',
+    defaultMessage: 'Enter your 4-digit PIN to unlock'
+  },
+  incorrectPin: {
+    id: 'cboard.components.PinDialog.incorrectPin',
+    defaultMessage: 'Incorrect PIN. Please try again.'
+  },
+  cancel: {
+    id: 'cboard.components.PinDialog.cancel',
+    defaultMessage: 'Cancel'
+  },
+  unlock: {
+    id: 'cboard.components.PinDialog.unlock',
+    defaultMessage: 'Unlock'
+  }
+});

--- a/src/components/UI/PinDialog/PinDialog.messages.js
+++ b/src/components/UI/PinDialog/PinDialog.messages.js
@@ -20,5 +20,9 @@ export default defineMessages({
   unlock: {
     id: 'cboard.components.PinDialog.unlock',
     defaultMessage: 'Unlock'
+  },
+  togglePinVisibility: {
+    id: 'cboard.components.PinDialog.togglePinVisibility',
+    defaultMessage: 'Toggle PIN visibility'
   }
 });

--- a/src/components/UI/PinDialog/index.js
+++ b/src/components/UI/PinDialog/index.js
@@ -1,0 +1,1 @@
+export { default } from './PinDialog';


### PR DESCRIPTION
New PIN lock feature to enhance the security of the app's settings and board unlocking functionality. Users can now enable a 4-digit PIN lock in the navigation settings, which will require entering the correct PIN to unlock protected areas. The implementation covers both the settings UI and the board container logic, including a new PIN entry dialog component.

Changes:

**PIN Lock Feature Implementation:**
* Added `pinLockEnabled` and `pinCode` options to the navigation settings state, allowing users to enable/disable the PIN lock and set a 4-digit PIN.
* Updated the navigation settings UI to include switches and input fields for enabling PIN lock and entering the PIN, with validation and visibility toggle.

**PIN Dialog Component:**
* Added a new reusable `PinDialog` component for PIN entry, with support for input validation, visibility toggle, and error messaging.

**Board Unlock Logic:**
* Integrated PIN lock checks into the board lock/unlock flow in `Board.container.js`, displaying the PIN dialog when required and handling PIN validation and error states.

**Internationalization:**
* Added new internationalized messages for the PIN lock feature and dialog, ensuring all user-facing text is translatable.


Closes #2125 