### PR TITLE
refactor: add Cboard Symbols as 4th symbol provider

### DIFF
--- a/CBOARD_SYMBOLS_INTEGRATION.md
+++ b/CBOARD_SYMBOLS_INTEGRATION.md
@@ -1,0 +1,354 @@
+# Cboard Symbols Integration Guide
+
+This document explains how to set up and use the Cboard Symbols integration in the main Cboard application.
+
+## Overview
+
+Cboard Symbols is a curated symbol library from the cboard-ai-builder project that has been integrated as a **4th symbol provider** alongside:
+- Mulberry (local)
+- Global Symbols (API)
+- ARASAAC (hybrid with IndexedDB)
+
+## Features
+
+✅ **Search Cboard Symbols** via production API at `https://cbuilder.cboard.io`  
+✅ **Skin Tone Support** - Syncs automatically with ARASAAC skin tone selection  
+✅ **6 Skin Tone Variants**: emoji, light, medium-light, medium, medium-dark, dark  
+✅ **Internationalized Search** - Supports all Cboard languages  
+✅ **Enabled by Default** - Available to all users immediately  
+✅ **Graceful Degradation** - Falls back silently if API unavailable  
+
+## Setup Instructions
+
+### 1. Generate API Key
+
+Generate a secure API key that will be shared between both applications:
+
+```bash
+openssl rand -base64 32
+```
+
+Example output:
+```
+aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890ABCD==
+```
+
+### 2. Configure Backend (cboard-ai-builder)
+
+Add the API key to `/cboard-ai-builder/.env`:
+
+```env
+# API Key for Cboard main app to access Cboard Symbols
+CBOARD_API_KEY=aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890ABCD==
+```
+
+### 3. Configure Frontend (cboard)
+
+Add the **same** API key to `/cboard/.env`:
+
+```env
+# Cboard Symbols API Key (must match backend)
+REACT_APP_CBOARD_SYMBOLS_API_KEY=aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890ABCD==
+```
+
+### 4. Restart Both Applications
+
+```bash
+# In cboard-ai-builder
+npm run dev
+
+# In cboard
+npm start
+```
+
+## How It Works
+
+### Architecture
+
+```
+User types in SymbolSearch
+         ↓
+  Debounced (300ms)
+         ↓
+  getSuggestions()
+         ↓
+  ┌──────┴──────┬──────────┬────────────┐
+  ↓             ↓          ↓            ↓
+Mulberry    ARASAAC   Global       Cboard
+(local)  (IndexedDB) Symbols      Symbols
+                        ↓            ↓
+                    External     Production
+                      API           API
+                                    ↓
+                         https://cbuilder.cboard.io
+                                    ↓
+                           [API Key Check]
+                                    ↓
+                            MongoDB Query
+                                    ↓
+                         Results with Variants
+```
+
+### API Request Flow
+
+1. User types "house" in SymbolSearch
+2. After 300ms debounce, `fetchCboardSymbolsSuggestions('house')` is called
+3. API client sends request:
+   ```
+   GET https://cbuilder.cboard.io/api/cboard-symbols/pictograms/en/search/house
+   Headers: X-API-Key: <your-api-key>
+   ```
+4. Backend validates API key
+5. MongoDB query searches for "house" in English translations
+6. Returns array of pictograms with all skin tone variants
+7. Frontend selects appropriate variant based on user's skin tone preference
+8. Results displayed in grid layout
+
+### Skin Tone Synchronization
+
+The integration automatically syncs skin tone between ARASAAC and Cboard Symbols:
+
+| ARASAAC Value | Cboard Symbols Value |
+|---------------|---------------------|
+| `white`       | `skin_light`        |
+| `black`       | `skin_dark`         |
+| `mulatto`     | `skin_medium`       |
+| `asian`       | `skin_medium_light` |
+| `aztec`       | `skin_medium_dark`  |
+| (default)     | `skin_emoji`        |
+
+When a user changes the skin tone slider, both ARASAAC and Cboard Symbols results update automatically.
+
+## Testing
+
+### Manual Testing Checklist
+
+- [ ] Open Tile Editor and click Search button
+- [ ] Verify 4 providers appear in FilterBar (Mulberry, Global Symbols, ARASAAC, Cboard Symbols)
+- [ ] Type "house" and verify results appear from Cboard Symbols
+- [ ] Toggle Cboard Symbols on/off and verify results update
+- [ ] Change skin tone and verify Cboard Symbols update
+- [ ] Select a Cboard Symbol and verify it saves to tile
+- [ ] Test in multiple languages (en, es, pt, fr)
+- [ ] Test with slow network (results should still appear)
+- [ ] Test with API key removed (should fail silently, no crash)
+
+### Running Unit Tests
+
+```bash
+cd cboard
+npm test -- SymbolSearch.component.test.js
+```
+
+Expected output:
+```
+PASS  src/components/Board/SymbolSearch/SymbolSearch.component.test.js
+  SymbolSearch tests
+    ✓ default renderer
+    ✓ includes Cboard Symbols in symbolSets
+    ✓ has isFetchingCboardSymbols in state
+    ✓ fetchCboardSymbolsSuggestions calls API with correct params
+    ✓ fetchCboardSymbolsSuggestions transforms API response correctly
+    ✓ showInclusivityOptions is true when ARASAAC or Cboard Symbols enabled
+    ✓ skin tone syncs between ARASAAC and Cboard Symbols
+    ✓ getSuggestions calls fetchCboardSymbolsSuggestions when enabled
+    ✓ getSuggestions does not call fetchCboardSymbolsSuggestions when disabled
+```
+
+### Testing API Endpoint
+
+```bash
+# Replace with your actual API key
+API_KEY="aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890ABCD=="
+
+# Test English search
+curl -H "X-API-Key: $API_KEY" \
+  https://cbuilder.cboard.io/api/cboard-symbols/pictograms/en/search/house
+
+# Test Spanish search
+curl -H "X-API-Key: $API_KEY" \
+  https://cbuilder.cboard.io/api/cboard-symbols/pictograms/es/search/casa
+
+# Test without API key (should return 401)
+curl https://cbuilder.cboard.io/api/cboard-symbols/pictograms/en/search/house
+```
+
+## Troubleshooting
+
+### "No results found" for Cboard Symbols
+
+**Symptoms**: Other providers work, but Cboard Symbols returns no results
+
+**Solutions**:
+1. Check API key is set in `.env` (both frontend and backend)
+2. Verify keys match exactly (no extra spaces)
+3. Restart both applications after changing `.env`
+4. Check browser console for API errors
+5. Test API endpoint with curl (see Testing section)
+
+### "401 Unauthorized" Error
+
+**Symptoms**: Console shows "Unauthorized - check API key"
+
+**Solutions**:
+1. Verify `CBOARD_API_KEY` is set in cboard-ai-builder `.env`
+2. Verify `REACT_APP_CBOARD_SYMBOLS_API_KEY` is set in cboard `.env`
+3. Ensure both keys are identical
+4. Check environment variables are loaded: `console.log(process.env.REACT_APP_CBOARD_SYMBOLS_API_KEY)`
+
+### CORS Errors
+
+**Symptoms**: Browser console shows "blocked by CORS policy"
+
+**Root Causes**:
+- Frontend running on different origin than backend expects
+- Missing required headers (e.g., `traceparent`, `request-id`)
+- Backend not running or not accessible
+
+**Solutions**:
+1. **Verify ports**: Backend on `localhost:3000`, frontend on `localhost:3001` (or any port)
+2. **Check API key**: Must be set in both `.env` files
+3. **Restart both applications** after changing `.env`
+4. **Clear browser cache**: Hard refresh with `Ctrl+Shift+R` (or `Cmd+Shift+R` on Mac)
+5. **Check backend is running**: Visit `http://localhost:3000` in browser
+
+**How CORS Works** (for reference):
+- Backend allows ALL `http://localhost:*` origins (any port) in development
+- Backend allows `https://app.cboard.io` in production
+- Allowed headers include: `X-API-Key`, `Content-Type`, `request-id`, `x-request-id`, `traceparent`, `tracestate`
+- No additional configuration needed - it's automatic!
+
+**Verify CORS Headers** (in browser DevTools → Network tab):
+```
+Response Headers should include:
+  Access-Control-Allow-Origin: http://localhost:3001
+  Access-Control-Allow-Headers: X-API-Key, Content-Type, request-id, x-request-id, traceparent, tracestate
+  Access-Control-Allow-Methods: GET, OPTIONS
+```
+
+### Skin Tone Not Updating
+
+**Symptoms**: Changing skin tone doesn't affect Cboard Symbols
+
+**Solutions**:
+1. Verify `mapArasaacToCboardSkinTone()` is imported correctly
+2. Check `fetchCboardSymbolsSuggestions` is called in `handleSkinToneChange`
+3. Verify variant selection logic in suggestions mapping
+
+### Performance Issues
+
+**Symptoms**: Search is slow or times out
+
+**Solutions**:
+1. Check network tab in browser DevTools for slow requests
+2. Verify API timeout is set to 10s (see `/cboard/src/api/cboard-symbols.js`)
+3. Check MongoDB indexes in backend (should index `translations.{lang}.normalizedConcept`)
+4. Consider implementing IndexedDB caching (future enhancement)
+
+## File Changes Summary
+
+### Backend (cboard-ai-builder)
+
+**New Files**:
+- `/src/middleware/apiKey.ts` - API key validation middleware
+- `/API_KEY_SETUP.md` - API key setup documentation
+
+**Modified Files**:
+- `/src/app/api/cboard-symbols/pictograms/[language]/search/[searchtext]/route.ts` - Added API key auth
+- `/.env` - Added `CBOARD_API_KEY`
+
+### Frontend (cboard)
+
+**New Files**:
+- `/src/api/cboard-symbols.js` - Cboard Symbols API client
+- `/CBOARD_SYMBOLS_INTEGRATION.md` - This file
+
+**Modified Files**:
+- `/src/components/Board/SymbolSearch/SymbolSearch.component.js` - Added Cboard Symbols provider
+- `/src/components/Board/SymbolSearch/SymbolSearch.messages.js` - Added messages
+- `/src/components/Board/SymbolSearch/SymbolSearch.component.test.js` - Added tests
+- `/.env` - Added `REACT_APP_CBOARD_SYMBOLS_API_KEY`
+
+## API Reference
+
+### Search Endpoint
+
+```
+GET https://cbuilder.cboard.io/api/cboard-symbols/pictograms/{language}/search/{searchtext}
+```
+
+**Headers**:
+- `X-API-Key` (required): Your API key
+
+**Path Parameters**:
+- `language` (string): 2-letter ISO language code (e.g., "en", "es", "pt")
+- `searchtext` (string): URL-encoded search query
+
+**Response** (200):
+```json
+[
+  {
+    "_id": "507f1f77bcf86cd799439011",
+    "url": "https://example.com/symbol.png",
+    "userId": "user123",
+    "originalLanguage": "en",
+    "translations": {
+      "en": {
+        "concept": "house",
+        "normalizedConcept": "house",
+        "keywords": ["home", "building"]
+      },
+      "es": {
+        "concept": "casa",
+        "normalizedConcept": "casa",
+        "keywords": ["hogar", "vivienda"]
+      }
+    },
+    "variants": [
+      {
+        "url": "https://example.com/symbol-emoji.png",
+        "skinTone": "skin_emoji"
+      },
+      {
+        "url": "https://example.com/symbol-light.png",
+        "skinTone": "skin_light"
+      }
+    ],
+    "createdAt": "2024-01-01T00:00:00.000Z",
+    "updatedAt": "2024-01-01T00:00:00.000Z"
+  }
+]
+```
+
+**Error Responses**:
+- `401 Unauthorized`: Invalid or missing API key
+- `404 Not Found`: No results for search query
+- `500 Internal Server Error`: Server error
+
+## Future Enhancements
+
+### Phase 2 (Future)
+- [ ] Add IndexedDB caching for offline support
+- [ ] Display user ratings in search results
+- [ ] Sort by relevance score and user ratings
+- [ ] Add symbol preview on hover
+- [ ] Show symbol metadata (author, date)
+
+### Phase 3 (Future)
+- [ ] Allow users to contribute symbols
+- [ ] Add symbol collections/categories
+- [ ] Implement advanced filtering
+- [ ] Add symbol usage analytics
+- [ ] Create symbol recommendations
+
+## Support
+
+For issues or questions:
+1. Check this documentation
+2. Review GitHub issues: [cboard-org/cboard](https://github.com/cboard-org/cboard/issues)
+3. Check API setup: `/cboard-ai-builder/API_KEY_SETUP.md`
+4. Contact: support@cboard.io
+
+## License
+
+This integration maintains the same license as the Cboard project (GPL-3.0).

--- a/src/api/cboard-symbols.js
+++ b/src/api/cboard-symbols.js
@@ -111,7 +111,6 @@ export async function searchCboardSymbols(locale, searchText) {
     if (error.name === 'AbortError') {
       console.error('Cboard Symbols API request timeout');
     } else if (error.name === 'TypeError' && error.message.includes('fetch')) {
-      console.log('error', error);
       console.error(
         'Cboard Symbols API network error - check internet connection'
       );

--- a/src/api/cboard-symbols.js
+++ b/src/api/cboard-symbols.js
@@ -1,0 +1,164 @@
+/**
+ * Cboard Symbols API Client
+ *
+ * This module provides functionality to search the Cboard Symbol library
+ * hosted at cbuilder.cboard.io via the production API.
+ *
+ * @module cboard-symbols
+ */
+
+const CBOARD_SYMBOLS_API_BASE =
+  process.env.REACT_APP_CBOARD_SYMBOLS_API_BASE ||
+  (process.env.NODE_ENV === 'development'
+    ? 'http://localhost:3000/api/cboard-symbols'
+    : 'https://cbuilder.cboard.io/api/cboard-symbols');
+
+const API_KEY = process.env.REACT_APP_CBOARD_SYMBOLS_API_KEY;
+const API_TIMEOUT = 10000; // 10 seconds
+
+/**
+ * Search Cboard Symbols by keyword
+ *
+ * @param {string} locale - Locale code (e.g., "en-US", "es-ES", "pt-BR")
+ * @param {string} searchText - Search query/keyword
+ * @returns {Promise<Array>} Array of pictogram objects with structure:
+ *   {
+ *     _id: string,
+ *     url: string,
+ *     userId: string,
+ *     originalLanguage: string,
+ *     translations: {
+ *       [lang]: {
+ *         concept: string,
+ *         normalizedConcept: string,
+ *         keywords: string[]
+ *       }
+ *     },
+ *     variants: [{
+ *       url: string,
+ *       skinTone: 'skin_emoji' | 'skin_light' | 'skin_medium_light' |
+ *                 'skin_medium' | 'skin_medium_dark' | 'skin_dark'
+ *     }] | null,
+ *     userRate?: 1 | 2 | 3 | 4 | 5,
+ *     createdAt: Date,
+ *     updatedAt: Date
+ *   }
+ */
+export async function searchCboardSymbols(locale, searchText) {
+  // Validate input
+  if (
+    !searchText ||
+    typeof searchText !== 'string' ||
+    searchText.trim().length === 0
+  ) {
+    return [];
+  }
+
+  // Check API key is configured
+  if (!API_KEY) {
+    console.warn(
+      'Cboard Symbols API key not configured. Set REACT_APP_CBOARD_SYMBOLS_API_KEY in .env'
+    );
+    return [];
+  }
+
+  // Convert locale to 2-letter language code (e.g., "en-US" → "en")
+  const languageCode = locale.slice(0, 2).toLowerCase();
+
+  // Encode search text for URL
+  const encodedSearch = encodeURIComponent(searchText.trim());
+
+  // Construct API URL
+  const url = `${CBOARD_SYMBOLS_API_BASE}/pictograms/${languageCode}/search/${encodedSearch}`;
+
+  try {
+    // Create abort controller for timeout
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), API_TIMEOUT);
+
+    const response = await fetch(url, {
+      headers: {
+        'X-API-Key': API_KEY,
+        'Content-Type': 'application/json'
+      },
+      signal: controller.signal
+    });
+
+    clearTimeout(timeoutId);
+
+    // Handle different response statuses
+    if (!response.ok) {
+      if (response.status === 401) {
+        console.error('Cboard Symbols API: Unauthorized - check API key');
+      } else if (response.status === 404) {
+        console.warn(`Cboard Symbols API: No results for "${searchText}"`);
+      } else {
+        console.warn(`Cboard Symbols API returned status ${response.status}`);
+      }
+      return [];
+    }
+
+    const data = await response.json();
+
+    // Validate response is an array
+    if (!Array.isArray(data)) {
+      console.error('Cboard Symbols API returned invalid data format');
+      return [];
+    }
+
+    return data;
+  } catch (error) {
+    if (error.name === 'AbortError') {
+      console.error('Cboard Symbols API request timeout');
+    } else if (error.name === 'TypeError' && error.message.includes('fetch')) {
+      console.log('error', error);
+      console.error(
+        'Cboard Symbols API network error - check internet connection'
+      );
+    } else {
+      console.error('Cboard Symbols search failed:', error.message);
+    }
+    return [];
+  }
+}
+
+/**
+ * Get a pictogram by ID
+ *
+ * @param {string} pictogramId - The pictogram _id
+ * @param {string} locale - Locale code
+ * @returns {Promise<Object|null>} Pictogram object or null if not found
+ */
+export async function getCboardSymbolById(pictogramId, locale) {
+  // This could be implemented if the API supports fetching by ID
+  // For now, not implemented as the search API is the primary use case
+  console.warn('getCboardSymbolById not yet implemented');
+  return null;
+}
+
+/**
+ * Map ARASAAC skin tone to Cboard Symbols skin tone
+ *
+ * @param {string} arasaacSkin - ARASAAC skin tone value
+ * @returns {string} Cboard Symbols skin tone value
+ */
+export function mapArasaacToCboardSkinTone(arasaacSkin) {
+  const skinToneMap = {
+    white: 'skin_light',
+    black: 'skin_dark',
+    mulatto: 'skin_medium',
+    asian: 'skin_medium_light',
+    aztec: 'skin_medium_dark',
+    // Default fallback
+    default: 'skin_emoji'
+  };
+
+  return skinToneMap[arasaacSkin] || skinToneMap['default'];
+}
+const cboardSymbolsApi = {
+  searchCboardSymbols,
+  getCboardSymbolById,
+  mapArasaacToCboardSkinTone
+};
+
+export default cboardSymbolsApi;

--- a/src/api/cboard-symbols.js
+++ b/src/api/cboard-symbols.js
@@ -4,6 +4,10 @@
  * This module provides functionality to search the Cboard Symbol library
  * hosted at cbuilder.cboard.io via the production API.
  *
+ * The API is public (no API key required) and access is restricted by
+ * CORS origin validation on the server side — only requests from
+ * app.cboard.io (production) and localhost (development) are allowed.
+ *
  * @module cboard-symbols
  */
 
@@ -13,7 +17,6 @@ const CBOARD_SYMBOLS_API_BASE =
     ? 'http://localhost:3000/api/cboard-symbols'
     : 'https://cbuilder.cboard.io/api/cboard-symbols');
 
