### PR TITLE
Clean PIN in navigationSettings on logout

### DIFF
--- a/src/components/App/App.reducer.js
+++ b/src/components/App/App.reducer.js
@@ -167,7 +167,12 @@ function appReducer(state = initialState, action) {
     case LOGOUT:
       return {
         ...state,
-        userData: {}
+        userData: {},
+        navigationSettings: {
+          ...state.navigationSettings,
+          pinLockEnabled: false,
+          pinCode: ''
+        }
       };
     case UPDATE_USER_DATA:
       return {

--- a/src/components/App/__tests__/App.reducer.test.js
+++ b/src/components/App/__tests__/App.reducer.test.js
@@ -109,6 +109,26 @@ describe('reducer', () => {
     };
     expect(appReducer(initialState, logout)).toEqual(initialState);
   });
+  it('should clear PIN on logout', () => {
+    const stateWithPin = {
+      ...initialState,
+      userData: uData,
+      navigationSettings: {
+        ...initialState.navigationSettings,
+        pinLockEnabled: true,
+        pinCode: '1234'
+      }
+    };
+    expect(appReducer(stateWithPin, { type: LOGOUT })).toEqual({
+      ...stateWithPin,
+      userData: {},
+      navigationSettings: {
+        ...stateWithPin.navigationSettings,
+        pinLockEnabled: false,
+        pinCode: ''
+      }
+    });
+  });
   it('should handle updateDisplaySettings', () => {
     const updateDisplaySettings = {
       type: UPDATE_DISPLAY_SETTINGS,


### PR DESCRIPTION
Clean PIN in `navigationSettings` on logout to prevent the error of showing the PIN of another account after it's logout.