### PR TITLE
fix: fork default communicator before sync push to avoid 500 on PUT

### DIFF
--- a/src/components/Board/Board.actions.js
+++ b/src/components/Board/Board.actions.js
@@ -727,6 +727,16 @@ export function pushLocalChangesToApi(remoteBoards = []) {
       dispatch
     });
 
+    if (boardsToSync.some(b => b.needsCreate)) {
+      const { communicators, activeCommunicatorId } = getState().communicator;
+      const activeCommunicator = communicators.find(
+        c => c.id === activeCommunicatorId
+      );
+      if (activeCommunicator && activeCommunicator.email !== userEmail) {
+        dispatch(verifyAndUpsertCommunicator(activeCommunicator));
+      }
+    }
+
     // PUSH: Create/update boards
     for (const { boardId, needsCreate } of boardsToSync) {
       // Re-read board from current state to avoid stale references


### PR DESCRIPTION
## Summary

- Fixes #2203
- After logging in to an account with no remote communicator + ≥2 local boards to sync, the second board's push triggered a `PUT /communicator/:id` returning 500 because the body still carried the default communicator's `email`/`author`.
- `pushLocalChangesToApi` now mirrors the pattern used in `CommunicatorDialog` (`copyBoard`, `setRootBoard`, `deleteMyBoard`, board reorder): if there's at least one board needing CREATE and the active communicator's email doesn't match the user's, dispatch `verifyAndUpsertCommunicator` so the default communicator is forked locally (new shortid + user's email/author) before any push runs.

## Why this happens

`updateApiObjectsNoChild` ends with `upsertApiCommunicator(comm)`. On the first board:
- `comm.id === 'cboard_default'` → `createApiCommunicator` (POST). `api.createCommunicator` strips `id` and overrides `email`/`author` server-side → POST succeeds.
- `CREATE_API_COMMUNICATOR_SUCCESS` only merges `id` and `lastEdited` back into local state, leaving `email='support@cboard.io'` and `author='Cboard Team'`.

On the second board:
- `comm.id` is the Mongo id from the server → `updateApiCommunicator` (PUT). `api.updateCommunicator` sends the body verbatim → 500.

By forking the communicator before the push, the POST payload carries the user's `email`/`author` from the start, so subsequent PUTs are consistent.

## Why not "just fix the reducer"

An alternative was to make `CREATE_API_COMMUNICATOR_SUCCESS` spread the full server response. That works but ignores the project's existing convention: every other communicator-push site (`CommunicatorDialog.copyBoard/setRootBoard/deleteMyBoard/board reorder`) calls `verifyAndUpsertCommunicator` first. The sync engine was the only path skipping this invariant.

## Test plan

- [ ] Log in to a fresh account (no communicator, no boards on server) with two local boards pending sync → both pushes succeed; second board's `PUT /communicator/:id` returns 200.
- [ ] Log in to a fresh account with a single board pending sync (POST-only path) → no regression.
- [ ] Log in to an account where local boards only need UPDATE (no CREATE) → `verifyAndUpsertCommunicator` is **not** dispatched (gate by `hasCreates`); communicator is untouched.
- [ ] Log in to an account whose active communicator already belongs to the user (`email === userEmail`) → no fork dispatched; behavior unchanged.
- [ ] Open `CommunicatorDialog` flows (copy/reorder/setRoot/delete) → unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)