### PR TITLE
feat: add receiver-side communication support loop

### DIFF
--- a/src/common/communicationSupport/chineseLexicon.js
+++ b/src/common/communicationSupport/chineseLexicon.js
@@ -1,0 +1,150 @@
+export const CHINESE_COMMUNICATION_LEXICON = [
+  { zh: '我', synonyms: ['自己', '本人'], category: 'daily' },
+  { zh: '你', synonyms: ['您'], category: 'daily' },
+  { zh: '他', synonyms: [], category: 'daily' },
+  { zh: '她', synonyms: [], category: 'daily' },
+  { zh: '好', synonyms: ['可以', '行', '嗯', '好的', '对'], category: 'daily' },
+  { zh: '不', synonyms: ['没', '不是', '否'], category: 'daily' },
+  { zh: '有', synonyms: ['是', '对', '有的'], category: 'daily' },
+  { zh: '谢谢', synonyms: ['感谢', '多谢'], category: 'emotions' },
+  {
+    zh: '想',
+    synonyms: ['要', '想要', '希望', '需要', '需'],
+    category: 'actions'
+  },
+  { zh: '去', synonyms: ['走', '出去'], category: 'actions' },
+  { zh: '来', synonyms: ['过来'], category: 'actions' },
+  { zh: '吃', synonyms: ['进食', '用餐', '吃饭'], category: 'actions' },
+  { zh: '喝', synonyms: ['饮'], category: 'actions' },
+  { zh: '看', synonyms: ['看看', '瞧'], category: 'actions' },
+  { zh: '听', synonyms: ['听听'], category: 'actions' },
+  { zh: '说', synonyms: ['讲', '告诉'], category: 'actions' },
+  { zh: '玩', synonyms: ['游戏'], category: 'actions' },
+  { zh: '休息', synonyms: ['歇', '歇歇'], category: 'actions' },
+  { zh: '睡觉', synonyms: ['睡', '躺', '困'], category: 'actions' },
+  { zh: '起床', synonyms: ['起来'], category: 'actions' },
+  { zh: '坐', synonyms: ['坐下'], category: 'actions' },
+  { zh: '站', synonyms: ['站起来'], category: 'actions' },
+  { zh: '走', synonyms: ['走路', '散步'], category: 'actions' },
+  { zh: '跑', synonyms: ['跑步'], category: 'actions' },
+  { zh: '帮忙', synonyms: ['帮', '帮助', '请帮', '求助'], category: 'actions' },
+  { zh: '叫', synonyms: ['喊', '叫人', '找'], category: 'actions' },
+  { zh: '买', synonyms: ['购买', '购物'], category: 'actions' },
+  { zh: '洗手', synonyms: ['洗'], category: 'actions' },
+  { zh: '刷牙', synonyms: ['刷'], category: 'actions' },
+  { zh: '不要', synonyms: ['不想', '不需要', '不用'], category: 'actions' },
+  { zh: '回家', synonyms: ['回去'], category: 'actions' },
+  { zh: '开心', synonyms: ['高兴', '快乐', '愉快'], category: 'emotions' },
+  { zh: '伤心', synonyms: ['难过', '不开心', '悲伤'], category: 'emotions' },
+  { zh: '害怕', synonyms: ['怕', '恐惧', '吓'], category: 'emotions' },
+  { zh: '喜欢', synonyms: ['爱', '喜爱'], category: 'emotions' },
+  {
+    zh: '痛',
+    synonyms: [
+      '疼',
+      '疼痛',
+      '难受',
+      '头疼',
+      '头痛',
+      '肚子疼',
+      '肚子痛',
+      '腰疼',
+      '腰痛',
+      '牙疼',
+      '牙痛',
+      '胸疼',
+      '胸痛',
+      '背疼',
+      '背痛',
+      '腿疼',
+      '腿痛'
+    ],
+    category: 'medical'
+  },
+  { zh: '饿', synonyms: ['肚子饿', '饥饿'], category: 'emotions' },
+  { zh: '渴', synonyms: ['口渴'], category: 'emotions' },
+  { zh: '冷', synonyms: ['寒冷', '好冷'], category: 'emotions' },
+  { zh: '热', synonyms: ['好热', '很热'], category: 'emotions' },
+  {
+    zh: '生病',
+    synonyms: ['病了', '不舒服', '感冒', '着凉'],
+    category: 'medical'
+  },
+  {
+    zh: '累',
+    synonyms: ['疲惫', '疲劳', '很累', '好累', '没力气'],
+    category: 'medical'
+  },
+  { zh: '发烧', synonyms: ['发热', '高烧', '烧'], category: 'medical' },
+  { zh: '咳嗽', synonyms: ['咳', '一直咳', '干咳'], category: 'medical' },
+  { zh: '头晕', synonyms: ['晕', '眩晕', '头昏'], category: 'medical' },
+  { zh: '恶心', synonyms: ['想吐', '呕吐', '反胃', '吐'], category: 'medical' },
+  {
+    zh: '呼吸困难',
+    synonyms: ['喘不过气', '气促', '透不过气'],
+    category: 'medical'
+  },
+  { zh: '出血', synonyms: ['流血', '伤口流血'], category: 'medical' },
+  { zh: '换衣服', synonyms: ['换衣', '穿衣服'], category: 'daily' },
+  { zh: '运动', synonyms: ['锻炼', '健身', '做运动'], category: 'actions' },
+  { zh: '看电视', synonyms: ['电视', '开电视'], category: 'daily' },
+  { zh: '理发', synonyms: ['剪头发', '剪发'], category: 'daily' },
+  { zh: '看书', synonyms: ['读书', '阅读'], category: 'daily' },
+  { zh: '妈妈', synonyms: ['妈', '母亲'], category: 'people' },
+  { zh: '爸爸', synonyms: ['爸', '父亲'], category: 'people' },
+  { zh: '哥哥', synonyms: ['兄弟'], category: 'people' },
+  { zh: '姐姐', synonyms: ['大姐', '姐'], category: 'people' },
+  { zh: '妹妹', synonyms: ['小妹', '妹'], category: 'people' },
+  { zh: '医生', synonyms: ['大夫', '看病'], category: 'people' },
+  { zh: '老师', synonyms: [], category: 'people' },
+  { zh: '朋友', synonyms: [], category: 'people' },
+  { zh: '家', synonyms: ['房子'], category: 'places' },
+  { zh: '医院', synonyms: ['看病'], category: 'places' },
+  { zh: '学校', synonyms: [], category: 'places' },
+  { zh: '公园', synonyms: ['花园'], category: 'places' },
+  { zh: '超市', synonyms: ['商店', '商场', '购物'], category: 'places' },
+  { zh: '厕所', synonyms: ['洗手间', '卫生间', '上厕所'], category: 'daily' },
+  { zh: '水', synonyms: ['饮水', '喝水', '杯水'], category: 'food' },
+  { zh: '饭', synonyms: ['米饭', '吃饭', '餐'], category: 'food' },
+  { zh: '牛奶', synonyms: ['奶'], category: 'food' },
+  { zh: '茶', synonyms: ['喝茶'], category: 'food' },
+  { zh: '咖啡', synonyms: [], category: 'food' },
+  { zh: '面包', synonyms: [], category: 'food' },
+  { zh: '苹果', synonyms: [], category: 'food' },
+  { zh: '香蕉', synonyms: [], category: 'food' },
+  { zh: '鸡蛋', synonyms: ['蛋'], category: 'food' },
+  { zh: '鱼', synonyms: [], category: 'food' },
+  { zh: '饼干', synonyms: [], category: 'food' },
+  { zh: '糖', synonyms: ['糖果'], category: 'food' },
+  { zh: '冰淇淋', synonyms: ['雪糕'], category: 'food' },
+  { zh: '药', synonyms: ['吃药', '服药', '药物'], category: 'objects' },
+  { zh: '手机', synonyms: ['电话', '打电话'], category: 'objects' },
+  { zh: '钱', synonyms: ['付钱'], category: 'objects' },
+  { zh: '车', synonyms: ['汽车', '开车'], category: 'objects' },
+  { zh: '花', synonyms: [], category: 'objects' },
+  { zh: '今天', synonyms: [], category: 'time' },
+  { zh: '明天', synonyms: [], category: 'time' },
+  { zh: '昨天', synonyms: [], category: 'time' },
+  { zh: '现在', synonyms: [], category: 'time' },
+  { zh: '早上', synonyms: ['上午'], category: 'time' },
+  { zh: '下午', synonyms: [], category: 'time' },
+  { zh: '今晚', synonyms: ['晚上'], category: 'time' },
+  { zh: '早饭', synonyms: ['早餐'], category: 'food' },
+  { zh: '午饭', synonyms: ['午餐', '中饭'], category: 'food' },
+  { zh: '晚饭', synonyms: ['晚餐'], category: 'food' },
+  { zh: '和', synonyms: ['跟', '与'], category: 'daily' }
+];
+
+const zhIndex = new Map();
+const synonymIndex = new Map();
+
+CHINESE_COMMUNICATION_LEXICON.forEach(entry => {
+  zhIndex.set(entry.zh, entry);
+  entry.synonyms.forEach(synonym => {
+    synonymIndex.set(synonym, entry);
+  });
+});
+
+export function findChineseCommunicationEntry(word) {
+  return zhIndex.get(word) || synonymIndex.get(word);
+}

