### PR TITLE
refactor(sync): batch untracked board graduation via MARK_BOARDS_SYNCED

### DIFF
--- a/docs/sync-engine.md
+++ b/docs/sync-engine.md
@@ -322,7 +322,8 @@ For each untracked board belonging to the user:
   │     │     │    (moment(local.lastEdited).isSameOrBefore(remote.lastEdited))
   │     │     │
   │     │     ├── YES → GRADUATE
-  │     │     │    dispatch(updateBoard(board, fromRemote=true))
+  │     │     │    collect board.id into boardsToGraduate
+  │     │     │    (batched: dispatch(markBoardsSynced(ids)) once at end)
   │     │     │    Effect: syncMeta[id] = { status: SYNCED }
   │     │     │    The board is now tracked. No API call needed.
   │     │     │
@@ -347,6 +348,8 @@ For each untracked board belonging to the user:
 #### Why Graduation Matters
 
 Graduation is a performance optimization and correctness guarantee. Without it, every untracked board that already exists on the server with identical or newer content would be unnecessarily pushed on every sync cycle. Graduation silently onboards these boards into the tracking system with zero API calls.
+
+Graduation only flips `syncMeta[id].status` to `SYNCED` — the board's data is unchanged (the local copy is the same age or older than the remote). For this reason it uses the dedicated `MARK_BOARDS_SYNCED` action, which batches all graduated board IDs into a single dispatch/reducer pass instead of dispatching one `UPDATE_BOARD` per board (which would also needlessly rewrite the `boards` array).
 
 #### Transformation During Onboarding
 
@@ -569,6 +572,7 @@ The `syncMeta` object tracks each board's sync status. Here's how every reducer 
 | `ADD_BOARDS`               | `[id]: { status: isLocalBoard ? PENDING : SYNCED }` | Pull adds remote boards, or boards added programmatically |
 | `CREATE_BOARD`             | `[id]: { status: PENDING }`                         | User creates a new board                                  |
 | `UPDATE_BOARD`             | `[id]: { status: fromRemote ? SYNCED : PENDING }`   | Local edit (PENDING) or remote pull (SYNCED)              |
+| `MARK_BOARDS_SYNCED`       | For each id: `[id]: { status: SYNCED }` (batched)   | Graduation of untracked boards (Pass 2, no data change)  |
 | `DELETE_BOARD`             | `[id]: { status: PENDING, isDeleted: true }`        | User deletes a board (soft delete)                        |
 | `CREATE_TILE`              | `[boardId]: { status: PENDING }`                    | Tile added to board                                       |
 | `DELETE_TILES`             | `[boardId]: { status: PENDING }`                    | Tiles removed from board                                  |

--- a/src/components/Board/Board.actions.js
+++ b/src/components/Board/Board.actions.js
@@ -44,6 +44,7 @@ import {
   SYNC_BOARDS_STARTED,
   SYNC_BOARDS_SUCCESS,
   SYNC_BOARDS_FAILURE,
+  MARK_BOARDS_SYNCED,
   SYNC_STATUS,
   SET_IS_SAVING
 } from './Board.constants';
