### PR TITLE
fix: address TTS voices array safety (#2047) and iOS Dynamic Type tile hit-area (#2064)

### DIFF
--- a/src/components/Board/Tile/Tile.css
+++ b/src/components/Board/Tile/Tile.css
@@ -8,8 +8,35 @@
 
   --folder-flap-height: 12px;
 
+  /*
+   * Issue #2064: guarantee a tap target that scales with user text size.
+   * 2.75rem ~= 44px at default root font size, matching Apple HIG and
+   * WCAG 2.5.5 minimum touch target. Using `rem` means the hit area
+   * grows with iOS Dynamic Type / system Text Size so the visible label
+   * and the tappable region stay aligned.
+   */
+  min-width: 2.75rem;
+  min-height: 2.75rem;
+
+  /* Suppress the iOS 300ms double-tap-zoom delay that can make taps feel
+   * unresponsive on high Dynamic Type settings. */
+  touch-action: manipulation;
+
   /* HACK: fixes iOS flicker on scroll */
   transform: translateZ(0);
+}
+
+/*
+ * Issue #2064: ensure taps always reach the <button> even when the
+ * Symbol overlay's decorative children (image, label) visually overflow
+ * or sit on top of the button. Without this the Typography label could
+ * absorb taps on iOS Safari when Dynamic Type scaled it past the tile
+ * bounds, producing "off-center" tap behavior.
+ */
+.Tile .Symbol,
+.Tile .Symbol__image-container,
+.Tile .Symbol__label {
+  pointer-events: none;
 }
 
 .Tile:not(.scanner__focused) {

--- a/src/providers/SpeechProvider/__tests__/tts.test.js
+++ b/src/providers/SpeechProvider/__tests__/tts.test.js
@@ -1,0 +1,109 @@
+/**
+ * Regression tests for `_getPlatformVoices` and `getVoices`.
+ *
+ * Fixes issue #2047: "Wrong voices initial value definition on tts file".
+ *
+ * The original bug: `_getPlatformVoices` initialized `voices` as `{}` and
+ * returned `voices._list || voices`. When `synth.getVoices()` threw, or a
+ * platform returned a non-array, the caller's `platformVoices.concat(...)`
+ * would throw a TypeError and crash the app.
+ *
+ * These tests lock in the guarantee that `_getPlatformVoices` always returns
+ * an array and that `getVoices` safely concatenates its three sources.
+ */
+
+// Mock dependencies that `tts.js` pulls in at import time. Keep them minimal;
+// we only exercise `_getPlatformVoices` and `getVoices` here.
+jest.mock('../../../api', () => ({
+  __esModule: true,
+  default: {
+    getAzureVoices: jest.fn().mockResolvedValue([])
+  }
+}));
+
+jest.mock('../../../store', () => ({
+  getStore: () => ({
+    getState: () => ({
+      speech: { voices: [] },
+      app: { isConnected: false }
+    })
+  })
+}));
+
+jest.mock('microsoft-cognitiveservices-speech-sdk', () => ({
+  SpeechConfig: { fromSubscription: jest.fn() },
+  SpeechSynthesizer: jest.fn()
+}));
+
+jest.mock('../../../cordova-util', () => ({
+  isAndroid: () => false,
+  isCordova: () => false
+}));
+
+describe('tts._getPlatformVoices (issue #2047 regression)', () => {
+  let tts;
+  let getVoicesMock;
+
+  beforeEach(() => {
+    jest.resetModules();
+    getVoicesMock = jest.fn();
+
+    // `tts.js` captures `window.speechSynthesis` at import time, so install
+    // the mock *before* requiring the module.
+    global.window = global.window || {};
+    global.window.speechSynthesis = {
+      getVoices: getVoicesMock,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn()
+    };
+
+    tts = require('../tts').default;
+  });
+
+  it('returns an array when synth.getVoices() returns an empty object (the original bug)', () => {
+    getVoicesMock.mockReturnValue({});
+    const result = tts._getPlatformVoices();
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toEqual([]);
+  });
+
+  it('returns an array when synth.getVoices() returns undefined', () => {
+    getVoicesMock.mockReturnValue(undefined);
+    const result = tts._getPlatformVoices();
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toEqual([]);
+  });
+
+  it('returns an array when synth.getVoices() throws', () => {
+    getVoicesMock.mockImplementation(() => {
+      throw new Error('speechSynthesis unavailable');
+    });
+    const result = tts._getPlatformVoices();
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toEqual([]);
+  });
+
+  it('returns the array when synth.getVoices() returns a proper array', () => {
+    const fakeVoices = [
+      { voiceURI: 'en-US-1', name: 'Voice 1', lang: 'en-US' },
+      { voiceURI: 'es-ES-1', name: 'Voice 2', lang: 'es-ES' }
+    ];
+    getVoicesMock.mockReturnValue(fakeVoices);
+    const result = tts._getPlatformVoices();
+    expect(result).toEqual(fakeVoices);
+  });
+
+  it('unwraps Cordova-style `._list` when present', () => {
+    const fakeList = [{ voiceURI: 'cordova-1', name: 'Cordova Voice' }];
+    getVoicesMock.mockReturnValue({ _list: fakeList });
+    const result = tts._getPlatformVoices();
+    expect(result).toEqual(fakeList);
+  });
+
+  it('guarantees the result of _getPlatformVoices supports .concat without throwing', () => {
+    getVoicesMock.mockReturnValue({}); // the historical bug trigger
+    const platformVoices = tts._getPlatformVoices();
+    // This is the exact call site that used to throw (see tts.js getVoices()).
+    expect(() => platformVoices.concat([]).concat([])).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Addresses two open bugs:

- **#2047** — `_getPlatformVoices` could return a non-array (or throw), crashing `.concat` in `getVoices()`. The runtime fix already landed via PR #2049; this PR adds the regression tests that were missing so the guarantee is locked in.
- **#2064** — On iOS with Accessibility Text Size above default, tile buttons were misaligned and unresponsive. Taps had to land off-center to register.

## Changes

### `src/providers/SpeechProvider/__tests__/tts.test.js` (new)
Regression tests for `_getPlatformVoices` covering five return paths:
- `synth.getVoices()` returns `{}` (the original bug from #2047)
- `synth.getVoices()` returns `undefined`
- `synth.getVoices()` throws
- `synth.getVoices()` returns a proper array
- Cordova `{ _list: [...] }` shape

Plus an explicit assertion that the result supports `.concat(...)` without throwing, which is the exact call site that used to crash.

### `src/components/Board/Tile/Tile.css`
- Added `min-width: 2.75rem` / `min-height: 2.75rem` so the tile hit area scales with iOS Dynamic Type and meets WCAG 2.5.5 / Apple HIG's 44px minimum tap target.
- Added `touch-action: manipulation` to remove iOS Safari's 300ms double-tap-zoom delay, which made taps feel unresponsive at large text sizes.
- Added `pointer-events: none` to `.Symbol`, `.Symbol__image-container`, and `.Symbol__label` so decorative overlays can't absorb taps when Dynamic Type scales them past the tile bounds (this was the "off-center tap" symptom).

## Testing

- `yarn test --testPathPattern="SpeechProvider/__tests__/tts.test"` — all 6 tests pass.
- Manual: verified tile taps register at center with iOS Simulator Larger Text enabled; no visual regression at default text size on desktop.

## Notes

- This branch combines two fixes into one PR for coursework reasons. Happy to split into two PRs if preferred.
- Issue #2047 also has open PR #2057 and issue #2064 has open PR #2078 — those address the runtime/markup fixes. This PR is complementary (test coverage + CSS-only hit-area hardening).

Fixes #2047
Fixes #2064