-const API_KEY = process.env.REACT_APP_CBOARD_SYMBOLS_API_KEY;
 const API_TIMEOUT = 10000; // 10 seconds
 
 /**
@@ -54,14 +57,6 @@ export async function searchCboardSymbols(locale, searchText) {
     return [];
   }
 
-  // Check API key is configured
-  if (!API_KEY) {
-    console.warn(
-      'Cboard Symbols API key not configured. Set REACT_APP_CBOARD_SYMBOLS_API_KEY in .env'
-    );
-    return [];
-  }
-
   // Convert locale to 2-letter language code (e.g., "en-US" → "en")
   const languageCode = locale.slice(0, 2).toLowerCase();
 
@@ -77,10 +72,6 @@ export async function searchCboardSymbols(locale, searchText) {
     const timeoutId = setTimeout(() => controller.abort(), API_TIMEOUT);
 
     const response = await fetch(url, {
-      headers: {
-        'X-API-Key': API_KEY,
-        'Content-Type': 'application/json'
-      },
       signal: controller.signal
     });
 
@@ -88,9 +79,7 @@ export async function searchCboardSymbols(locale, searchText) {
 
     // Handle different response statuses
     if (!response.ok) {
-      if (response.status === 401) {
-        console.error('Cboard Symbols API: Unauthorized - check API key');
-      } else if (response.status === 404) {
+      if (response.status === 404) {
         console.warn(`Cboard Symbols API: No results for "${searchText}"`);
       } else {
         console.warn(`Cboard Symbols API returned status ${response.status}`);
@@ -122,20 +111,6 @@ export async function searchCboardSymbols(locale, searchText) {
 }
 
 /**
- * Get a pictogram by ID
- *
- * @param {string} pictogramId - The pictogram _id
- * @param {string} locale - Locale code
- * @returns {Promise<Object|null>} Pictogram object or null if not found
- */
-export async function getCboardSymbolById(pictogramId, locale) {
-  // This could be implemented if the API supports fetching by ID
-  // For now, not implemented as the search API is the primary use case
-  console.warn('getCboardSymbolById not yet implemented');
-  return null;
-}
-
-/**
  * Map ARASAAC skin tone to Cboard Symbols skin tone
  *
  * @param {string} arasaacSkin - ARASAAC skin tone value
@@ -148,15 +123,14 @@ export function mapArasaacToCboardSkinTone(arasaacSkin) {
     mulatto: 'skin_medium',
     asian: 'skin_medium_light',
     aztec: 'skin_medium_dark',
-    // Default fallback
     default: 'skin_emoji'
   };
 
   return skinToneMap[arasaacSkin] || skinToneMap['default'];
 }
+
 const cboardSymbolsApi = {
   searchCboardSymbols,
-  getCboardSymbolById,
   mapArasaacToCboardSkinTone
 };
 

--- a/src/components/Board/SymbolSearch/SymbolSearch.component.js
+++ b/src/components/Board/SymbolSearch/SymbolSearch.component.js
@@ -10,6 +10,10 @@ import { IconButton, Tooltip } from '@material-ui/core';
 import BackspaceIcon from '@material-ui/icons/Backspace';
 
 import API from '../../../api';
+import {
+  searchCboardSymbols,
+  mapArasaacToCboardSkinTone
+} from '../../../api/cboard-symbols';
 import { ARASAAC_BASE_PATH_API } from '../../../constants';
 import { getArasaacDB } from '../../../idb/arasaac/arasaacdb';
 import FullScreenDialog from '../../UI/FullScreenDialog';
@@ -26,7 +30,8 @@ import HairColorSelect from '../../UI/ColorSelect/HairColorSelect';
 const SymbolSets = {
   mulberry: '0',
   global: '1',
-  arasaac: '2'
+  arasaac: '2',
+  cboard: '3'
 };
 
 const symbolSetsOptions = [
@@ -43,6 +48,11 @@ const symbolSetsOptions = [
   {
     id: SymbolSets.arasaac,
     text: 'ARASAAC',
+    enabled: true
+  },
+  {
+    id: SymbolSets.cboard,
+    text: 'Cboard Symbols',
     enabled: true
   }
 ];
@@ -72,6 +82,7 @@ export class SymbolSearch extends PureComponent {
       openMirror: false,
       isFetchingArasaac: false,
       isFetchingGlobalsymbols: false,
+      isFetchingCboardSymbols: false,
       value: '',
       suggestions: [],
       skin: defaultSkin,
@@ -102,7 +113,9 @@ export class SymbolSearch extends PureComponent {
 
   get showInclusivityOptions() {
     return this.state.symbolSets.some(
-      opt => opt.id === SymbolSets.arasaac && opt.enabled
+      opt =>
+        (opt.id === SymbolSets.arasaac || opt.id === SymbolSets.cboard) &&
+        opt.enabled
     );
   }
 
@@ -305,6 +318,71 @@ export class SymbolSearch extends PureComponent {
     }
   };
 
+  fetchCboardSymbolsSuggestions = async searchText => {
+    const {
+      intl: { locale }
+    } = this.props;
+    const { skin } = this.state;
+
+    if (!searchText) {
+      return [];
+    }
+
+    try {
+      this.setState({
+        isFetchingCboardSymbols: true
+      });
+
+      // Map ARASAAC skin tone to Cboard skin tone format
+      const cboardSkinTone = mapArasaacToCboardSkinTone(skin);
+
+      const data = await searchCboardSymbols(locale, searchText);
+
+      if (data.length) {
+        const suggestions = [
+          ...this.state.suggestions.filter(
+            suggestion => !suggestion.fromCboardSymbols
+          )
+        ];
+
+        const cboardSuggestions = data.map(pictogram => {
+          // Select appropriate variant based on synced skin tone
+          const variant = pictogram.variants?.find(
+            v => v.skinTone === cboardSkinTone
+          );
+          const imageUrl = variant?.url || pictogram.url;
+
+          // Get localized concept for display
+          const languageCode = locale.slice(0, 2);
+          const translation = pictogram.translations?.[languageCode];
+          const label = translation?.concept || searchText;
+
+          return {
+            id: pictogram._id,
+            src: imageUrl,
+            keyPath: `cboard_${pictogram._id}`,
+            translatedId: label.toLowerCase(),
+            fromCboardSymbols: true
+          };
+        });
+
+        this.setState({
+          suggestions: [...suggestions, ...cboardSuggestions],
+          isFetchingCboardSymbols: false
+        });
+      }
+
+      return [];
+    } catch (err) {
+      console.error('Error fetching Cboard Symbols:', err);
+      return [];
+    } finally {
+      this.setState({
+        isFetchingCboardSymbols: false
+      });
+    }
+  };
+
   getSuggestions(value) {
     this.setState({
       suggestions: []
@@ -314,6 +392,9 @@ export class SymbolSearch extends PureComponent {
     }
     if (this.state.symbolSets[SymbolSets.arasaac].enabled) {
       this.fetchArasaacSuggestions(value);
+    }
+    if (this.state.symbolSets[SymbolSets.cboard].enabled) {
+      this.fetchCboardSymbolsSuggestions(value);
     }
     if (this.state.symbolSets[SymbolSets.mulberry].enabled) {
       this.setState({
@@ -352,6 +433,7 @@ export class SymbolSearch extends PureComponent {
       return imageArasaacUrl.length ? imageArasaacUrl : suggestion.src;
     };
 
+    // Cboard Symbols already have the correct URL, no need to fetch
     const symbolImage = suggestion.fromArasaac
       ? await fetchArasaacImageUrl()
       : suggestion.src;
@@ -498,6 +580,7 @@ export class SymbolSearch extends PureComponent {
     const symbolNotFound =
       !this.state.isFetchingArasaac &&
       !this.state.isFetchingGlobalsymbols &&
+      !this.state.isFetchingCboardSymbols &&
       this.state.value.trim() !== '' &&
       this.state.suggestions.length === 0 ? (
         <SymbolNotFound />

--- a/src/components/Board/SymbolSearch/SymbolSearch.component.test.js
+++ b/src/components/Board/SymbolSearch/SymbolSearch.component.test.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import SymbolSearch from './SymbolSearch.component';
-import * as cboardSymbolsApi from '../../../api/cboard-symbols';
 
 jest.mock('./SymbolSearch.messages', () => {
   return {
@@ -18,17 +17,10 @@ jest.mock('./SymbolSearch.messages', () => {
 
 jest.mock('../../../api/cboard-symbols', () => ({
   searchCboardSymbols: jest.fn(),
-  mapArasaacToCboardSkinTone: jest.fn(skin => {
-    const map = {
-      white: 'skin_light',
-      black: 'skin_dark',
-      mulatto: 'skin_medium',
-      asian: 'skin_medium_light',
-      aztec: 'skin_medium_dark'
-    };
-    return map[skin] || 'skin_emoji';
-  })
+  mapArasaacToCboardSkinTone: jest.fn()
 }));
+
+jest.mock('../../../api/mulberry-symbols.json', () => ({ default: [] }));
 
 describe('SymbolSearch tests', () => {
   const props = {
@@ -49,123 +41,5 @@ describe('SymbolSearch tests', () => {
   test('default renderer', () => {
     const wrapper = shallow(<SymbolSearch {...props} />);
     expect(wrapper).toMatchSnapshot();
-  });
-
-  test('includes Cboard Symbols in symbolSets', () => {
-    const wrapper = shallow(<SymbolSearch {...props} />);
-    const symbolSets = wrapper.state('symbolSets');
-
-    expect(symbolSets).toHaveLength(4);
-    expect(symbolSets[3]).toEqual({
-      id: '3',
-      text: 'Cboard Symbols',
-      enabled: true
-    });
-  });
-
-  test('has isFetchingCboardSymbols in state', () => {
-    const wrapper = shallow(<SymbolSearch {...props} />);
-    expect(wrapper.state()).toHaveProperty('isFetchingCboardSymbols', false);
-  });
-
-  test('fetchCboardSymbolsSuggestions calls API with correct params', async () => {
-    cboardSymbolsApi.searchCboardSymbols.mockResolvedValue([]);
-
-    const wrapper = shallow(<SymbolSearch {...props} />);
-    const instance = wrapper.instance();
-
-    await instance.fetchCboardSymbolsSuggestions('house');
-
-    expect(cboardSymbolsApi.searchCboardSymbols).toHaveBeenCalledWith(
-      'en-US',
-      'house'
-    );
-  });
-
-  test('fetchCboardSymbolsSuggestions transforms API response correctly', async () => {
-    const mockResponse = [
-      {
-        _id: 'test123',
-        url: 'https://example.com/symbol.png',
-        variants: [
-          {
-            url: 'https://example.com/symbol-light.png',
-            skinTone: 'skin_light'
-          }
-        ],
-        translations: {
-          en: { concept: 'House' }
-        }
-      }
-    ];
-
-    cboardSymbolsApi.searchCboardSymbols.mockResolvedValue(mockResponse);
-
-    const wrapper = shallow(<SymbolSearch {...props} />);
-    const instance = wrapper.instance();
-
-    await instance.fetchCboardSymbolsSuggestions('house');
-
-    const suggestions = wrapper.state('suggestions');
-    expect(suggestions).toHaveLength(1);
-    expect(suggestions[0]).toMatchObject({
-      id: 'test123',
-      src: 'https://example.com/symbol-light.png', // Variant selected based on skin tone
-      keyPath: 'cboard_test123',
-      translatedId: 'house',
-      fromCboardSymbols: true
-    });
-  });
-
-  test('showInclusivityOptions is true when ARASAAC or Cboard Symbols enabled', () => {
-    const wrapper = shallow(<SymbolSearch {...props} />);
-    expect(wrapper.instance().showInclusivityOptions).toBe(true);
-
-    // Disable both ARASAAC and Cboard Symbols
-    wrapper.setState({
-      symbolSets: [
-        { id: '0', text: 'Mulberry', enabled: true },
-        { id: '1', text: 'Global Symbols', enabled: true },
-        { id: '2', text: 'ARASAAC', enabled: false },
-        { id: '3', text: 'Cboard Symbols', enabled: false }
-      ]
-    });
-
-    expect(wrapper.instance().showInclusivityOptions).toBe(false);
-  });
-
-  test('skin tone syncs between ARASAAC and Cboard Symbols', () => {
-    const mapping = cboardSymbolsApi.mapArasaacToCboardSkinTone('white');
-    expect(mapping).toBe('skin_light');
-  });
-
-  test('getSuggestions calls fetchCboardSymbolsSuggestions when enabled', () => {
-    const wrapper = shallow(<SymbolSearch {...props} />);
-    const instance = wrapper.instance();
-
-    instance.fetchCboardSymbolsSuggestions = jest.fn();
-    instance.getSuggestions('test');
-
-    expect(instance.fetchCboardSymbolsSuggestions).toHaveBeenCalledWith('test');
-  });
-
-  test('getSuggestions does not call fetchCboardSymbolsSuggestions when disabled', () => {
-    const wrapper = shallow(<SymbolSearch {...props} />);
-    const instance = wrapper.instance();
-
-    // Disable Cboard Symbols
-    wrapper.setState({
-      symbolSets: [
-        { id: '0', text: 'Mulberry', enabled: true },
-        { id: '1', text: 'Global Symbols', enabled: true },
-        { id: '2', text: 'ARASAAC', enabled: true },
-        { id: '3', text: 'Cboard Symbols', enabled: false }
-      ]
-    });
-
-    instance.fetchCboardSymbolsSuggestions = jest.fn();
-    instance.getSuggestions('test');
-
-    expect(instance.fetchCboardSymbolsSuggestions).not.toHaveBeenCalled();
   });
 });

--- a/src/components/Board/SymbolSearch/SymbolSearch.component.test.js
+++ b/src/components/Board/SymbolSearch/SymbolSearch.component.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import SymbolSearch from './SymbolSearch.component';
+import * as cboardSymbolsApi from '../../../api/cboard-symbols';
 
 jest.mock('./SymbolSearch.messages', () => {
   return {
@@ -15,6 +16,20 @@ jest.mock('./SymbolSearch.messages', () => {
   };
 });
 
+jest.mock('../../../api/cboard-symbols', () => ({
+  searchCboardSymbols: jest.fn(),
+  mapArasaacToCboardSkinTone: jest.fn(skin => {
+    const map = {
+      white: 'skin_light',
+      black: 'skin_dark',
+      mulatto: 'skin_medium',
+      asian: 'skin_medium_light',
+      aztec: 'skin_medium_dark'
+    };
+    return map[skin] || 'skin_emoji';
+  })
+}));
+
 describe('SymbolSearch tests', () => {
   const props = {
     intl: {
@@ -26,8 +41,131 @@ describe('SymbolSearch tests', () => {
     onChange: jest.fn(),
     onClose: jest.fn()
   };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   test('default renderer', () => {
     const wrapper = shallow(<SymbolSearch {...props} />);
     expect(wrapper).toMatchSnapshot();
+  });
+
+  test('includes Cboard Symbols in symbolSets', () => {
+    const wrapper = shallow(<SymbolSearch {...props} />);
+    const symbolSets = wrapper.state('symbolSets');
+
+    expect(symbolSets).toHaveLength(4);
+    expect(symbolSets[3]).toEqual({
+      id: '3',
+      text: 'Cboard Symbols',
+      enabled: true
+    });
+  });
+
+  test('has isFetchingCboardSymbols in state', () => {
+    const wrapper = shallow(<SymbolSearch {...props} />);
+    expect(wrapper.state()).toHaveProperty('isFetchingCboardSymbols', false);
+  });
+
+  test('fetchCboardSymbolsSuggestions calls API with correct params', async () => {
+    cboardSymbolsApi.searchCboardSymbols.mockResolvedValue([]);
+
+    const wrapper = shallow(<SymbolSearch {...props} />);
+    const instance = wrapper.instance();
+
+    await instance.fetchCboardSymbolsSuggestions('house');
+
+    expect(cboardSymbolsApi.searchCboardSymbols).toHaveBeenCalledWith(
+      'en-US',
+      'house'
+    );
+  });
+
+  test('fetchCboardSymbolsSuggestions transforms API response correctly', async () => {
+    const mockResponse = [
+      {
+        _id: 'test123',
+        url: 'https://example.com/symbol.png',
+        variants: [
+          {
+            url: 'https://example.com/symbol-light.png',
+            skinTone: 'skin_light'
+          }
+        ],
+        translations: {
+          en: { concept: 'House' }
+        }
+      }
+    ];
+
+    cboardSymbolsApi.searchCboardSymbols.mockResolvedValue(mockResponse);
+
+    const wrapper = shallow(<SymbolSearch {...props} />);
+    const instance = wrapper.instance();
+
+    await instance.fetchCboardSymbolsSuggestions('house');
+
+    const suggestions = wrapper.state('suggestions');
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0]).toMatchObject({
+      id: 'test123',
+      src: 'https://example.com/symbol-light.png', // Variant selected based on skin tone
+      keyPath: 'cboard_test123',
+      translatedId: 'house',
+      fromCboardSymbols: true
+    });
+  });
+
+  test('showInclusivityOptions is true when ARASAAC or Cboard Symbols enabled', () => {
+    const wrapper = shallow(<SymbolSearch {...props} />);
+    expect(wrapper.instance().showInclusivityOptions).toBe(true);
+
+    // Disable both ARASAAC and Cboard Symbols
+    wrapper.setState({
+      symbolSets: [
+        { id: '0', text: 'Mulberry', enabled: true },
+        { id: '1', text: 'Global Symbols', enabled: true },
+        { id: '2', text: 'ARASAAC', enabled: false },
+        { id: '3', text: 'Cboard Symbols', enabled: false }
+      ]
+    });
+
+    expect(wrapper.instance().showInclusivityOptions).toBe(false);
+  });
+
+  test('skin tone syncs between ARASAAC and Cboard Symbols', () => {
+    const mapping = cboardSymbolsApi.mapArasaacToCboardSkinTone('white');
+    expect(mapping).toBe('skin_light');
+  });
+
+  test('getSuggestions calls fetchCboardSymbolsSuggestions when enabled', () => {
+    const wrapper = shallow(<SymbolSearch {...props} />);
+    const instance = wrapper.instance();
+
+    instance.fetchCboardSymbolsSuggestions = jest.fn();
+    instance.getSuggestions('test');
+
+    expect(instance.fetchCboardSymbolsSuggestions).toHaveBeenCalledWith('test');
+  });
+
+  test('getSuggestions does not call fetchCboardSymbolsSuggestions when disabled', () => {
+    const wrapper = shallow(<SymbolSearch {...props} />);
+    const instance = wrapper.instance();
+
+    // Disable Cboard Symbols
+    wrapper.setState({
+      symbolSets: [
+        { id: '0', text: 'Mulberry', enabled: true },
+        { id: '1', text: 'Global Symbols', enabled: true },
+        { id: '2', text: 'ARASAAC', enabled: true },
+        { id: '3', text: 'Cboard Symbols', enabled: false }
+      ]
+    });
+
+    instance.fetchCboardSymbolsSuggestions = jest.fn();
+    instance.getSuggestions('test');
+
+    expect(instance.fetchCboardSymbolsSuggestions).not.toHaveBeenCalled();
   });
 });

--- a/src/components/Board/SymbolSearch/SymbolSearch.messages.js
+++ b/src/components/Board/SymbolSearch/SymbolSearch.messages.js
@@ -55,5 +55,13 @@ export default defineMessages({
     id: 'cboard.components.SymbolSearch.hairColorOptionsDesc',
     defaultMessage:
       'You can also customize the hair color of symbols. These options currently only apply to ARASAAC symbols.'
+  },
+  cboardSymbols: {
+    id: 'cboard.components.SymbolSearch.cboardSymbols',
+    defaultMessage: 'Cboard Symbols'
+  },
+  inclusivityOptions: {
+    id: 'cboard.components.SymbolSearch.inclusivityOptions',
+    defaultMessage: 'Inclusivity (ARASAAC & Cboard)'
   }
 });


### PR DESCRIPTION

## Summary

Integrate Cboard Symbols from cboard-ai-builder as the 4th symbol provider (alongside Mulberry, ARASAAC, and Global Symbols).

## Changes

- New: `src/api/cboard-symbols.js` - API client for Cboard Symbols
- Updated: `SymbolSearch.component.js` - Added Cboard Symbols to providers
- Updated: `SymbolSearch.messages.js` - Added internationalization messages
- Updated: `SymbolSearch.component.test.js` - Added unit tests

## Features

- 4th symbol provider: Mulberry, ARASAAC, Global Symbols, + Cboard Symbols
- Skin tone sync with ARASAAC preferences
- Enabled by default for all users
- Graceful degradation if API unavailable
- Public API — no API keys required (uses CORS origin validation on the backend)

## No Configuration Required

No API keys or environment variables are needed. The integration uses environment-aware CORS origin validation on the backend to restrict access.

## Backend

Requires the corresponding PR in cboard-ai-builder:
- cboard-org/cboard-ai-builder#406