--- a/src/common/communicationSupport/legacy.js
+++ b/src/common/communicationSupport/legacy.js
@@ -1,0 +1,30 @@
+export const LEGACY_COMMUNICATION_SUPPORT_SETTINGS_KEY = 'tuyujia';
+
+export const LEGACY_COMMUNICATION_TILE_METADATA_KEYS = {
+  synonyms: 'tuyujiaSynonyms',
+  excludeTokens: 'tuyujiaExcludeTokens',
+  category: 'tuyujiaCategory'
+};
+
+export const LEGACY_COMMUNICATION_STORAGE_KEYS = {
+  savedPhrases: 'cboard_tuyujia_saved_phrases',
+  history: 'cboard_tuyujia_history'
+};
+
+export const COMMUNICATION_SUPPORT_VARIANTS = {
+  default: 'default',
+  tuyujia: 'tuyujia'
+};
+
+export const COMMUNICATION_SUPPORT_ROUTE_SEGMENTS = {
+  default: 'communication-support',
+  tuyujia: 'tuyujia'
+};
+
+export const TUYUJIA_COMMUNICATION_SUPPORT_COPY = {
+  title: '图语家双向沟通',
+  subtitle:
+    '患者端支持候选句播报与收藏，照护者端支持语音输入、编辑换图和全屏展示。',
+  expressSectionTitle: '患者端候选句',
+  receiveSectionTitle: '照护者输入转图片'
+};

--- a/src/common/communicationSupport/receiverPipeline.js
+++ b/src/common/communicationSupport/receiverPipeline.js
@@ -1,0 +1,97 @@
+import {
+  createCommunicationOutputFromMatches,
+  matchTextToCommunicationTiles
+} from './symbolMatching';
+
+export function createReceiverReviewId(prefix = 'review') {
+  return (
+    prefix +
+    '_' +
+    Math.random()
+      .toString(36)
+      .slice(2, 10)
+  );
+}
+
+export function buildReceiverReviewItems(
+  matches,
+  createId = createReceiverReviewId
+) {
+  return (matches || []).map(match => ({
+    id: createId('review'),
+    token: match.token,
+    tile: match.tile,
+    matchType: match.matchType
+  }));
+}
+
+export function buildReceiverLoopState(text, boards, options = {}) {
+  const result = matchTextToCommunicationTiles(text, boards, options);
+  const reviewItems = buildReceiverReviewItems(
+    result.matches,
+    options.createId
+  );
+
+  return {
+    inputText: result.inputText,
+    segmentation: result.segmentation,
+    matches: result.matches,
+    reviewItems,
+    missingTokens: reviewItems
+      .filter(item => !item.tile)
+      .map(item => item.token),
+    outputPreview: createCommunicationOutputFromMatches(reviewItems),
+    matchRate: result.matchRate
+  };
+}
+
+export function moveReceiverReviewItem(reviewItems, itemId, offset) {
+  const currentIndex = reviewItems.findIndex(item => item.id === itemId);
+  const targetIndex = currentIndex + offset;
+
+  if (
+    currentIndex < 0 ||
+    targetIndex < 0 ||
+    targetIndex >= reviewItems.length
+  ) {
+    return reviewItems;
+  }
+
+  const nextItems = reviewItems.slice();
+  const currentItem = nextItems[currentIndex];
+  nextItems.splice(currentIndex, 1);
+  nextItems.splice(targetIndex, 0, currentItem);
+  return nextItems;
+}
+
+export function deleteReceiverReviewItem(reviewItems, itemId) {
+  return reviewItems.filter(item => item.id !== itemId);
+}
+
+export function replaceReceiverReviewItem(reviewItems, itemId, candidate) {
+  return reviewItems.map(item => {
+    if (item.id !== itemId) {
+      return item;
+    }
+
+    return {
+      ...item,
+      tile: candidate,
+      matchType: 'manual'
+    };
+  });
+}
+
+export function buildReceiverOutputPreview(reviewItems) {
+  return createCommunicationOutputFromMatches(reviewItems);
+}
+
+export function buildReceiverHistoryEntry(inputText, reviewItems) {
+  const outputItems = buildReceiverOutputPreview(reviewItems);
+
+  return {
+    direction: 'receive',
+    inputText,
+    labels: outputItems.map(item => item.label).filter(Boolean)
+  };
+}

--- a/src/common/communicationSupport/receiverPipeline.test.js
+++ b/src/common/communicationSupport/receiverPipeline.test.js
@@ -1,0 +1,103 @@
+import {
+  buildReceiverHistoryEntry,
+  buildReceiverLoopState,
+  deleteReceiverReviewItem,
+  moveReceiverReviewItem,
+  replaceReceiverReviewItem
+} from './receiverPipeline';
+
+const boards = [
+  {
+    id: 'home',
+    name: '首页',
+    tiles: [
+      {
+        id: 'want',
+        label: '想',
+        image: '/want.png'
+      },
+      {
+        id: 'water',
+        label: '水',
+        image: '/water.png'
+      },
+      {
+        id: 'drink',
+        label: '饮料',
+        image: '/drink.png',
+        communicationSynonyms: '喝的'
+      }
+    ]
+  }
+];
+
+describe('receiverPipeline', () => {
+  test('builds a pure text-token-image review state', () => {
+    const result = buildReceiverLoopState('我想喝水', boards, {
+      preSegmented: ['想', '水'],
+      createId: () => 'review-fixed'
+    });
+
+    expect(result.segmentation.segments).toEqual(['想', '水']);
+    expect(result.reviewItems).toEqual([
+      expect.objectContaining({
+        id: 'review-fixed',
+        token: '想',
+        matchType: 'exact'
+      }),
+      expect.objectContaining({
+        id: 'review-fixed',
+        token: '水',
+        matchType: 'exact'
+      })
+    ]);
+    expect(result.outputPreview).toEqual([
+      expect.objectContaining({ id: 'want', label: '想' }),
+      expect.objectContaining({ id: 'water', label: '水' })
+    ]);
+  });
+
+  test('supports review item move, replace, delete, and history output', () => {
+    const state = buildReceiverLoopState('我想喝水', boards, {
+      preSegmented: ['想', '水'],
+      createId: (() => {
+        let index = 0;
+        return () => 'review-' + index++;
+      })()
+    });
+
+    const moved = moveReceiverReviewItem(state.reviewItems, 'review-0', 1);
+    expect(moved.map(item => item.token)).toEqual(['水', '想']);
+
+    const replaced = replaceReceiverReviewItem(moved, 'review-1', {
+      id: 'drink',
+      boardId: 'home',
+      boardName: '首页',
+      labels: ['饮料'],
+      synonyms: ['喝的'],
+      tile: {
+        id: 'drink',
+        label: '饮料',
+        image: '/drink.png'
+      }
+    });
+    expect(replaced[0]).toEqual(
+      expect.objectContaining({
+        matchType: 'manual',
+        tile: expect.objectContaining({
+          tile: expect.objectContaining({ label: '饮料' })
+        })
+      })
+    );
+
+    const trimmed = deleteReceiverReviewItem(replaced, 'review-0');
+    expect(trimmed.map(item => item.token)).toEqual(['水']);
+
+    const historyEntry = buildReceiverHistoryEntry('我想喝水', replaced);
+    expect(historyEntry).toEqual({
+      direction: 'receive',
+      inputText: '我想喝水',
+      labels: ['饮料', '想']
+    });
+  });
+});

