### PR TITLE
Refactor Export component to functional component

### DIFF
--- a/src/components/Settings/Export/Export.component.js
+++ b/src/components/Settings/Export/Export.component.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, intlShape } from 'react-intl';
 import Link from '@material-ui/core/Link';
@@ -14,12 +14,13 @@ import InputLabel from '@material-ui/core/InputLabel';
 import FormControl from '@material-ui/core/FormControl';
 import Button from '@material-ui/core/Button';
 import GetAppIcon from '@material-ui/icons/GetApp';
+import ListSubheader from '@material-ui/core/ListSubheader';
 
 import FullScreenDialog from '../../UI/FullScreenDialog';
 import messages from './Export.messages';
 
 import './Export.css';
-import ListSubheader from '@material-ui/core/ListSubheader';
+
 import {
   LARGE_FONT_SIZE,
   MEDIUM_FONT_SIZE,
@@ -39,340 +40,325 @@ const propTypes = {
   intl: intlShape.isRequired
 };
 
-class Export extends React.Component {
-  constructor(props) {
-    super(props);
+function useExportLoading(onExportClick) {
+  const [loading, setLoading] = useState(false);
 
-    this.state = {
-      exportSingleBoard: '',
-      exportAllBoard: '',
-      labelFontSize: MEDIUM_FONT_SIZE,
-      singleBoard: '',
-      loadingSingle: false,
-      loadingAll: false,
-      boardError: false
-    };
-  }
+  const trigger = (format, board, fontSize) => {
+    if (!format) return false;
 
-  openMenu(e) {
-    this.setState({ exportMenu: e.currentTarget });
-  }
+    setLoading(true);
 
-  closeMenu() {
-    this.setState({ exportMenu: null });
-  }
+    onExportClick(format, board, fontSize, () => setLoading(false));
 
-  handleBoardChange = event => {
-    this.setState({
-      boardError: false,
-      singleBoard: event.target.value
-    });
+    return true;
   };
 
-  handleSizeChange = event => {
-    this.setState({
-      boardError: false,
-      labelFontSize: event.target.value
-    });
-  };
-
-  handleSingleBoardChange = event => {
-    this.setState({ exportSingleBoard: event.target.value });
-  };
-
-  handleAllBoardChange = event => {
-    this.setState({ exportAllBoard: event.target.value });
-  };
-
-  handleAllExport = () => {
-    if (!this.state.exportAllBoard) return;
-    const doneCallback = () => this.setState({ loadingAll: false });
-    this.setState({ loadingAll: true }, () => {
-      this.props.onExportClick(
-        this.state.exportAllBoard,
-        '',
-        this.state.labelFontSize,
-        doneCallback
-      );
-    });
-  };
-
-  handleSingleExport = () => {
-    if (!this.state.singleBoard || !this.state.exportSingleBoard) {
-      this.setState({ boardError: true });
-      return;
-    }
-    const doneCallback = () => this.setState({ loadingSingle: false });
-    this.setState({ loadingSingle: true }, () => {
-      this.props.onExportClick(
-        this.state.exportSingleBoard,
-        this.state.singleBoard,
-        this.state.labelFontSize,
-        doneCallback
-      );
-    });
-  };
-
-  render() {
-    const { onClose, boards, intl } = this.props;
-    return (
-      <div className="Export">
-        <FullScreenDialog
-          open
-          title={<FormattedMessage {...messages.export} />}
-          onClose={onClose}
-        >
-          <Paper className="Export__section">
-            <List>
-              <ListItem className="Export__ListItem">
-                <ListItemText
-                  className="Export__ListItemText"
-                  primary={<FormattedMessage {...messages.exportSingle} />}
-                  secondary={
-                    <FormattedMessage
-                      {...messages.exportSingleSecondary}
-                      values={{
-                        cboardLink: (
-                          <Link
-                            href="https://www.cboard.io/help/#HowdoIimportaboardintoCboard"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                          >
-                            Cboard
-                          </Link>
-                        ),
-                        link: (
-                          <Link
-                            href="https://www.openboardformat.org/"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                          >
-                            OpenBoard
-                          </Link>
-                        )
-                      }}
-                    />
-                  }
-                />
-                <ListItemSecondaryAction>
-                  <div className="Export__SelectContainer">
-                    {this.state.loadingSingle ? (
-                      <CircularProgress
-                        size={25}
-                        className="Export__SelectContainer--spinner"
-                        thickness={7}
-                      />
-                    ) : (
-                      <div className="Export__SelectContainer">
-                        <FormControl
-                          className="Export__SelectContainer__Select"
-                          variant="standard"
-                          error={this.state.boardError}
-                          disabled={this.state.loading}
-                        >
-                          <InputLabel id="boards-select-label">
-                            {intl.formatMessage(messages.boards)}
-                          </InputLabel>
-                          <Select
-                            labelId="boards-select-label"
-                            id="boards-select"
-                            autoWidth={false}
-                            value={this.state.singleBoard}
-                            onChange={this.handleBoardChange}
-                          >
-                            {boards.map(
-                              board =>
-                                !board.hidden && (
-                                  <MenuItem key={board.id} value={board}>
-                                    {board.name ||
-                                      (board.nameKey &&
-                                        intl.formatMessage({
-                                          id: board.nameKey
-                                        }))}
-                                  </MenuItem>
-                                )
-                            )}
-                          </Select>
-                        </FormControl>
-                        <FormControl
-                          className="Export__SelectContainer__Select"
-                          variant="standard"
-                          disabled={this.state.loading}
-                        >
-                          <InputLabel id="export-single-select-label">
-                            {intl.formatMessage(messages.export)}
-                          </InputLabel>
-                          <Select
-                            labelId="export-single-select-label"
-                            id="export-single-select"
-                            autoWidth={false}
-                            disabled={this.state.loading}
-                            value={this.state.exportSingleBoard}
-                            onChange={this.handleSingleBoardChange}
-                          >
-                            <MenuItem value="cboard">Cboard</MenuItem>
-                            <MenuItem value="openboard">OpenBoard</MenuItem>
-                            <MenuItem value="pdf">PDF</MenuItem>
-                            <MenuItem value="picsee_pdf">
-                              PicseePal PDF
-                            </MenuItem>
-                          </Select>
-                        </FormControl>
-                        <Button
-                          variant="contained"
-                          color="primary"
-                          onClick={this.handleSingleExport}
-                          disabled={
-                            !this.state.singleBoard ||
-                            !this.state.exportSingleBoard ||
-                            this.state.loadingSingle
-                          }
-                          startIcon={<GetAppIcon />}
-                        >
-                          <FormattedMessage {...messages.export} />
-                        </Button>
-                      </div>
-                    )}
-                  </div>
-                </ListItemSecondaryAction>
-              </ListItem>
-            </List>
-          </Paper>
-          <Paper className="Export__section">
-            <List>
-              <ListItem>
-                <ListItemText
-                  className="Export__ListItemText"
-                  primary={<FormattedMessage {...messages.exportAll} />}
-                  secondary={
-                    <FormattedMessage
-                      {...messages.exportAllSecondary}
-                      values={{
-                        cboardLink: (
-                          <Link
-                            href="https://www.cboard.io/help/#HowdoIimportaboardintoCboard"
-                            target="_blank"
-                          >
-                            Cboard
-                          </Link>
-                        ),
-                        link: (
-                          <Link
-                            href="https://www.openboardformat.org/"
-                            target="_blank"
-                          >
-                            OpenBoard
-                          </Link>
-                        )
-                      }}
-                    />
-                  }
-                />
-                <ListItemSecondaryAction>
-                  <div className="Export__SelectContainer">
-                    {this.state.loadingAll ? (
-                      <CircularProgress
-                        size={25}
-                        className="Export__SelectContainer--spinner"
-                        thickness={7}
-                      />
-                    ) : (
-                      <div className="Export__SelectContainer">
-                        <FormControl
-                          className="Export__SelectContainer__Select"
-                          variant="standard"
-                          disabled={this.state.loadingAll}
-                        >
-                          <InputLabel id="export-all-select-label">
-                            {intl.formatMessage(messages.export)}
-                          </InputLabel>
-                          <Select
-                            labelId="export-all-select-label"
-                            id="export-all-select"
-                            autoWidth={false}
-                            value={this.state.exportAllBoard}
-                            onChange={this.handleAllBoardChange}
-                          >
-                            <MenuItem value="cboard">Cboard</MenuItem>
-                            <MenuItem value="openboard">OpenBoard</MenuItem>
-                            <MenuItem value="pdf">PDF</MenuItem>
-                            <MenuItem value="picsee_pdf">
-                              PicseePal PDF
-                            </MenuItem>
-                          </Select>
-                        </FormControl>
-                        <Button
-                          variant="contained"
-                          color="primary"
-                          onClick={this.handleAllExport}
-                          disabled={
-                            !this.state.exportAllBoard || this.state.loadingAll
-                          }
-                          startIcon={<GetAppIcon />}
-                        >
-                          <FormattedMessage {...messages.export} />
-                        </Button>
-                      </div>
-                    )}
-                  </div>
-                </ListItemSecondaryAction>
-              </ListItem>
-            </List>
-          </Paper>
-          <Paper className="Export__section">
-            <List
-              className="Export__List"
-              subheader={
-                <ListSubheader>
-                  <FormattedMessage {...messages.pdfSettings} />
-                </ListSubheader>
-              }
-            >
-              <ListItem>
-                <ListItemText
-                  className="Export__ListItemText"
-                  primary={<FormattedMessage {...messages.fontSize} />}
-                  secondary={
-                    <FormattedMessage {...messages.fontSizeSecondary} />
-                  }
-                />
-                <ListItemSecondaryAction>
-                  <div className="Export__SelectContainer">
-                    <FormControl
-                      className="Export__SelectContainer__Select"
-                      variant="standard"
-                    >
-                      <InputLabel id="export-all-select-label-size">
-                        {intl.formatMessage(messages.fontSize)}
-                      </InputLabel>
-                      <Select
-                        labelId="export-all-select-label-size"
-                        id="export-all-select-size"
-                        autoWidth={false}
-                        value={this.state.labelFontSize}
-                        onChange={this.handleSizeChange}
-                      >
-                        <MenuItem value={SMALL_FONT_SIZE}>
-                          <FormattedMessage {...messages.small} />
-                        </MenuItem>
-                        <MenuItem value={MEDIUM_FONT_SIZE}>
-                          <FormattedMessage {...messages.medium} />
-                        </MenuItem>
-                        <MenuItem value={LARGE_FONT_SIZE}>
-                          <FormattedMessage {...messages.large} />
-                        </MenuItem>
-                      </Select>
-                    </FormControl>
-                  </div>
-                </ListItemSecondaryAction>
-              </ListItem>
-            </List>
-          </Paper>
-        </FullScreenDialog>
-      </div>
-    );
-  }
+  return [loading, trigger];
 }
+
+const Export = ({ onClose, boards, intl, onExportClick }) => {
+  const [exportSingleBoard, setExportSingleBoard] = useState('');
+  const [exportAllBoard, setExportAllBoard] = useState('');
+  const [singleBoard, setSingleBoard] = useState('');
+  const [labelFontSize, setLabelFontSize] = useState(MEDIUM_FONT_SIZE);
+  const [boardError, setBoardError] = useState(false);
+
+  const [loadingSingle, triggerSingleExport] = useExportLoading(onExportClick);
+
+  const [loadingAll, triggerAllExport] = useExportLoading(onExportClick);
+
+  const handleBoardChange = useCallback(event => {
+    setBoardError(false);
+    setSingleBoard(event.target.value);
+  }, []);
+
+  const handleSizeChange = useCallback(event => {
+    setBoardError(false);
+    setLabelFontSize(event.target.value);
+  }, []);
+
+  const handleSingleBoardChange = useCallback(event => {
+    setExportSingleBoard(event.target.value);
+  }, []);
+
+  const handleAllBoardChange = useCallback(event => {
+    setExportAllBoard(event.target.value);
+  }, []);
+
+  const handleAllExport = useCallback(
+    () => {
+      triggerAllExport(exportAllBoard, '', labelFontSize);
+    },
+    [exportAllBoard, labelFontSize, triggerAllExport]
+  );
+
+  const handleSingleExport = useCallback(
+    () => {
+      if (!singleBoard || !exportSingleBoard) {
+        setBoardError(true);
+        return;
+      }
+
+      triggerSingleExport(exportSingleBoard, singleBoard, labelFontSize);
+    },
+    [exportSingleBoard, singleBoard, labelFontSize, triggerSingleExport]
+  );
+
+  return (
+    <div className="Export">
+      <FullScreenDialog
+        open
+        title={<FormattedMessage {...messages.export} />}
+        onClose={onClose}
+      >
+        <Paper className="Export__section">
+          <List>
+            <ListItem className="Export__ListItem">
+              <ListItemText
+                className="Export__ListItemText"
+                primary={<FormattedMessage {...messages.exportSingle} />}
+                secondary={
+                  <FormattedMessage
+                    {...messages.exportSingleSecondary}
+                    values={{
+                      cboardLink: (
+                        <Link
+                          href="https://www.cboard.io/help/#HowdoIimportaboardintoCboard"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          Cboard
+                        </Link>
+                      ),
+                      link: (
+                        <Link
+                          href="https://www.openboardformat.org/"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          OpenBoard
+                        </Link>
+                      )
+                    }}
+                  />
+                }
+              />
+              <ListItemSecondaryAction>
+                <div className="Export__SelectContainer">
+                  {loadingSingle ? (
+                    <CircularProgress
+                      size={25}
+                      className="Export__SelectContainer--spinner"
+                      thickness={7}
+                    />
+                  ) : (
+                    <div className="Export__SelectContainer">
+                      <FormControl
+                        className="Export__SelectContainer__Select"
+                        variant="standard"
+                        error={boardError}
+                      >
+                        <InputLabel id="boards-select-label">
+                          {intl.formatMessage(messages.boards)}
+                        </InputLabel>
+
+                        <Select
+                          labelId="boards-select-label"
+                          id="boards-select"
+                          autoWidth={false}
+                          value={singleBoard}
+                          onChange={handleBoardChange}
+                        >
+                          {boards.map(
+                            board =>
+                              !board.hidden && (
+                                <MenuItem key={board.id} value={board}>
+                                  {board.name ||
+                                    (board.nameKey &&
+                                      intl.formatMessage({
+                                        id: board.nameKey
+                                      }))}
+                                </MenuItem>
+                              )
+                          )}
+                        </Select>
+                      </FormControl>
+
+                      <FormControl
+                        className="Export__SelectContainer__Select"
+                        variant="standard"
+                      >
+                        <InputLabel id="export-single-select-label">
+                          {intl.formatMessage(messages.export)}
+                        </InputLabel>
+
+                        <Select
+                          labelId="export-single-select-label"
+                          id="export-single-select"
+                          autoWidth={false}
+                          value={exportSingleBoard}
+                          onChange={handleSingleBoardChange}
+                        >
+                          <MenuItem value="cboard">Cboard</MenuItem>
+                          <MenuItem value="openboard">OpenBoard</MenuItem>
+                          <MenuItem value="pdf">PDF</MenuItem>
+                          <MenuItem value="picsee_pdf">PicseePal PDF</MenuItem>
+                        </Select>
+                      </FormControl>
+
+                      <Button
+                        variant="contained"
+                        color="primary"
+                        onClick={handleSingleExport}
+                        disabled={
+                          !singleBoard || !exportSingleBoard || loadingSingle
+                        }
+                        startIcon={<GetAppIcon />}
+                      >
+                        <FormattedMessage {...messages.export} />
+                      </Button>
+                    </div>
+                  )}
+                </div>
+              </ListItemSecondaryAction>
+            </ListItem>
+          </List>
+        </Paper>
+
+        <Paper className="Export__section">
+          <List>
+            <ListItem>
+              <ListItemText
+                className="Export__ListItemText"
+                primary={<FormattedMessage {...messages.exportAll} />}
+                secondary={
+                  <FormattedMessage
+                    {...messages.exportAllSecondary}
+                    values={{
+                      cboardLink: (
+                        <Link
+                          href="https://www.cboard.io/help/#HowdoIimportaboardintoCboard"
+                          target="_blank"
+                        >
+                          Cboard
+                        </Link>
+                      ),
+                      link: (
+                        <Link
+                          href="https://www.openboardformat.org/"
+                          target="_blank"
+                        >
+                          OpenBoard
+                        </Link>
+                      )
+                    }}
+                  />
+                }
+              />
+              <ListItemSecondaryAction>
+                <div className="Export__SelectContainer">
+                  {loadingAll ? (
+                    <CircularProgress
+                      size={25}
+                      className="Export__SelectContainer--spinner"
+                      thickness={7}
+                    />
+                  ) : (
+                    <div className="Export__SelectContainer">
+                      <FormControl
+                        className="Export__SelectContainer__Select"
+                        variant="standard"
+                        disabled={loadingAll}
+                      >
+                        <InputLabel id="export-all-select-label">
+                          {intl.formatMessage(messages.export)}
+                        </InputLabel>
+
+                        <Select
+                          labelId="export-all-select-label"
+                          id="export-all-select"
+                          autoWidth={false}
+                          value={exportAllBoard}
+                          onChange={handleAllBoardChange}
+                        >
+                          <MenuItem value="cboard">Cboard</MenuItem>
+                          <MenuItem value="openboard">OpenBoard</MenuItem>
+                          <MenuItem value="pdf">PDF</MenuItem>
+                          <MenuItem value="picsee_pdf">PicseePal PDF</MenuItem>
+                        </Select>
+                      </FormControl>
+
+                      <Button
+                        variant="contained"
+                        color="primary"
+                        onClick={handleAllExport}
+                        disabled={!exportAllBoard || loadingAll}
+                        startIcon={<GetAppIcon />}
+                      >
+                        <FormattedMessage {...messages.export} />
+                      </Button>
+                    </div>
+                  )}
+                </div>
+              </ListItemSecondaryAction>
+            </ListItem>
+          </List>
+        </Paper>
+
+        <Paper className="Export__section">
+          <List
+            className="Export__List"
+            subheader={
+              <ListSubheader>
+                <FormattedMessage {...messages.pdfSettings} />
+              </ListSubheader>
+            }
+          >
+            <ListItem>
+              <ListItemText
+                className="Export__ListItemText"
+                primary={<FormattedMessage {...messages.fontSize} />}
+                secondary={<FormattedMessage {...messages.fontSizeSecondary} />}
+              />
+              <ListItemSecondaryAction>
+                <div className="Export__SelectContainer">
+                  <FormControl
+                    className="Export__SelectContainer__Select"
+                    variant="standard"
+                  >
+                    <InputLabel id="export-all-select-label-size">
+                      {intl.formatMessage(messages.fontSize)}
+                    </InputLabel>
+
+                    <Select
+                      labelId="export-all-select-label-size"
+                      id="export-all-select-size"
+                      autoWidth={false}
+                      value={labelFontSize}
+                      onChange={handleSizeChange}
+                    >
+                      <MenuItem value={SMALL_FONT_SIZE}>
+                        <FormattedMessage {...messages.small} />
+                      </MenuItem>
+
+                      <MenuItem value={MEDIUM_FONT_SIZE}>
+                        <FormattedMessage {...messages.medium} />
+                      </MenuItem>
+
+                      <MenuItem value={LARGE_FONT_SIZE}>
+                        <FormattedMessage {...messages.large} />
+                      </MenuItem>
+                    </Select>
+                  </FormControl>
+                </div>
+              </ListItemSecondaryAction>
+            </ListItem>
+          </List>
+        </Paper>
+      </FullScreenDialog>
+    </div>
+  );
+};
 
 Export.propTypes = propTypes;
 

--- a/src/components/Settings/Export/Export.test.js
+++ b/src/components/Settings/Export/Export.test.js
@@ -73,34 +73,62 @@ describe('Export tests', () => {
     const allExportButton = buttons.at(1);
     expect(allExportButton.prop('disabled')).toBe(true);
   });
+});
 
-  test('calls onExportClick when export single board button is clicked with valid selections', () => {
-    const onExportClick = jest.fn();
-    const wrapper = shallow(
-      <Export {...COMPONENT_PROPS} onExportClick={onExportClick} />
-    );
-    wrapper.setState({
-      singleBoard: { id: 'board1', name: 'Test Board' },
-      exportSingleBoard: 'pdf'
-    });
-    wrapper.instance().handleSingleExport();
-    expect(onExportClick).toHaveBeenCalled();
+test('calls onExportClick when export single board button is clicked with valid selections', () => {
+  const onExportClick = jest.fn();
+
+  const wrapper = shallow(
+    <Export {...COMPONENT_PROPS} onExportClick={onExportClick} />
+  );
+
+  wrapper.find('#boards-select').simulate('change', {
+    target: {
+      value: { id: 'board1', name: 'Test Board' }
+    }
   });
 
-  test('calls onExportClick when export all boards button is clicked with valid format', () => {
-    const onExportClick = jest.fn();
-    const wrapper = shallow(
-      <Export {...COMPONENT_PROPS} onExportClick={onExportClick} />
-    );
-    wrapper.setState({ exportAllBoard: 'cboard' });
-    wrapper.instance().handleAllExport();
-    expect(onExportClick).toHaveBeenCalled();
+  wrapper.find('#export-single-select').simulate('change', {
+    target: { value: 'pdf' }
   });
 
-  test('sets boardError when export single is clicked without selecting a board', () => {
-    const wrapper = shallow(<Export {...COMPONENT_PROPS} />);
-    wrapper.setState({ exportSingleBoard: 'pdf' });
-    wrapper.instance().handleSingleExport();
-    expect(wrapper.state('boardError')).toBe(true);
+  const buttons = wrapper.find('WithStyles(ForwardRef(Button))');
+
+  buttons.at(0).simulate('click');
+
+  expect(onExportClick).toHaveBeenCalled();
+});
+
+test('calls onExportClick when export all boards button is clicked with valid format', () => {
+  const onExportClick = jest.fn();
+
+  const wrapper = shallow(
+    <Export {...COMPONENT_PROPS} onExportClick={onExportClick} />
+  );
+
+  wrapper.find('#export-all-select').simulate('change', {
+    target: { value: 'cboard' }
   });
+
+  const buttons = wrapper.find('WithStyles(ForwardRef(Button))');
+
+  buttons.at(1).simulate('click');
+
+  expect(onExportClick).toHaveBeenCalled();
+});
+
+test('sets boardError when export single is clicked without selecting a board', () => {
+  const wrapper = shallow(<Export {...COMPONENT_PROPS} />);
+
+  wrapper.find('#export-single-select').simulate('change', {
+    target: { value: 'pdf' }
+  });
+
+  const buttons = wrapper.find('WithStyles(ForwardRef(Button))');
+
+  buttons.at(0).simulate('click');
+
+  const formControls = wrapper.find('WithStyles(ForwardRef(FormControl))');
+
+  expect(formControls.at(0).prop('error')).toBe(true);
 });


### PR DESCRIPTION
**Changes**

-  Converted `Export.component.js` from a class component to a functional component
-  Replaced class state with `useState`
-  Converted handlers to functions using `useCallback`
- Added `useExportLoading` hook to reduce duplicated loading logic
- Removed unused `openMenu` and `closeMenu` methods
- Updated tests to work with the functional component implementation by replacing class-component-specific APIs (`setState`, `instance`) with interaction-based testing

**Notes**

- No UI changes
- No logic changes
- No style changes

Closes #2150
