### PR TITLE
fix: tolerate image fetch failures during OpenBoard export

### DIFF
--- a/src/components/Settings/Export/Export.helpers.js
+++ b/src/components/Settings/Export/Export.helpers.js
@@ -172,29 +172,34 @@ async function boardToOBF(boardsMap, board = {}, intl, { embed = false }) {
               ? `.${tile.image}`
               : tile.image;
 
-          const imageResponse = image.startsWith('data:')
-            ? getBase64Image(image)
-            : await getDataUri(image);
-
-          const getCustomImagePath = () => {
-            const components = [
-              'custom',
-              board.name || board.nameKey,
-              tile.label || tile.labelKey || tile.id
-            ];
-            const extension = mime.extension(imageResponse['content_type']);
-            return `/${_.join(components, '/')}.${extension}`;
-          };
-
-          const path = image.startsWith('data:')
-            ? getCustomImagePath()
-            : isCordova()
-            ? ''
-            : image.startsWith('/')
-            ? image
-            : `/${image}`;
+          let imageResponse = null;
+          try {
+            imageResponse = image.startsWith('data:')
+              ? getBase64Image(image)
+              : await getDataUri(image);
+          } catch (err) {
+            console.warn(`Skipping image for tile ${tile.id}.`, err);
+          }
 
           if (imageResponse) {
+            const getCustomImagePath = () => {
+              const components = [
+                'custom',
+                board.name || board.nameKey,
+                tile.label || tile.labelKey || tile.id
+              ];
+              const extension = mime.extension(imageResponse['content_type']);
+              return `/${_.join(components, '/')}.${extension}`;
+            };
+
+            const path = image.startsWith('data:')
+              ? getCustomImagePath()
+              : isCordova()
+              ? ''
+              : image.startsWith('/')
+              ? image
+              : `/${image}`;
+
             const imageID = new mongoose.Types.ObjectId().toString();
             fetchedImages[imageID] = _.defaults({ path }, imageResponse);
             button['image_id'] = imageID;
@@ -750,13 +755,16 @@ export async function openboardExportManyAdapter(boards = [], intl) {
   for (let i = 0; i < boardsLength; i++) {
     const board = boards[i];
     const boardMapFilename = `boards/${board.id}.obf`;
-    const { obf, images } = await boardToOBF(boardsMap, board, intl, {
-      embed: false
-    });
-
-    if (!obf) {
+    let result;
+    try {
+      result = await boardToOBF(boardsMap, board, intl, { embed: false });
+    } catch (err) {
+      console.warn(`Skipping board ${board.id} during OpenBoard export.`, err);
       continue;
     }
+
+    const { obf, images } = result;
+    if (!obf) continue;
 
     zip.file(boardMapFilename, JSON.stringify(obf, null, 2));
 


### PR DESCRIPTION
Closes #2156.

## Summary

- A single unreachable tile image (CORS, 404, offline, malformed data URI) would reject the `Promise.all` inside `boardToOBF`, aborting the whole `.obz` export and surfacing the generic *"Ups..Something went wrong"* notification.
- `boardToOBF` now wraps image resolution in try/catch. Tiles whose image can't be fetched/decoded are written without an `image_id` instead of rejecting the board. The `path` / `getCustomImagePath` computation is guarded behind the `if (imageResponse)` check so it cannot dereference a null response.
- `openboardExportManyAdapter` now wraps the per-board `boardToOBF` call so a catastrophic failure on one board skips that board instead of aborting the entire zip.

## Test plan

- [ ] Block one tile image URL in devtools (simulate CORS / 404). Run "Export all boards" as OpenBoard — export completes, `.obz` imports cleanly, failing tile has no image (placeholder) but surrounding tiles and board navigation are intact.
- [ ] Happy path: export an unmodified account as OpenBoard — output is equivalent to pre-patch behavior.
- [ ] Single-board OpenBoard export (`openboardExportOneAdapter`) still works — unchanged code path.
- [ ] Logged-out local-only install: export/import roundtrip does not regress.