--- a/src/common/communicationSupport/segmentation.js
+++ b/src/common/communicationSupport/segmentation.js
@@ -1,0 +1,116 @@
+const SPLIT_COMPOUNDS = new Set([
+  '我去',
+  '我想',
+  '我要',
+  '我喜欢',
+  '我吃',
+  '我喝',
+  '我看',
+  '他去',
+  '他想',
+  '他要',
+  '她去',
+  '她想',
+  '她要',
+  '你去',
+  '你想',
+  '你要',
+  '不想',
+  '不要',
+  '不去',
+  '不吃',
+  '不喝'
+]);
+
+const MERGE_PAIRS = {
+  '睡+觉': '睡觉',
+  '起+床': '起床',
+  '回+家': '回家',
+  '开+心': '开心',
+  '伤+心': '伤心',
+  '难+过': '难过',
+  '害+怕': '害怕',
+  '生+病': '生病',
+  '洗+手': '洗手',
+  '刷+牙': '刷牙',
+  '上+厕+所': '上厕所'
+};
+
+const STOP_CHARS = new Set([
+  '，',
+  '。',
+  '？',
+  '！',
+  '、',
+  ' ',
+  '　',
+  '的',
+  '了',
+  '吗',
+  '呢',
+  '啊',
+  '吧'
+]);
+
+export function segmentChineseCommunicationText(text) {
+  const cleaned = (text || '').trim();
+
+  if (!cleaned) {
+    return { segments: [], engine: 'intl-segmenter' };
+  }
+
+  let raw = [];
+  let engine = 'char-split';
+
+  if (typeof Intl !== 'undefined' && Intl.Segmenter) {
+    const segmenter = new Intl.Segmenter('zh-CN', { granularity: 'word' });
+    raw = Array.from(segmenter.segment(cleaned))
+      .filter(segment => segment.isWordLike)
+      .map(segment => segment.segment);
+    engine = 'intl-segmenter';
+  } else {
+    raw = cleaned.split('').filter(char => !STOP_CHARS.has(char));
+  }
+
+  const split = [];
+  raw.forEach(word => {
+    if (SPLIT_COMPOUNDS.has(word)) {
+      split.push.apply(split, word.split(''));
+      return;
+    }
+    split.push(word);
+  });
+
+  const merged = [];
+  let index = 0;
+
+  while (index < split.length) {
+    if (index + 2 < split.length) {
+      const triKey = [split[index], split[index + 1], split[index + 2]].join(
+        '+'
+      );
+      if (MERGE_PAIRS[triKey]) {
+        merged.push(MERGE_PAIRS[triKey]);
+        index += 3;
+        continue;
+      }
+    }
+
+    if (index + 1 < split.length) {
+      const biKey = [split[index], split[index + 1]].join('+');
+      if (MERGE_PAIRS[biKey]) {
+        merged.push(MERGE_PAIRS[biKey]);
+        index += 2;
+        continue;
+      }
+    }
+
+    merged.push(split[index]);
+    index += 1;
+  }
+
+  return {
+    segments: merged.filter(word => word && !STOP_CHARS.has(word)),
+    engine
+  };
+}

