### PR TITLE
Fix communication history export user handling and tracked user IDs

### DIFF
--- a/src/components/Board/Board.container.js
+++ b/src/components/Board/Board.container.js
@@ -908,11 +908,7 @@ export class BoardContainer extends Component {
       if (!this.sessionId) {
         this.sessionId = sessionId;
       }
-      trackSymbolSelection(
-        enhancedTile,
-        userData?.email || userData?.id || null,
-        sessionId
-      );
+      trackSymbolSelection(enhancedTile, userData?.id || null, sessionId);
 
       clickSymbol(tile.label);
       if (!navigationSettings.quietBuilderMode) {

--- a/src/components/Board/Output/Output.container.js
+++ b/src/components/Board/Output/Output.container.js
@@ -185,11 +185,7 @@ export class OutputContainer extends Component {
       await this.speakOutput(liveText);
     } else {
       if (output.length > 0) {
-        trackPhraseSpoken(
-          output,
-          userData?.email || userData?.id || null,
-          sessionId
-        );
+        trackPhraseSpoken(output, userData?.id || null, sessionId);
       }
 
       const outputFrames = this.groupOutputByType();
@@ -221,14 +217,14 @@ export class OutputContainer extends Component {
       sessionId
     } = this.props;
     cancelSpeech();
-    trackBackspaceAction(userData?.email || userData?.id || null, sessionId);
+    trackBackspaceAction(userData?.id || null, sessionId);
     this.popOutput();
   };
 
   handleClearClick = () => {
     const { cancelSpeech, trackClearAction, userData, sessionId } = this.props;
     cancelSpeech();
-    trackClearAction(userData?.email || userData?.id || null, sessionId);
+    trackClearAction(userData?.id || null, sessionId);
     this.clearOutput();
   };
 

--- a/src/components/CommunicationHistory/ExportDialog/ExportDialog.component.js
+++ b/src/components/CommunicationHistory/ExportDialog/ExportDialog.component.js
@@ -17,47 +17,47 @@ import {
   Checkbox,
   Typography,
   CircularProgress,
-  Box,
+  Box
 } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import GetAppIcon from '@material-ui/icons/GetApp';
 import CloseIcon from '@material-ui/icons/Close';
 import messages from './ExportDialog.messages';
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(theme => ({
   dialogPaper: {
     minWidth: '500px',
-    maxWidth: '600px',
+    maxWidth: '600px'
   },
   formControl: {
     marginTop: theme.spacing(2),
     marginBottom: theme.spacing(2),
-    width: '100%',
+    width: '100%'
   },
   dateInputs: {
     display: 'flex',
     gap: theme.spacing(2),
-    marginTop: theme.spacing(1),
+    marginTop: theme.spacing(1)
   },
   exportButton: {
-    marginLeft: theme.spacing(1),
+    marginLeft: theme.spacing(1)
   },
   progressWrapper: {
     display: 'flex',
     alignItems: 'center',
-    gap: theme.spacing(2),
+    gap: theme.spacing(2)
   },
   statsBox: {
     backgroundColor: theme.palette.grey[100],
     padding: theme.spacing(2),
     borderRadius: theme.shape.borderRadius,
-    marginTop: theme.spacing(2),
+    marginTop: theme.spacing(2)
   },
   statItem: {
     display: 'flex',
     justifyContent: 'space-between',
-    marginBottom: theme.spacing(1),
-  },
+    marginBottom: theme.spacing(1)
+  }
 }));
 
 const ExportDialog = ({
@@ -65,20 +65,20 @@ const ExportDialog = ({
   onClose,
   onExport,
   communicationHistory,
-  users,
+  currentUserId,
+  currentUserName,
   intl,
-  isExporting,
+  isExporting
 }) => {
   const classes = useStyles();
   const [dateRange, setDateRange] = useState('all');
   const [customStartDate, setCustomStartDate] = useState('');
   const [customEndDate, setCustomEndDate] = useState('');
-  const [selectedUser, setSelectedUser] = useState('all');
   const [includeImages, setIncludeImages] = useState(true);
   const [includeSummary, setIncludeSummary] = useState(true);
   const [includeMetadata, setIncludeMetadata] = useState(true);
 
-  const handleDateRangeChange = (event) => {
+  const handleDateRangeChange = event => {
     setDateRange(event.target.value);
     if (event.target.value !== 'custom') {
       setCustomStartDate('');
@@ -89,10 +89,6 @@ const ExportDialog = ({
   const getFilteredEntries = () => {
     let filtered = [...communicationHistory];
 
-    if (selectedUser !== 'all') {
-      filtered = filtered.filter((entry) => entry.userId === selectedUser);
-    }
-
     let startDate = null;
     let endDate = moment().endOf('day');
 
@@ -101,10 +97,14 @@ const ExportDialog = ({
         startDate = moment().startOf('day');
         break;
       case 'week':
-        startDate = moment().subtract(7, 'days').startOf('day');
+        startDate = moment()
+          .subtract(7, 'days')
+          .startOf('day');
         break;
       case 'month':
-        startDate = moment().subtract(30, 'days').startOf('day');
+        startDate = moment()
+          .subtract(30, 'days')
+          .startOf('day');
         break;
       case 'custom':
         if (customStartDate) {
@@ -119,7 +119,7 @@ const ExportDialog = ({
     }
 
     if (startDate) {
-      filtered = filtered.filter((entry) => {
+      filtered = filtered.filter(entry => {
         const entryDate = moment(entry.timestamp);
         return (
           entryDate.isSameOrAfter(startDate) &&
@@ -133,35 +133,35 @@ const ExportDialog = ({
 
   const handleExport = () => {
     const filteredEntries = getFilteredEntries();
+    const reportUserId = currentUserId || 'Guest';
+    const reportUserName = currentUserName || 'Guest';
+
     const exportData = {
       entries: filteredEntries,
-      userId: selectedUser === 'all' ? null : selectedUser,
-      userName:
-        selectedUser === 'all'
-          ? 'All Users'
-          : users.find((u) => u.id === selectedUser)?.name || 'Unknown User',
+      userId: reportUserId,
+      userName: reportUserName,
       dateRange: {
         from: dateRange === 'custom' ? customStartDate : null,
         to: dateRange === 'custom' ? customEndDate : null,
-        type: dateRange,
+        type: dateRange
       },
       options: {
         includeImages,
         includeSummary,
-        includeMetadata,
+        includeMetadata
       },
       metadata: {
         exportDate: moment().toISOString(),
-        totalEntries: filteredEntries.length,
-      },
+        totalEntries: filteredEntries.length
+      }
     };
 
     onExport(exportData);
   };
 
   const filteredEntries = getFilteredEntries();
-  const symbolCount = filteredEntries.filter((e) => e.type === 'symbol').length;
-  const phraseCount = filteredEntries.filter((e) => e.type === 'phrase').length;
+  const symbolCount = filteredEntries.filter(e => e.type === 'symbol').length;
+  const phraseCount = filteredEntries.filter(e => e.type === 'phrase').length;
 
   return (
     <Dialog
@@ -175,30 +175,6 @@ const ExportDialog = ({
         <FormattedMessage {...messages.exportTitle} />
       </DialogTitle>
       <DialogContent>
-        <FormControl className={classes.formControl}>
-          <FormLabel component="legend">
-            <FormattedMessage {...messages.selectUser} />
-          </FormLabel>
-          <RadioGroup
-            value={selectedUser}
-            onChange={(e) => setSelectedUser(e.target.value)}
-          >
-            <FormControlLabel
-              value="all"
-              control={<Radio color="primary" />}
-              label={intl.formatMessage(messages.allUsers)}
-            />
-            {users.map((user) => (
-              <FormControlLabel
-                key={user.id}
-                value={user.id}
-                control={<Radio color="primary" />}
-                label={user.name}
-              />
-            ))}
-          </RadioGroup>
-        </FormControl>
-
         <FormControl className={classes.formControl}>
           <FormLabel component="legend">
             <FormattedMessage {...messages.dateRange} />
@@ -237,7 +213,7 @@ const ExportDialog = ({
                 type="date"
                 label={intl.formatMessage(messages.startDate)}
                 value={customStartDate}
-                onChange={(e) => setCustomStartDate(e.target.value)}
+                onChange={e => setCustomStartDate(e.target.value)}
                 InputLabelProps={{ shrink: true }}
                 fullWidth
               />
@@ -245,7 +221,7 @@ const ExportDialog = ({
                 type="date"
                 label={intl.formatMessage(messages.endDate)}
                 value={customEndDate}
-                onChange={(e) => setCustomEndDate(e.target.value)}
+                onChange={e => setCustomEndDate(e.target.value)}
                 InputLabelProps={{ shrink: true }}
                 fullWidth
               />
@@ -261,7 +237,7 @@ const ExportDialog = ({
             control={
               <Checkbox
                 checked={includeImages}
-                onChange={(e) => setIncludeImages(e.target.checked)}
+                onChange={e => setIncludeImages(e.target.checked)}
                 color="primary"
               />
             }
@@ -271,7 +247,7 @@ const ExportDialog = ({
             control={
               <Checkbox
                 checked={includeSummary}
-                onChange={(e) => setIncludeSummary(e.target.checked)}
+                onChange={e => setIncludeSummary(e.target.checked)}
                 color="primary"
               />
             }
@@ -281,7 +257,7 @@ const ExportDialog = ({
             control={
               <Checkbox
                 checked={includeMetadata}
-                onChange={(e) => setIncludeMetadata(e.target.checked)}
+                onChange={e => setIncludeMetadata(e.target.checked)}
                 color="primary"
               />
             }
@@ -353,14 +329,17 @@ ExportDialog.propTypes = {
   onClose: PropTypes.func.isRequired,
   onExport: PropTypes.func.isRequired,
   communicationHistory: PropTypes.array.isRequired,
-  users: PropTypes.array,
+  currentUserId: PropTypes.string,
+  currentUserName: PropTypes.string,
   intl: PropTypes.object.isRequired,
-  isExporting: PropTypes.bool,
+  isExporting: PropTypes.bool
 };
 
 ExportDialog.defaultProps = {
-  users: [],
-  isExporting: false,
+  currentUserId: null,
+  currentUserName: null,
+  isExporting: false
 };
 
+export { ExportDialog };
 export default injectIntl(ExportDialog);

--- a/src/components/CommunicationHistory/ExportDialog/ExportDialog.component.test.js
+++ b/src/components/CommunicationHistory/ExportDialog/ExportDialog.component.test.js
@@ -1,0 +1,122 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Button from '@material-ui/core/Button';
+import { ExportDialog } from './ExportDialog.component';
+
+jest.mock('./ExportDialog.messages', () => ({
+  __esModule: true,
+  default: {
+    exportTitle: {
+      id: 'exportTitle',
+      defaultMessage: 'Export Communication History'
+    },
+    dateRange: { id: 'dateRange', defaultMessage: 'Date Range' },
+    allTime: { id: 'allTime', defaultMessage: 'All Time' },
+    today: { id: 'today', defaultMessage: 'Today' },
+    lastWeek: { id: 'lastWeek', defaultMessage: 'Last 7 Days' },
+    lastMonth: { id: 'lastMonth', defaultMessage: 'Last 30 Days' },
+    customRange: { id: 'customRange', defaultMessage: 'Custom Range' },
+    startDate: { id: 'startDate', defaultMessage: 'Start Date' },
+    endDate: { id: 'endDate', defaultMessage: 'End Date' },
+    exportOptions: { id: 'exportOptions', defaultMessage: 'Export Options' },
+    includeImages: {
+      id: 'includeImages',
+      defaultMessage: 'Include pictogram images'
+    },
+    includeSummary: {
+      id: 'includeSummary',
+      defaultMessage: 'Include summary statistics'
+    },
+    includeMetadata: {
+      id: 'includeMetadata',
+      defaultMessage: 'Include session metadata'
+    },
+    previewStats: { id: 'previewStats', defaultMessage: 'Preview Statistics' },
+    totalEntries: { id: 'totalEntries', defaultMessage: 'Total Entries:' },
+    symbols: { id: 'symbols', defaultMessage: 'Symbols:' },
+    phrases: { id: 'phrases', defaultMessage: 'Phrases:' },
+    cancel: { id: 'cancel', defaultMessage: 'Cancel' },
+    export: { id: 'export', defaultMessage: 'Export PDF' },
+    exporting: { id: 'exporting', defaultMessage: 'Exporting...' }
+  }
+}));
+
+const baseProps = {
+  open: true,
+  onClose: jest.fn(),
+  onExport: jest.fn(),
+  communicationHistory: [
+    {
+      id: '1',
+      type: 'symbol',
+      label: 'Hello',
+      timestamp: '2024-01-15T10:00:00.000Z'
+    },
+    {
+      id: '2',
+      type: 'phrase',
+      label: 'I want water',
+      timestamp: '2024-01-16T10:00:00.000Z'
+    }
+  ],
+  currentUserId: 'user-123',
+  currentUserName: 'Jane Doe',
+  intl: {
+    formatMessage: msg => msg.defaultMessage || msg.id
+  },
+  isExporting: false
+};
+
+describe('ExportDialog component', () => {
+  it('does not render user selection controls', () => {
+    const wrapper = shallow(<ExportDialog {...baseProps} />);
+
+    expect(wrapper.text()).not.toContain('Select User');
+    expect(wrapper.text()).not.toContain('All Users');
+  });
+
+  it('exports using current user metadata', () => {
+    const onExport = jest.fn();
+    const wrapper = shallow(
+      <ExportDialog {...baseProps} onExport={onExport} />
+    );
+
+    wrapper
+      .find(Button)
+      .at(1)
+      .prop('onClick')();
+
+    expect(onExport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entries: baseProps.communicationHistory,
+        userId: 'user-123',
+        userName: 'Jane Doe',
+        dateRange: expect.objectContaining({ type: 'all' })
+      })
+    );
+  });
+
+  it('uses Guest metadata when no current user is available', () => {
+    const onExport = jest.fn();
+    const wrapper = shallow(
+      <ExportDialog
+        {...baseProps}
+        onExport={onExport}
+        currentUserId={null}
+        currentUserName={null}
+      />
+    );
+
+    wrapper
+      .find(Button)
+      .at(1)
+      .prop('onClick')();
+
+    expect(onExport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'Guest',
+        userName: 'Guest'
+      })
+    );
+  });
+});

--- a/src/components/CommunicationHistory/ExportDialog/ExportDialog.container.js
+++ b/src/components/CommunicationHistory/ExportDialog/ExportDialog.container.js
@@ -12,7 +12,8 @@ import { showNotification } from '../../Notifications/Notifications.actions';
 const mapStateToProps = state => ({
   communicationHistory: state.communicationHistory.entries,
   isExporting: state.communicationHistory.isExporting,
-  users: state.app.userData ? [state.app.userData] : []
+  currentUserId: state.app.userData?.id || null,
+  currentUserName: state.app.userData?.name || null
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/components/CommunicationHistory/ExportDialog/ExportDialog.messages.js
+++ b/src/components/CommunicationHistory/ExportDialog/ExportDialog.messages.js
@@ -5,14 +5,6 @@ export default defineMessages({
     id: 'cboard.components.CommunicationHistory.ExportDialog.exportTitle',
     defaultMessage: 'Export Communication History'
   },
-  selectUser: {
-    id: 'cboard.components.CommunicationHistory.ExportDialog.selectUser',
-    defaultMessage: 'Select User'
-  },
-  allUsers: {
-    id: 'cboard.components.CommunicationHistory.ExportDialog.allUsers',
-    defaultMessage: 'All Users'
-  },
   dateRange: {
     id: 'cboard.components.CommunicationHistory.ExportDialog.dateRange',
     defaultMessage: 'Date Range'


### PR DESCRIPTION
## Summary
- remove multi-user selection from Communication History export dialog and keep export scoped to current user context with `Guest` fallback metadata
- update export dialog wiring to pass current user identity from Redux and add component tests covering selector removal and Guest fallback
- ensure communication history tracking stores canonical user IDs (not emails) for symbol/phrase/clear/backspace entries

## Linked Issues
- Closes #2172

## Testing
- `CI=true yarn test --watch=false --runTestsByPath src/components/CommunicationHistory/ExportDialog/ExportDialog.component.test.js src/components/Board/__tests__/Board.container.test.js`