@@ -255,6 +256,16 @@ export function updateBoard(boardData, fromRemote = false) {
     type: UPDATE_BOARD,
     boardData,
     fromRemote
+  };
+}
+/**
+ * Batch-mark untracked boards as SYNCED (graduation) without touching board data.
+ * Used to onboard untracked boards into the sync system in a single dispatch.
+ */
+export function markBoardsSynced(boardIds) {
+  return {
+    type: MARK_BOARDS_SYNCED,
+    boardIds
   };
 }
 export function deleteBoard(boardId) {
@@ -635,6 +646,7 @@ function classifyBoardsForPush({
 }) {
   const boardsToSync = [];
   const boardsToDelete = [];
+  const boardsToGraduate = [];
 
   // Helper to transform default/offline boards to belong to the current user
   const transformAndTrack = board => {
@@ -673,8 +685,8 @@ function classifyBoardsForPush({
 
     const remote = remoteBoardMap.get(b.id);
     if (remote && moment(b.lastEdited).isSameOrBefore(remote.lastEdited)) {
-      // Graduate to SYNCED without pushing
-      dispatch(updateBoard(b, true));
+      // Graduate to SYNCED without pushing (board data is unchanged)
+      boardsToGraduate.push(b.id);
       continue;
     }
 
@@ -690,6 +702,11 @@ function classifyBoardsForPush({
     if (syncMeta[b.id]?.isDeleted === true) {
       boardsToDelete.push(b);
     }
+  }
+
+  // Graduate untracked boards to SYNCED in a single batched dispatch.
+  if (boardsToGraduate.length > 0) {
+    dispatch(markBoardsSynced(boardsToGraduate));
   }
 
   return { boardsToSync, boardsToDelete };

--- a/src/components/Board/Board.constants.js
+++ b/src/components/Board/Board.constants.js
@@ -43,6 +43,7 @@ export const DOWNLOAD_IMAGE_FAILURE = 'cboard/Board/DOWNLOAD_IMAGE_FAILURE';
 export const SYNC_BOARDS_STARTED = 'cboard/Board/SYNC_BOARDS_STARTED';
 export const SYNC_BOARDS_SUCCESS = 'cboard/Board/SYNC_BOARDS_SUCCESS';
 export const SYNC_BOARDS_FAILURE = 'cboard/Board/SYNC_BOARDS_FAILURE';
+export const MARK_BOARDS_SYNCED = 'cboard/Board/MARK_BOARDS_SYNCED';
 export const SET_IS_SAVING = 'cboard/Board/SET_IS_SAVING';
 
 export const DEFAULT_ROWS_NUMBER = 5;

--- a/src/components/Board/Board.reducer.js
+++ b/src/components/Board/Board.reducer.js
@@ -41,6 +41,7 @@ import {
   SYNC_BOARDS_STARTED,
   SYNC_BOARDS_SUCCESS,
   SYNC_BOARDS_FAILURE,
+  MARK_BOARDS_SYNCED,
   SYNC_STATUS,
   SET_IS_SAVING
 } from './Board.constants';
@@ -159,6 +160,19 @@ function boardReducer(state = initialState, action) {
         ...state,
         boards: state.boards.concat(newBoards),
         syncMeta: { ...state.syncMeta, ...addedSyncMeta }
+      };
+    }
+    case MARK_BOARDS_SYNCED: {
+      const syncedSyncMeta = action.boardIds.reduce((acc, id) => {
+        acc[id] = {
+          ...(state.syncMeta[id] || {}),
+          status: SYNC_STATUS.SYNCED
+        };
+        return acc;
+      }, {});
+      return {
+        ...state,
+        syncMeta: { ...state.syncMeta, ...syncedSyncMeta }
       };
     }
     case CHANGE_BOARD:

--- a/src/components/Board/__tests__/Board.actions.test.js
+++ b/src/components/Board/__tests__/Board.actions.test.js
@@ -785,12 +785,12 @@ describe('pushLocalChangesToApi', () => {
     expect(actionTypes).not.toContain(types.UPDATE_API_BOARD_STARTED);
     expect(actionTypes).not.toContain(types.CREATE_API_BOARD_STARTED);
 
-    // Should graduate to SYNCED via updateBoard with fromRemote=true
-    expect(actionTypes).toContain(types.UPDATE_BOARD);
-    const updateAction = storeWithBoards
+    // Should graduate to SYNCED via a single batched MARK_BOARDS_SYNCED action
+    expect(actionTypes).toContain(types.MARK_BOARDS_SYNCED);
+    const markAction = storeWithBoards
       .getActions()
-      .find(a => a.type === types.UPDATE_BOARD);
-    expect(updateAction.fromRemote).toBe(true);
+      .find(a => a.type === types.MARK_BOARDS_SYNCED);
+    expect(markAction.boardIds).toContain('12345678901234567890');
   });
 
   it('should push untracked board that does not exist on server', async () => {


### PR DESCRIPTION
## What

Replaces the per-board `dispatch(updateBoard(b, true))` used to graduate untracked boards in Pass 2 of `classifyBoardsForPush` with a single batched `MARK_BOARDS_SYNCED` action.

Closes #2211

## Why

Graduation onboards an untracked board into the sync system when a same-ID remote board exists with an equal-or-newer `lastEdited`. The board's data never changes — the only meaningful effect is setting `syncMeta[id].status = SYNCED`.

Using `UPDATE_BOARD` for this was wasteful:
- rewrites the `boards` array (splice) once per board,
- recomputes `lastEdited` (to the same value),
- dispatches one action per board → N reducer passes.

## Changes

- **`Board.constants.js`** — new `MARK_BOARDS_SYNCED` action type.
- **`Board.actions.js`** — new `markBoardsSynced(boardIds)` action creator. Pass 2 now collects graduated IDs into `boardsToGraduate` and dispatches a single `markBoardsSynced(...)` before returning (dispatch kept inside `classifyBoardsForPush`).
- **`Board.reducer.js`** — new `MARK_BOARDS_SYNCED` case that batch-sets `status: SYNCED` for all IDs in one reducer pass (same pattern as `ADD_BOARDS`) and leaves the `boards` array untouched.
- **`docs/sync-engine.md`** — updated the graduation logic (§7) and the `syncMeta` lifecycle table (§10.2).
- **`Board.actions.test.js`** — updated the graduation test to assert the batched `MARK_BOARDS_SYNCED` action.

## Scope note

Graduation of untracked boards happens **only** in Pass 2. The other `updateBoard(_, true)` calls in the PULL phase (`applyRemoteChangesToState`) are genuine data updates from remote and keep using `UPDATE_BOARD`.

## Testing

`Board.actions.test.js` and `Board.reducer.test.js` — 137 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)