--- a/src/common/communicationSupport/symbolMatching.js
+++ b/src/common/communicationSupport/symbolMatching.js
@@ -1,0 +1,365 @@
+import { resolveBoardName, resolveTileLabel } from '../../helpers';
+import { findChineseCommunicationEntry } from './chineseLexicon';
+import { segmentChineseCommunicationText } from './segmentation';
+import { getCommunicationTileMetadata } from './tileMetadata';
+
+const NEGATION_PREFIXES = ['不', '没', '别', '勿', '莫', '未'];
+const MATCH_STAGE_GAP = 100;
+const DOMAIN_MATCH_BONUS = 40;
+
+const MATCH_STAGE_SCORE = {
+  exact: MATCH_STAGE_GAP * 4,
+  synonym: MATCH_STAGE_GAP * 3,
+  'lexicon-synonym': MATCH_STAGE_GAP * 2,
+  partial: MATCH_STAGE_GAP
+};
+
+function parseHintList(value) {
+  if (!value) return [];
+  return String(value)
+    .split(/[,\n]/)
+    .map(item => item.trim())
+    .filter(Boolean);
+}
+
+function inferSemanticDomain(board, boardName) {
+  const normalizedText = [boardName, board && board.id, board && board.nameKey]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+
+  if (/emotion|feeling|happy|sad|angry/.test(normalizedText)) {
+    return 'emotions';
+  }
+
+  if (/food|drink|snack|eat|bread|kitchen/.test(normalizedText)) {
+    return 'food';
+  }
+
+  if (/body|hygiene|doctor|medical|pain|toilet/.test(normalizedText)) {
+    return 'medical';
+  }
+
+  if (/people|family|teacher|friend/.test(normalizedText)) {
+    return 'people';
+  }
+
+  if (/place|school|transport|weather|time|position/.test(normalizedText)) {
+    return 'places';
+  }
+
+  if (
+    /action|activity|sport|question|quick chat|quickchat/.test(normalizedText)
+  ) {
+    return 'actions';
+  }
+
+  if (/clothing|furniture|technology|toy|animal|plant/.test(normalizedText)) {
+    return 'objects';
+  }
+
+  return null;
+}
+
+function normalizeTile(tile, board, intl) {
+  const resolvedLabel = resolveTileLabel(tile, intl);
+  const resolvedBoardName = resolveBoardName(board, intl);
+  const tileMetadata = getCommunicationTileMetadata(tile);
+  const boardMetadata = getCommunicationTileMetadata(board);
+  const labels = [resolvedLabel, tile.label, tile.vocalization]
+    .map(value => (value || '').trim())
+    .filter(Boolean);
+
+  return {
+    id: tile.id,
+    tile,
+    boardId: board.id,
+    boardName: resolvedBoardName,
+    labels,
+    synonyms: parseHintList(tileMetadata.synonyms),
+    excludeTokens: parseHintList(tileMetadata.excludeTokens),
+    semanticDomain:
+      tileMetadata.category ||
+      boardMetadata.category ||
+      inferSemanticDomain(board, resolvedBoardName)
+  };
+}
+
+export function buildCommunicationTileCatalog(boards, intl) {
+  const seen = new Set();
+  const catalog = [];
+
+  (boards || []).forEach(board => {
+    (board.tiles || []).forEach(tile => {
+      if (!tile || !tile.id || tile.loadBoard || seen.has(tile.id)) {
+        return;
+      }
+
+      const normalized = normalizeTile(tile, board, intl);
+      if (!normalized.labels.length) {
+        return;
+      }
+
+      seen.add(tile.id);
+      catalog.push(normalized);
+    });
+  });
+
+  return catalog;
+}
+
+function buildExclusionTerms(token, candidate, lexiconEntry) {
+  return [token, candidate.matchedKey, lexiconEntry && lexiconEntry.zh].filter(
+    Boolean
+  );
+}
+
+function scoreCandidate(token, candidate, lexiconEntry) {
+  const base = MATCH_STAGE_SCORE[candidate.matchType];
+  const excludedTokens = new Set(candidate.tile.excludeTokens || []);
+  const exclusionTerms = buildExclusionTerms(token, candidate, lexiconEntry);
+
+  for (let index = 0; index < exclusionTerms.length; index += 1) {
+    if (excludedTokens.has(exclusionTerms[index])) {
+      return Number.NEGATIVE_INFINITY;
+    }
+  }
+
+  let score = base;
+
+  if (candidate.matchType === 'partial') {
+    score += candidate.matchedLabelLength || 0;
+  }
+
+  if (
+    lexiconEntry &&
+    lexiconEntry.category &&
+    candidate.tile.semanticDomain === lexiconEntry.category
+  ) {
+    score += DOMAIN_MATCH_BONUS;
+  }
+
+  return score;
+}
+
+function pickBestCandidate(token, candidates, lexiconEntry) {
+  let bestCandidate = null;
+  let bestScore = Number.NEGATIVE_INFINITY;
+
+  candidates.forEach(candidate => {
+    const score = scoreCandidate(token, candidate, lexiconEntry);
+    if (score > bestScore) {
+      bestCandidate = candidate;
+      bestScore = score;
+    }
+  });
+
+  return bestScore === Number.NEGATIVE_INFINITY ? null : bestCandidate;
+}
+
+function mapCandidates(items, matchType, matchedKey, matchedLabelLength) {
+  return items.map(item => ({
+    tile: item,
+    matchType,
+    matchedKey,
+    matchedLabelLength
+  }));
+}
+
+function normalizeSegments(segments) {
+  const normalized = [];
+
+  for (let index = 0; index < segments.length; index += 1) {
+    const token = segments[index];
+    const nextToken = segments[index + 1];
+    const tailChar = token ? token[token.length - 1] : '';
+
+    if (
+      token &&
+      token.length > 1 &&
+      NEGATION_PREFIXES.includes(tailChar) &&
+      nextToken &&
+      nextToken.length >= 2
+    ) {
+      const headToken = token.slice(0, -1);
+      if (headToken) {
+        normalized.push(headToken);
+      }
+      normalized.push(tailChar + nextToken);
+      index += 1;
+      continue;
+    }
+
+    if (
+      NEGATION_PREFIXES.includes(token) &&
+      nextToken &&
+      nextToken.length >= 2
+    ) {
+      normalized.push(token + nextToken);
+      index += 1;
+      continue;
+    }
+
+    normalized.push(token);
+  }
+
+  return normalized;
+}
+
+export function matchTextToCommunicationTiles(text, boards, options = {}) {
+  const rawSegmentation = options.preSegmented
+    ? { segments: options.preSegmented, engine: 'intl-segmenter' }
+    : segmentChineseCommunicationText(text);
+  const segmentation = {
+    ...rawSegmentation,
+    segments: normalizeSegments(rawSegmentation.segments)
+  };
+  const catalog = buildCommunicationTileCatalog(boards, options.intl);
+  const matches = segmentation.segments.map((token, index) => {
+    const previousToken = index > 0 ? segmentation.segments[index - 1] : '';
+    const negatedToken = NEGATION_PREFIXES.includes(previousToken)
+      ? previousToken + token
+      : '';
+    const lexiconEntry = findChineseCommunicationEntry(token);
+    const negatedLexiconEntry = negatedToken
+      ? findChineseCommunicationEntry(negatedToken)
+      : null;
+    let matched = null;
+
+    if (negatedLexiconEntry) {
+      const negatedCandidate = pickBestCandidate(
+        negatedToken,
+        mapCandidates(
+          catalog.filter(item => item.labels.includes(negatedLexiconEntry.zh)),
+          'lexicon-synonym',
+          negatedLexiconEntry.zh
+        ),
+        negatedLexiconEntry
+      );
+
+      if (negatedCandidate) {
+        matched = negatedCandidate;
+      }
+    }
+
+    if (!matched && negatedToken) {
+      return {
+        token,
+        tile: null,
+        matchType: 'none'
+      };
+    }
+
+    const exactCandidate = pickBestCandidate(
+      token,
+      mapCandidates(
+        catalog.filter(item => item.labels.includes(token)),
+        'exact',
+        token
+      ),
+      lexiconEntry
+    );
+
+    if (exactCandidate) {
+      matched = exactCandidate;
+    }
+
+    if (!matched) {
+      const synonymCandidate = pickBestCandidate(
+        token,
+        mapCandidates(
+          catalog.filter(item => item.synonyms.includes(token)),
+          'synonym',
+          token
+        ),
+        lexiconEntry
+      );
+
+      if (synonymCandidate) {
+        matched = synonymCandidate;
+      }
+    }
+
+    if (!matched && lexiconEntry) {
+      const lexiconCandidate = pickBestCandidate(
+        token,
+        mapCandidates(
+          catalog.filter(item => item.labels.includes(lexiconEntry.zh)),
+          'lexicon-synonym',
+          lexiconEntry.zh
+        ),
+        lexiconEntry
+      );
+
+      if (lexiconCandidate) {
+        matched = lexiconCandidate;
+      }
+    }
+
+    if (
+      !matched &&
+      token.length >= 3 &&
+      !NEGATION_PREFIXES.some(prefix => token.startsWith(prefix))
+    ) {
+      const partialCandidates = [];
+
+      catalog.forEach(item => {
+        let bestLabel = null;
+        item.labels.forEach(label => {
+          if (label.length >= 2 && token.includes(label)) {
+            if (!bestLabel || label.length > bestLabel.length) {
+              bestLabel = label;
+            }
+          }
+        });
+
+        if (bestLabel) {
+          partialCandidates.push({
+            tile: item,
+            matchType: 'partial',
+            matchedKey: bestLabel,
+            matchedLabelLength: bestLabel.length
+          });
+        }
+      });
+
+      const partialCandidate = pickBestCandidate(
+        token,
+        partialCandidates,
+        lexiconEntry
+      );
+
+      if (partialCandidate) {
+        matched = partialCandidate;
+      }
+    }
+
+    return {
+      token,
+      tile: matched ? matched.tile : null,
+      matchType: matched ? matched.matchType : 'none'
+    };
+  });
+
+  const matchedCount = matches.filter(item => item.tile).length;
+
+  return {
+    inputText: text,
+    segmentation,
+    matches,
+    matchRate: matches.length ? matchedCount / matches.length : 0
+  };
+}
+
+export function createCommunicationOutputFromMatches(matches) {
+  return (matches || [])
+    .filter(item => item.tile)
+    .map(item => ({
+      id: item.tile.id,
+      image: item.tile.tile.image,
+      label: item.tile.tile.label,
+      vocalization: item.tile.tile.vocalization,
+      keyPath: item.tile.tile.keyPath,
+      backgroundColor: item.tile.tile.backgroundColor
+    }));
+}

