### PR TITLE
Sync markToUpdate and shouldCreateBoard in syncMeta

### DIFF
--- a/src/components/Board/Board.reducer.js
+++ b/src/components/Board/Board.reducer.js
@@ -422,11 +422,17 @@ function boardReducer(state = initialState, action) {
       });
 
       const newSyncMeta = removeSyncMeta(state.syncMeta, action.boardId);
+      const patchedSyncMeta = finalBoards.reduce((meta, board) => {
+        if (board.markToUpdate || board.shouldCreateBoard) {
+          return setSyncMeta(meta, board.id, { status: SYNC_STATUS.PENDING });
+        }
+        return meta;
+      }, newSyncMeta);
       return {
         ...state,
         isFetching: false,
         boards: finalBoards,
-        syncMeta: setSyncMeta(newSyncMeta, action.board.id, {
+        syncMeta: setSyncMeta(patchedSyncMeta, action.board.id, {
           status: SYNC_STATUS.SYNCED
         })
       };

--- a/src/components/Board/Board.reducer.js
+++ b/src/components/Board/Board.reducer.js
@@ -365,6 +365,7 @@ function boardReducer(state = initialState, action) {
     case CREATE_API_BOARD_SUCCESS: {
       const tilesToUpdateIds = [];
       const boardsToMarkForCreation = [];
+      const pendingBoardIds = new Set();
 
       for (const board of state.boards) {
         if (!board.tiles) continue;
@@ -380,7 +381,7 @@ function boardReducer(state = initialState, action) {
         }
       }
 
-      // Pass 2: immutably produce new boards
+      // Pass 2: immutably produce new boards; collect PENDING ids alongside flag decisions
       const updatedBoards = state.boards.map(board => {
         const tileNeedsUpdate = board.tiles?.some(
           t => t != null && t.loadBoard === action.boardId
@@ -397,6 +398,10 @@ function boardReducer(state = initialState, action) {
           newBoard = { ...board, tiles: newTiles };
           if (isServerBoard(board) && board.hasOwnProperty('email')) {
             newBoard = { ...newBoard, markToUpdate: true };
+            // Skip the board being created — it is always set to SYNCED below
+            if (board.id !== action.boardId) {
+              pendingBoardIds.add(board.id);
+            }
           }
         }
 
@@ -411,28 +416,29 @@ function boardReducer(state = initialState, action) {
         return newBoard;
       });
 
-      // Pass 3: apply shouldCreateBoard where needed
+      // Pass 3: apply shouldCreateBoard where needed; collect PENDING ids alongside flag decisions
       const finalBoards = updatedBoards.map(board => {
         if (!boardsToMarkForCreation.includes(board.id)) return board;
         const boardTileIds = board.tiles?.map(t => t.id) ?? [];
         const alreadyOnDb = boardTileIds.some(id =>
           tilesToUpdateIds.includes(id)
         );
-        return alreadyOnDb ? board : { ...board, shouldCreateBoard: true };
+        if (alreadyOnDb) return board;
+        pendingBoardIds.add(board.id);
+        return { ...board, shouldCreateBoard: true };
       });
 
-      const newSyncMeta = removeSyncMeta(state.syncMeta, action.boardId);
-      const patchedSyncMeta = finalBoards.reduce((meta, board) => {
-        if (board.markToUpdate || board.shouldCreateBoard) {
-          return setSyncMeta(meta, board.id, { status: SYNC_STATUS.PENDING });
-        }
-        return meta;
-      }, newSyncMeta);
+      let newSyncMeta = removeSyncMeta(state.syncMeta, action.boardId);
+      for (const id of pendingBoardIds) {
+        newSyncMeta = setSyncMeta(newSyncMeta, id, {
+          status: SYNC_STATUS.PENDING
+        });
+      }
       return {
         ...state,
         isFetching: false,
         boards: finalBoards,
-        syncMeta: setSyncMeta(patchedSyncMeta, action.board.id, {
+        syncMeta: setSyncMeta(newSyncMeta, action.board.id, {
           status: SYNC_STATUS.SYNCED
         })
       };

--- a/src/components/Board/__tests__/Board.reducer.test.js
+++ b/src/components/Board/__tests__/Board.reducer.test.js
@@ -752,5 +752,70 @@ describe('reducer', () => {
       });
       expect(result.syncMeta[mockBoard.id]).toBeUndefined();
     });
+
+    it('should set syncMeta PENDING for server board with markToUpdate on CREATE_API_BOARD_SUCCESS', () => {
+      // A server board (id >= 14 chars, has email) whose tile references the local board being promoted
+      const serverParentBoard = {
+        id: 'server-board-id-1234',
+        name: 'Server Parent',
+        email: 'user@example.com',
+        tiles: [{ id: 'tile-xyz', loadBoard: 'localChild' }]
+      };
+      const localChildBoard = {
+        id: 'localChild',
+        name: 'Local Child',
+        tiles: []
+      };
+      const stateWithBoards = {
+        ...initialState,
+        boards: [...initialState.boards, serverParentBoard, localChildBoard]
+      };
+      const createApiBoardSuccess = {
+        type: CREATE_API_BOARD_SUCCESS,
+        board: { id: 'new-server-id-98765', lastEdited: '2024-01-01' },
+        boardId: 'localChild'
+      };
+      const result = boardReducer(stateWithBoards, createApiBoardSuccess);
+      // Server parent board got markToUpdate: true → must be PENDING so next sync picks it up
+      expect(result.syncMeta['server-board-id-1234']).toEqual({
+        status: SYNC_STATUS.PENDING
+      });
+      // Newly created board stays SYNCED
+      expect(result.syncMeta['new-server-id-98765']).toEqual({
+        status: SYNC_STATUS.SYNCED
+      });
+    });
+
+    it('should set syncMeta PENDING for local board with shouldCreateBoard on CREATE_API_BOARD_SUCCESS', () => {
+      // A local board (id < 14 chars) whose tile references the local board being promoted
+      const localParentBoard = {
+        id: 'localParent',
+        name: 'Local Parent',
+        tiles: [{ id: 'tile-abc', loadBoard: 'localChild' }]
+      };
+      const localChildBoard = {
+        id: 'localChild',
+        name: 'Local Child',
+        tiles: []
+      };
+      const stateWithBoards = {
+        ...initialState,
+        boards: [...initialState.boards, localParentBoard, localChildBoard]
+      };
+      const createApiBoardSuccess = {
+        type: CREATE_API_BOARD_SUCCESS,
+        board: { id: 'new-server-id-98765', lastEdited: '2024-01-01' },
+        boardId: 'localChild'
+      };
+      const result = boardReducer(stateWithBoards, createApiBoardSuccess);
+      // Local parent board got shouldCreateBoard: true → must be PENDING so next sync creates it
+      expect(result.syncMeta['localParent']).toEqual({
+        status: SYNC_STATUS.PENDING
+      });
+      // Newly created board stays SYNCED
+      expect(result.syncMeta['new-server-id-98765']).toEqual({
+        status: SYNC_STATUS.SYNCED
+      });
+    });
   });
 });


### PR DESCRIPTION
`CREATE_API_BOARD_SUCCESS` now stamps syncMeta as `PENDING` for every board that received `markToUpdate: true` or `shouldCreateBoard: true`, so the standard `syncBoards()` cycle can recover them even if `updateApiMarkedBoards` fails.


How to test:
  1. Open the app and go to any board
  2. Open Redux DevTools, go to the State tab
  3. Unlock the board and create a new folder tile (this creates a local child board with a short ID)
  4. Wait a few seconds for the sync to run
  5. In Redux DevTools, find the CREATE_API_BOARD_SUCCESS action
  6. In the state diff, check syncMeta — the parent board's entry should show { status: 'pending' }
  7. Find the UPDATE_API_BOARD_SUCCESS action that fires shortly after
  8. Check that the parent board is now { status: 'synced' } in syncMeta
  9. Check that the parent board's tile loadBoard field now contains a long MongoDB ObjectId (not the original short local ID)

**Expected**: the parent board goes pending → synced and its tile points to the server ID.

Closes #2198 