--- a/src/common/communicationSupport/tileMetadata.js
+++ b/src/common/communicationSupport/tileMetadata.js
@@ -1,0 +1,65 @@
+import { LEGACY_COMMUNICATION_TILE_METADATA_KEYS } from './legacy';
+
+export const COMMUNICATION_TILE_METADATA_KEYS = {
+  synonyms: 'communicationSynonyms',
+  excludeTokens: 'communicationExcludeTokens',
+  category: 'communicationCategory'
+};
+
+export { LEGACY_COMMUNICATION_TILE_METADATA_KEYS } from './legacy';
+
+function readFirstString(target, keys) {
+  for (let index = 0; index < keys.length; index += 1) {
+    const key = keys[index];
+    const value = target && target[key];
+    if (typeof value === 'string' && value.length) {
+      return value;
+    }
+  }
+
+  return '';
+}
+
+export function getCommunicationTileMetadata(target = {}) {
+  return {
+    synonyms: readFirstString(target, [
+      COMMUNICATION_TILE_METADATA_KEYS.synonyms,
+      LEGACY_COMMUNICATION_TILE_METADATA_KEYS.synonyms
+    ]),
+    excludeTokens: readFirstString(target, [
+      COMMUNICATION_TILE_METADATA_KEYS.excludeTokens,
+      LEGACY_COMMUNICATION_TILE_METADATA_KEYS.excludeTokens
+    ]),
+    category: readFirstString(target, [
+      COMMUNICATION_TILE_METADATA_KEYS.category,
+      LEGACY_COMMUNICATION_TILE_METADATA_KEYS.category
+    ])
+  };
+}
+
+export function setCommunicationTileMetadata(target = {}, metadata = {}) {
+  const nextTarget = { ...target };
+
+  if (Object.prototype.hasOwnProperty.call(metadata, 'synonyms')) {
+    nextTarget[COMMUNICATION_TILE_METADATA_KEYS.synonyms] =
+      metadata.synonyms || '';
+    nextTarget[LEGACY_COMMUNICATION_TILE_METADATA_KEYS.synonyms] =
+      metadata.synonyms || '';
+  }
+
+  if (Object.prototype.hasOwnProperty.call(metadata, 'excludeTokens')) {
+    nextTarget[COMMUNICATION_TILE_METADATA_KEYS.excludeTokens] =
+      metadata.excludeTokens || '';
+    nextTarget[LEGACY_COMMUNICATION_TILE_METADATA_KEYS.excludeTokens] =
+      metadata.excludeTokens || '';
+  }
+
+  if (Object.prototype.hasOwnProperty.call(metadata, 'category')) {
+    nextTarget[COMMUNICATION_TILE_METADATA_KEYS.category] =
+      metadata.category || '';
+    nextTarget[LEGACY_COMMUNICATION_TILE_METADATA_KEYS.category] =
+      metadata.category || '';
+  }
+
+  return nextTarget;
+}

--- a/src/components/Board/CommunicationSupport/CommunicationSupportPanel.css
+++ b/src/components/Board/CommunicationSupport/CommunicationSupportPanel.css
@@ -1,0 +1,278 @@
+.CommunicationSupportPanel {
+  border-top: 1px solid #e0e4ea;
+  border-bottom: 1px solid #e0e4ea;
+  background: #f8fbff;
+  padding: 12px 16px;
+}
+
+.CommunicationSupportPanel__header,
+.CommunicationSupportPanel__sectionHeader,
+.CommunicationSupportPanel__actions,
+.CommunicationSupportPanel__savedRow,
+.CommunicationSupportPanel__matchActions,
+.CommunicationSupportPanel__matchMain {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.CommunicationSupportPanel__title {
+  margin: 0;
+  font-size: 16px;
+}
+
+.CommunicationSupportPanel__subtitle,
+.CommunicationSupportPanel__hint,
+.CommunicationSupportPanel__meta,
+.CommunicationSupportPanel__resultMeta,
+.CommunicationSupportPanel__missing,
+.CommunicationSupportPanel__empty {
+  margin: 4px 0 0;
+  color: #516072;
+  font-size: 12px;
+}
+
+.CommunicationSupportPanel__toolbar {
+  margin-top: 12px;
+}
+
+.CommunicationSupportPanel__modeTabs {
+  display: inline-flex;
+  border-radius: 999px;
+  background: #fff;
+  border: 1px solid #d8e3f2;
+  padding: 4px;
+}
+
+.CommunicationSupportPanel__tab {
+  border: 0;
+  background: transparent;
+  border-radius: 999px;
+  padding: 8px 14px;
+  color: #516072;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.CommunicationSupportPanel__tab--active {
+  background: #0f4c81;
+  color: #fff;
+}
+
+.CommunicationSupportPanel__content {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 16px;
+  margin-top: 12px;
+}
+
+.CommunicationSupportPanel__section {
+  background: #fff;
+  border: 1px solid #d8e3f2;
+  border-radius: 12px;
+  padding: 12px;
+}
+
+.CommunicationSupportPanel__section h4 {
+  margin: 0;
+  font-size: 14px;
+}
+
+.CommunicationSupportPanel__candidates,
+.CommunicationSupportPanel__matches,
+.CommunicationSupportPanel__savedList {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.CommunicationSupportPanel__candidate {
+  width: 100%;
+  border: 0;
+  text-align: left;
+  cursor: pointer;
+  border-radius: 10px;
+  background: #eef5ff;
+  color: #133152;
+  padding: 10px 12px;
+  font-size: 14px;
+}
+
+.CommunicationSupportPanel__candidate--active {
+  background: #0f4c81;
+  color: #fff;
+}
+
+.CommunicationSupportPanel__actions {
+  margin-top: 12px;
+  justify-content: flex-start;
+  flex-wrap: wrap;
+}
+
+.CommunicationSupportPanel__results {
+  margin-top: 12px;
+}
+
+.CommunicationSupportPanel__matchRow,
+.CommunicationSupportPanel__historyRow {
+  border-radius: 10px;
+  border: 1px solid #edf1f6;
+  padding: 8px 10px;
+}
+
+.CommunicationSupportPanel__matchRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: space-between;
+}
+
+.CommunicationSupportPanel__matchMain {
+  flex: 1;
+  min-width: 260px;
+}
+
+.CommunicationSupportPanel__matchPreview {
+  width: 88px;
+  min-width: 88px;
+}
+
+.CommunicationSupportPanel__matchText {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.CommunicationSupportPanel__missingPreview {
+  width: 64px;
+  height: 64px;
+  border-radius: 14px;
+  border: 1px dashed #d8e3f2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 28px;
+  color: #9d2727;
+}
+
+.CommunicationSupportPanel__matchActions {
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.CommunicationSupportPanel__token,
+.CommunicationSupportPanel__savedSentence,
+.CommunicationSupportPanel__historyTitle {
+  font-weight: 600;
+  color: #133152;
+}
+
+.CommunicationSupportPanel__status {
+  width: fit-content;
+  border-radius: 999px;
+  padding: 3px 8px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.CommunicationSupportPanel__status--ok {
+  background: #e4f7ea;
+  color: #17643a;
+}
+
+.CommunicationSupportPanel__status--miss {
+  background: #feeaea;
+  color: #9d2727;
+}
+
+.CommunicationSupportPanel__savedContent {
+  min-width: 0;
+}
+
+.CommunicationSupportPanel__examples {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 12px;
+}
+
+.CommunicationSupportPanel__example {
+  border: 1px solid #d8e3f2;
+  background: #fff;
+  border-radius: 999px;
+  padding: 8px 12px;
+  color: #133152;
+  cursor: pointer;
+}
+
+.CommunicationSupportPanel__swapGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.CommunicationSupportPanel__swapOption {
+  border: 1px solid #d8e3f2;
+  background: #fff;
+  border-radius: 12px;
+  padding: 10px;
+  cursor: pointer;
+}
+
+.CommunicationSupportPanel__displayOverlay {
+  display: grid !important;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+  align-items: start;
+}
+
+.CommunicationSupportPanel__displayItem {
+  border-radius: 16px;
+  border: 1px solid #d8e3f2;
+  padding: 12px;
+  background: #fff;
+}
+
+.is-dark .CommunicationSupportPanel {
+  background: #28303a;
+  border-color: #404e5c;
+}
+
+.is-dark .CommunicationSupportPanel__section,
+.is-dark .CommunicationSupportPanel__modeTabs,
+.is-dark .CommunicationSupportPanel__example,
+.is-dark .CommunicationSupportPanel__swapOption,
+.is-dark .CommunicationSupportPanel__displayItem {
+  background: #34404c;
+  border-color: #4d6072;
+}
+
+.is-dark .CommunicationSupportPanel__title,
+.is-dark .CommunicationSupportPanel__section h4,
+.is-dark .CommunicationSupportPanel__token,
+.is-dark .CommunicationSupportPanel__savedSentence,
+.is-dark .CommunicationSupportPanel__historyTitle {
+  color: #f6f9fc;
+}
+
+.is-dark .CommunicationSupportPanel__subtitle,
+.is-dark .CommunicationSupportPanel__hint,
+.is-dark .CommunicationSupportPanel__meta,
+.is-dark .CommunicationSupportPanel__resultMeta,
+.is-dark .CommunicationSupportPanel__missing,
+.is-dark .CommunicationSupportPanel__empty {
+  color: #d0dae4;
+}
+
+.is-dark .CommunicationSupportPanel__candidate {
+  background: #2d5b84;
+  color: #f6f9fc;
+}
+
+.is-dark .CommunicationSupportPanel__candidate--active {
+  background: #7ca9d8;
+  color: #10273e;
+}

--- a/src/components/Board/CommunicationSupport/ReceiverLoopPanel.component.js
+++ b/src/components/Board/CommunicationSupport/ReceiverLoopPanel.component.js
@@ -1,0 +1,556 @@
+import React, { useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import TextField from '@material-ui/core/TextField';
+import Symbol from '../Symbol';
+import { buildCommunicationTileCatalog } from '../../../common/communicationSupport/symbolMatching';
+import {
+  buildReceiverHistoryEntry,
+  buildReceiverLoopState,
+  buildReceiverOutputPreview,
+  deleteReceiverReviewItem,
+  moveReceiverReviewItem,
+  replaceReceiverReviewItem
+} from '../../../common/communicationSupport/receiverPipeline';
+
+const EXAMPLE_PHRASES = [
+  '我想喝水',
+  '我要去厕所',
+  '我不舒服',
+  '你头晕吗',
+  '需要吃药吗',
+  '我们要去医院'
+];
+
+const DEFAULT_COPY = {
+  receiveSectionTitle: '文字转图片',
+  receiveHint: '使用当前已加载 boards 内的 tiles 做匹配',
+  listening: '聆听中...',
+  receivePlaceholder: '例如：我想喝水、我要去厕所、我不舒服',
+  generateSequence: '生成图片序列',
+  matching: '匹配中...',
+  stopRecording: '停止录音',
+  voiceInput: '语音输入',
+  resetInput: '重新输入',
+  previewLabel: '预览图片',
+  emptyPreview: '无',
+  missingLabel: '缺词提示',
+  sendToOutput: '发送到输出栏',
+  fullscreen: '全屏展示',
+  recentHistoryTitle: '最近历史',
+  historyHint: '表达与接收都会记录',
+  noHistory: '还没有本地历史。',
+  replaceSymbol: '替换图片',
+  searchPlaceholder: '搜索标签或同义词',
+  close: '关闭',
+  fullscreenTitle: '接收端全屏展示',
+  replaceAction: '换图',
+  sourceBoard: '来源板',
+  moveLeft: '左移',
+  moveRight: '右移',
+  remove: '删除',
+  unmatched: '未匹配',
+  expressHistoryLabel: '表达',
+  receiveHistoryLabel: '接收'
+};
+
+function HistoryRow({ item, copy }) {
+  const title =
+    item.direction === 'express'
+      ? item.sentence || item.labels.join('')
+      : item.inputText || item.labels.join('');
+
+  return (
+    <div className="CommunicationSupportPanel__historyRow">
+      <div className="CommunicationSupportPanel__historyTitle">{title}</div>
+      <div className="CommunicationSupportPanel__meta">
+        {item.direction === 'express'
+          ? copy.expressHistoryLabel
+          : copy.receiveHistoryLabel}{' '}
+        · {item.labels.join(' / ')}
+      </div>
+    </div>
+  );
+}
+
+HistoryRow.propTypes = {
+  item: PropTypes.shape({
+    direction: PropTypes.string.isRequired,
+    sentence: PropTypes.string,
+    inputText: PropTypes.string,
+    labels: PropTypes.arrayOf(PropTypes.string).isRequired
+  }).isRequired,
+  copy: PropTypes.object.isRequired
+};
+
+function MatchRow({
+  match,
+  onJumpBoard,
+  onMoveLeft,
+  onMoveRight,
+  onDelete,
+  onSwap,
+  copy
+}) {
+  const hasMatch = Boolean(match.tile);
+
+  return (
+    <div className="CommunicationSupportPanel__matchRow">
+      <div className="CommunicationSupportPanel__matchMain">
+        <div className="CommunicationSupportPanel__matchPreview">
+          {hasMatch ? (
+            <Symbol
+              image={match.tile.tile.image}
+              keyPath={match.tile.tile.keyPath}
+              label={match.tile.tile.label}
+              labelpos="Below"
+            />
+          ) : (
+            <div className="CommunicationSupportPanel__missingPreview">?</div>
+          )}
+        </div>
+        <div className="CommunicationSupportPanel__matchText">
+          <span className="CommunicationSupportPanel__token">
+            {match.token}
+          </span>
+          <span
+            className={
+              hasMatch
+                ? 'CommunicationSupportPanel__status CommunicationSupportPanel__status--ok'
+                : 'CommunicationSupportPanel__status CommunicationSupportPanel__status--miss'
+            }
+          >
+            {hasMatch ? match.tile.tile.label : copy.unmatched}
+          </span>
+          {hasMatch && (
+            <span className="CommunicationSupportPanel__meta">
+              {match.matchType} · {match.tile.boardName}
+            </span>
+          )}
+        </div>
+      </div>
+      <div className="CommunicationSupportPanel__matchActions">
+        <Button color="primary" size="small" onClick={() => onSwap(match.id)}>
+          {copy.replaceAction}
+        </Button>
+        {hasMatch && match.tile.boardId && (
+          <Button
+            color="primary"
+            size="small"
+            onClick={() => onJumpBoard(match.tile.boardId)}
+          >
+            {copy.sourceBoard}
+          </Button>
+        )}
+        <Button size="small" onClick={() => onMoveLeft(match.id)}>
+          {copy.moveLeft}
+        </Button>
+        <Button size="small" onClick={() => onMoveRight(match.id)}>
+          {copy.moveRight}
+        </Button>
+        <Button size="small" onClick={() => onDelete(match.id)}>
+          {copy.remove}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+MatchRow.propTypes = {
+  match: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    token: PropTypes.string.isRequired,
+    matchType: PropTypes.string.isRequired,
+    tile: PropTypes.shape({
+      boardId: PropTypes.string,
+      boardName: PropTypes.string,
+      tile: PropTypes.shape({
+        label: PropTypes.string
+      })
+    })
+  }).isRequired,
+  onJumpBoard: PropTypes.func.isRequired,
+  onMoveLeft: PropTypes.func.isRequired,
+  onMoveRight: PropTypes.func.isRequired,
+  onDelete: PropTypes.func.isRequired,
+  onSwap: PropTypes.func.isRequired,
+  copy: PropTypes.object.isRequired
+};
+
+export default function ReceiverLoopPanel({
+  boards,
+  intl,
+  onApplyOutput,
+  onJumpBoard,
+  onAppendHistory,
+  historyItems,
+  speech,
+  copyOverrides
+}) {
+  const copy = { ...DEFAULT_COPY, ...(copyOverrides || {}) };
+  const [inputText, setInputText] = useState('');
+  const [receivePhase, setReceivePhase] = useState('idle');
+  const [reviewItems, setReviewItems] = useState([]);
+  const [showSwapId, setShowSwapId] = useState(null);
+  const [swapQuery, setSwapQuery] = useState('');
+  const [showDisplay, setShowDisplay] = useState(false);
+
+  const tileCatalog = useMemo(
+    () => buildCommunicationTileCatalog(boards, intl),
+    [boards, intl]
+  );
+
+  const swapResults = useMemo(
+    () => {
+      const query = swapQuery.trim();
+
+      if (!query) {
+        return tileCatalog.slice(0, 16);
+      }
+
+      return tileCatalog
+        .filter(item => {
+          return (
+            item.labels.some(label => label.indexOf(query) >= 0) ||
+            item.synonyms.some(synonym => synonym.indexOf(query) >= 0)
+          );
+        })
+        .slice(0, 24);
+    },
+    [swapQuery, tileCatalog]
+  );
+
+  const missingTokens = useMemo(
+    () => {
+      return reviewItems.filter(item => !item.tile).map(item => item.token);
+    },
+    [reviewItems]
+  );
+
+  const receiveOutputPreview = useMemo(
+    () => {
+      return buildReceiverOutputPreview(reviewItems);
+    },
+    [reviewItems]
+  );
+
+  const speechState = speech || null;
+  const isListening = Boolean(speechState && speechState.isListening);
+  const speechError = speechState ? speechState.error : '';
+
+  function openReviewForText(text) {
+    const result = buildReceiverLoopState(text, boards, { intl });
+    setReviewItems(result.reviewItems);
+    setReceivePhase('review');
+  }
+
+  function handleMatch() {
+    setReceivePhase('matching');
+
+    window.setTimeout(() => {
+      openReviewForText(inputText);
+    }, 30);
+  }
+
+  function handleApplyReceiveOutput() {
+    const outputItems = buildReceiverOutputPreview(reviewItems);
+
+    if (!outputItems.length) {
+      return;
+    }
+
+    onApplyOutput(outputItems);
+
+    if (onAppendHistory) {
+      onAppendHistory(buildReceiverHistoryEntry(inputText, reviewItems));
+    }
+  }
+
+  function moveReviewItem(itemId, offset) {
+    setReviewItems(prevItems =>
+      moveReceiverReviewItem(prevItems, itemId, offset)
+    );
+  }
+
+  function handleDeleteReviewItem(itemId) {
+    setReviewItems(prevItems => deleteReceiverReviewItem(prevItems, itemId));
+  }
+
+  function handleSwapPick(candidate) {
+    setReviewItems(prevItems =>
+      replaceReceiverReviewItem(prevItems, showSwapId, candidate)
+    );
+    setShowSwapId(null);
+    setSwapQuery('');
+  }
+
+  function handleResetReceive() {
+    setReceivePhase('idle');
+    setReviewItems([]);
+    setInputText('');
+    setShowDisplay(false);
+  }
+
+  return (
+    <div className="CommunicationSupportPanel__content">
+      <div className="CommunicationSupportPanel__section">
+        <div className="CommunicationSupportPanel__sectionHeader">
+          <h4>{copy.receiveSectionTitle}</h4>
+          <span className="CommunicationSupportPanel__hint">
+            {copy.receiveHint}
+          </span>
+        </div>
+        <TextField
+          fullWidth
+          multiline
+          rowsMin={2}
+          rowsMax={4}
+          value={isListening ? speechState.interimText || inputText : inputText}
+          variant="outlined"
+          placeholder={isListening ? copy.listening : copy.receivePlaceholder}
+          onChange={event => {
+            if (!isListening) {
+              setInputText(event.target.value);
+            }
+          }}
+          InputProps={{ readOnly: isListening }}
+        />
+        <div className="CommunicationSupportPanel__actions">
+          <Button
+            color="primary"
+            variant="contained"
+            onClick={handleMatch}
+            disabled={!inputText.trim() || isListening}
+          >
+            {receivePhase === 'matching'
+              ? copy.matching
+              : copy.generateSequence}
+          </Button>
+          {speechState && (
+            <Button
+              color="primary"
+              variant="outlined"
+              onClick={() => {
+                if (isListening) {
+                  speechState.stopListening();
+                  return;
+                }
+
+                setInputText('');
+                speechState.startListening(finalText => {
+                  setInputText(finalText);
+                  setReceivePhase('matching');
+                  window.setTimeout(() => {
+                    openReviewForText(finalText);
+                  }, 30);
+                });
+              }}
+            >
+              {isListening ? copy.stopRecording : copy.voiceInput}
+            </Button>
+          )}
+          <Button
+            color="primary"
+            variant="outlined"
+            onClick={handleResetReceive}
+          >
+            {copy.resetInput}
+          </Button>
+        </div>
+        {speechError && (
+          <div className="CommunicationSupportPanel__missing">
+            {speechError}
+          </div>
+        )}
+        <div className="CommunicationSupportPanel__examples">
+          {EXAMPLE_PHRASES.map(phrase => (
+            <button
+              key={phrase}
+              className="CommunicationSupportPanel__example"
+              onClick={() => setInputText(phrase)}
+            >
+              {phrase}
+            </button>
+          ))}
+        </div>
+        {receivePhase === 'review' && (
+          <div className="CommunicationSupportPanel__results">
+            <div className="CommunicationSupportPanel__resultMeta">
+              {copy.previewLabel}：
+              {receiveOutputPreview.map(item => item.label).join(' / ') ||
+                copy.emptyPreview}
+            </div>
+            <div className="CommunicationSupportPanel__matches">
+              {reviewItems.map(match => (
+                <MatchRow
+                  key={match.id}
+                  match={match}
+                  onJumpBoard={onJumpBoard}
+                  onMoveLeft={id => moveReviewItem(id, -1)}
+                  onMoveRight={id => moveReviewItem(id, 1)}
+                  onDelete={handleDeleteReviewItem}
+                  onSwap={setShowSwapId}
+                  copy={copy}
+                />
+              ))}
+            </div>
+            {!!missingTokens.length && (
+              <div className="CommunicationSupportPanel__missing">
+                {copy.missingLabel}：{missingTokens.join('、')}
+              </div>
+            )}
+            <div className="CommunicationSupportPanel__actions">
+              <Button
+                color="primary"
+                variant="contained"
+                onClick={handleApplyReceiveOutput}
+                disabled={!receiveOutputPreview.length}
+              >
+                {copy.sendToOutput}
+              </Button>
+              <Button
+                color="primary"
+                variant="outlined"
+                onClick={() => setShowDisplay(true)}
+                disabled={!receiveOutputPreview.length}
+              >
+                {copy.fullscreen}
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="CommunicationSupportPanel__section">
+        <div className="CommunicationSupportPanel__sectionHeader">
+          <h4>{copy.recentHistoryTitle}</h4>
+          <span className="CommunicationSupportPanel__hint">
+            {copy.historyHint}
+          </span>
+        </div>
+        <div className="CommunicationSupportPanel__savedList">
+          {historyItems.length ? (
+            historyItems.map((item, index) => (
+              <HistoryRow
+                key={item.createdAt || index}
+                item={item}
+                copy={copy}
+              />
+            ))
+          ) : (
+            <div className="CommunicationSupportPanel__empty">
+              {copy.noHistory}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <Dialog
+        open={Boolean(showSwapId)}
+        onClose={() => setShowSwapId(null)}
+        fullWidth
+        maxWidth="md"
+      >
+        <DialogTitle>{copy.replaceSymbol}</DialogTitle>
+        <DialogContent dividers>
+          <TextField
+            fullWidth
+            variant="outlined"
+            placeholder={copy.searchPlaceholder}
+            value={swapQuery}
+            onChange={event => setSwapQuery(event.target.value)}
+          />
+          <div className="CommunicationSupportPanel__swapGrid">
+            {swapResults.map(candidate => (
+              <button
+                key={candidate.id}
+                className="CommunicationSupportPanel__swapOption"
+                onClick={() => handleSwapPick(candidate)}
+              >
+                <Symbol
+                  image={candidate.tile.image}
+                  keyPath={candidate.tile.keyPath}
+                  label={candidate.tile.label}
+                  labelpos="Below"
+                />
+                <span className="CommunicationSupportPanel__meta">
+                  {candidate.boardName}
+                </span>
+              </button>
+            ))}
+          </div>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setShowSwapId(null)} color="primary">
+            {copy.close}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog
+        open={showDisplay}
+        onClose={() => setShowDisplay(false)}
+        fullScreen
+      >
+        <DialogTitle>{copy.fullscreenTitle}</DialogTitle>
+        <DialogContent className="CommunicationSupportPanel__displayOverlay">
+          {receiveOutputPreview.map(item => (
+            <div
+              className="CommunicationSupportPanel__displayItem"
+              key={item.id || item.label}
+            >
+              <Symbol
+                image={item.image}
+                keyPath={item.keyPath}
+                label={item.label}
+                labelpos="Below"
+              />
+            </div>
+          ))}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setShowDisplay(false)} color="primary">
+            {copy.close}
+          </Button>
+          <Button
+            onClick={handleApplyReceiveOutput}
+            color="primary"
+            variant="contained"
+            disabled={!receiveOutputPreview.length}
+          >
+            {copy.sendToOutput}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+}
+
+ReceiverLoopPanel.propTypes = {
+  boards: PropTypes.arrayOf(PropTypes.object).isRequired,
+  intl: PropTypes.object,
+  onApplyOutput: PropTypes.func.isRequired,
+  onJumpBoard: PropTypes.func.isRequired,
+  onAppendHistory: PropTypes.func,
+  historyItems: PropTypes.arrayOf(PropTypes.object),
+  speech: PropTypes.shape({
+    isListening: PropTypes.bool,
+    interimText: PropTypes.string,
+    error: PropTypes.string,
+    stopListening: PropTypes.func,
+    startListening: PropTypes.func
+  }),
+  copyOverrides: PropTypes.object
+};
+
+ReceiverLoopPanel.defaultProps = {
+  intl: null,
+  onAppendHistory: null,
+  historyItems: [],
+  speech: null,
+  copyOverrides: null
+};

--- a/src/components/Board/CommunicationSupport/ReceiverLoopPanel.component.test.js
+++ b/src/components/Board/CommunicationSupport/ReceiverLoopPanel.component.test.js
@@ -1,0 +1,197 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { act } from 'react-dom/test-utils';
+import ReceiverLoopPanel from './ReceiverLoopPanel.component';
+import * as symbolMatching from '../../../common/communicationSupport/symbolMatching';
+
+const mockedMatches = [
+  {
+    token: '想',
+    matchType: 'exact',
+    tile: {
+      id: 'want',
+      boardId: 'home',
+      boardName: '首页',
+      tile: {
+        id: 'want',
+        label: '想',
+        image: '/want.png'
+      }
+    }
+  },
+  {
+    token: '喝',
+    matchType: 'exact',
+    tile: {
+      id: 'drink-verb',
+      boardId: 'home',
+      boardName: '首页',
+      tile: {
+        id: 'drink-verb',
+        label: '喝',
+        image: '/drink-verb.png'
+      }
+    }
+  },
+  {
+    token: '水',
+    matchType: 'exact',
+    tile: {
+      id: 'water',
+      boardId: 'home',
+      boardName: '首页',
+      tile: {
+        id: 'water',
+        label: '水',
+        image: '/water.png'
+      }
+    }
+  }
+];
+
+jest.mock('../../../common/communicationSupport/symbolMatching', () => ({
+  buildCommunicationTileCatalog: jest.fn(),
+  createCommunicationOutputFromMatches: jest.fn(),
+  matchTextToCommunicationTiles: jest.fn()
+}));
+
+jest.mock('../Symbol', () => {
+  return function MockSymbol(props) {
+    return <div className="MockSymbol">{props.label}</div>;
+  };
+});
+
+async function setInput(wrapper, value) {
+  const textField = wrapper.find('ForwardRef(TextField)').at(0);
+  await act(async () => {
+    textField.prop('onChange')({
+      target: { value }
+    });
+  });
+  wrapper.update();
+}
+
+describe('ReceiverLoopPanel', () => {
+  const onApplyOutput = jest.fn();
+  const onAppendHistory = jest.fn();
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    onApplyOutput.mockClear();
+    onAppendHistory.mockClear();
+    symbolMatching.buildCommunicationTileCatalog.mockReturnValue([
+      {
+        id: 'drink',
+        boardName: '饮品',
+        labels: ['饮料'],
+        synonyms: ['喝的'],
+        tile: {
+          id: 'drink',
+          label: '饮料',
+          image: '/drink.png'
+        }
+      }
+    ]);
+    symbolMatching.matchTextToCommunicationTiles.mockReturnValue({
+      matches: mockedMatches,
+      matchRate: 1
+    });
+    symbolMatching.createCommunicationOutputFromMatches.mockImplementation(
+      matches =>
+        matches
+          .filter(item => item.tile && item.tile.tile)
+          .map(item => ({
+            id: item.tile.tile.id,
+            label: item.tile.tile.label,
+            image: item.tile.tile.image
+          }))
+    );
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  test('supports a text-token-image receiver loop without wrapper dependencies', async () => {
+    const wrapper = mount(
+      <ReceiverLoopPanel
+        boards={[]}
+        intl={null}
+        onApplyOutput={onApplyOutput}
+        onJumpBoard={jest.fn()}
+        onAppendHistory={onAppendHistory}
+        historyItems={[]}
+      />
+    );
+
+    await setInput(wrapper, '我想喝水');
+
+    wrapper
+      .find('ForwardRef(Button)')
+      .filterWhere(node => node.text() === '生成图片序列')
+      .first()
+      .simulate('click');
+
+    await act(async () => {
+      jest.runAllTimers();
+    });
+    wrapper.update();
+
+    expect(wrapper.text()).toContain('预览图片：想 / 喝 / 水');
+
+    wrapper
+      .find('ForwardRef(Button)')
+      .filterWhere(node => node.text() === '右移')
+      .at(0)
+      .simulate('click');
+    wrapper.update();
+
+    expect(wrapper.text()).toContain('预览图片：喝 / 想 / 水');
+
+    wrapper
+      .find('ForwardRef(Button)')
+      .filterWhere(node => node.text() === '换图')
+      .at(2)
+      .simulate('click');
+    wrapper.update();
+
+    wrapper
+      .find('button')
+      .filterWhere(node => node.text().includes('饮料'))
+      .first()
+      .simulate('click');
+    wrapper.update();
+
+    expect(wrapper.text()).toContain('预览图片：喝 / 想 / 饮料');
+
+    wrapper
+      .find('ForwardRef(Button)')
+      .filterWhere(node => node.text() === '发送到输出栏')
+      .first()
+      .simulate('click');
+
+    expect(onApplyOutput).toHaveBeenCalledWith([
+      {
+        id: 'drink-verb',
+        label: '喝',
+        image: '/drink-verb.png'
+      },
+      {
+        id: 'want',
+        label: '想',
+        image: '/want.png'
+      },
+      {
+        id: 'drink',
+        label: '饮料',
+        image: '/drink.png'
+      }
+    ]);
+    expect(onAppendHistory).toHaveBeenCalledWith({
+      direction: 'receive',
+      inputText: '我想喝水',
+      labels: ['喝', '想', '饮料']
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a receiver-side communication support loop with text-to-symbol matching, review, reorder, replace, and send-to-output behavior, backed by receiver pipeline tests and UI tests.

## Context

This workflow is informed by experimentation from picinterpreter (TuYuJia), a communication-support prototype that explored bidirectional AAC flows, especially the receiver-side path of:

- entering short text
- matching text to symbols
- reviewing and correcting the symbol sequence before use

Reference repository:
- https://github.com/picinterpreter/picinterpreter

## Why

This PR brings that receiver-side loop into a more generic, reusable form for cboard rather than shipping a product-branded integration.

## Verification

- `src/common/communicationSupport/receiverPipeline.test.js`
- `src/components/Board/CommunicationSupport/ReceiverLoopPanel.component.test.js`
- `src/components/Board/Tuyujia/__tests__/matcher.test.js`
