### PR TITLE
feat(sync): manifest-driven board PULL with bulk body fetch

### DIFF
--- a/docs/sync-engine.md
+++ b/docs/sync-engine.md
@@ -34,6 +34,7 @@ edge cases.
 | Term                  | Definition                                                                                                                                                                                                   |
 | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **syncMeta**          | A Redux state object (`state.board.syncMeta`) that maps each board ID to its sync metadata: `{ status, isDeleted? }`. It is the single source of truth for whether a board needs syncing.                    |
+| **Sync manifest**     | The lightweight `{ id, lastEdited }[]` list returned by `getBoardsSync()` (`GET /board/sync/:email`). It is the **authoritative, complete, unpaged** list of the boards that exist on the server. PULL classification runs against it; full board bodies are fetched separately only for the boards it identifies as new or changed. |
 | **PENDING**           | `syncMeta` status indicating the board has local changes not yet pushed to the server. Any local edit (board update, tile create/edit/delete) sets this status.                                              |
 | **SYNCED**            | `syncMeta` status indicating the board's local state matches the server. Set after successful API create/update or when pulling a remote board.                                                              |
 | **isDeleted**         | Boolean flag on a `syncMeta` entry. When `true`, the board is marked for deletion on the server during the next PUSH phase. The board data remains in Redux until the API deletion succeeds.                 |
@@ -59,9 +60,9 @@ Server (API)                          Local (Redux)
      │                                      │
      │  ┌──────────────────────────────┐    │
      │  │  Phase 1: PULL               │    │
-     │──┤  Remote → Local              │───▶│  Apply additions, updates,
-     │  │  classifyRemoteBoards()      │    │  and verified deletions
-     │  │  applyRemoteChangesToState() │    │
+     │──┤  Remote → Local              │───▶│  Apply manifest-driven
+     │  │  classifyRemoteBoards()      │    │  deletions, then fetch &
+     │  │  applyRemoteChangesToState() │    │  apply new/changed bodies
      │  └──────────────────────────────┘    │
      │                                      │
      │  ┌──────────────────────────────┐    │
@@ -84,10 +85,10 @@ Server (API)                          Local (Redux)
 ## 3. Entry Point
 
 **Function:** `getApiMyBoards()`
-**File:** `src/components/Board/Board.actions.js:530`
+**File:** `src/components/Board/Board.actions.js:532`
 
 ```
-Board component mounts (logged in + online)
+App sync trigger (logged in + online — see §11)
        │
        ▼
   getApiObjects()
@@ -96,20 +97,22 @@ Board component mounts (logged in + online)
   getApiMyBoards()
        │
        ├── dispatch(getApiMyBoardsStarted())
-       ├── API.getMyBoards({ limit: 500 })
+       ├── API.getBoardsSync()           ◄── lightweight { id, lastEdited } manifest
        ├── dispatch(getApiMyBoardsSuccess(res))
        │
        └── if res.data is Array:
               dispatch(syncBoards(res.data))   ◄── triggers the engine
 ```
 
-The remote boards array (`res.data`) is passed directly to `syncBoards()` as the authoritative server state snapshot.
+`getBoardsSync()` (`GET /board/sync/:email`) returns the **complete, unpaged sync manifest** — only `{ id, lastEdited }` per board, not full bodies. That manifest array (`res.data`) is passed directly to `syncBoards()` as the authoritative server state snapshot. Full board bodies (with tiles) are fetched later, only for the boards PULL classifies as new or changed.
+
+> **Note:** `getApiMyBoardsSuccess` only flips `isFetching` — it does **not** store the manifest into `state.board.boards`. The manifest is a classification input, never board data.
 
 ---
 
 ## 4. Orchestrator: `syncBoards()`
 
-**File:** `src/components/Board/Board.actions.js:782-822`
+**File:** `src/components/Board/Board.actions.js:817`
 
 `syncBoards(remoteBoards)` is the master orchestrator. It is a Redux thunk that:
 
@@ -144,64 +147,97 @@ await dispatch(pushLocalChangesToApi(remoteBoards));
 
 **File:** `src/components/Board/Board.utils.js:78-116`
 
-Compares the server snapshot against local state and returns three lists:
+Compares the **sync manifest** (`{ id, lastEdited }` entries) against local state and returns three lists. Each `boardsToAdd` / `boardsToUpdate` element is the lightweight manifest entry — its full body is fetched in PULL (see 5.2):
 
 | Output             | Condition                                                                                                                                | Description                                                                        |
 | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| `boardsToAdd`      | Remote board ID not found in local boards                                                                                                | New board from server — never seen locally.                                        |
+| `boardsToAdd`      | Manifest board ID not found in local boards                                                                                              | New board on the server — never seen locally.                                      |
 | `boardsToUpdate`   | `moment(remote.lastEdited).isAfter(local.lastEdited)`                                                                                    | Server has a newer version. Remote wins (last-write-wins).                         |
-| `boardIdsToDelete` | Local board has a server ID (`>= 14 chars`) AND is not in the remote set AND is not locally marked as deleted AND has a `syncMeta` entry | Board appears to have been deleted on the server. Requires verification (see 5.2). |
+| `boardIdsToDelete` | Local board has a server ID (`>= 14 chars`) AND is not in the manifest AND is not locally marked as deleted AND has a `syncMeta` entry   | Board is absent from the manifest, which is authoritative for existence → deleted on the server (see 5.2). |
+
+> **`lastEdited` is the freshness contract.** Updates are detected solely by comparing timestamps. The engine never re-pulls a board whose `lastEdited` hasn't advanced, so every server-side board mutation **must** bump `lastEdited`, or the change will stay invisible on already-synced devices.
 
 **Why `boardIdsToDelete` requires `localHasSyncStatus`:** Only boards that the sync system is already tracking are candidates for server-side deletion detection. Untracked boards (no `syncMeta` entry) are excluded to prevent false deletions of pre-existing boards that haven't been onboarded yet.
 
 ### 5.2 `applyRemoteChangesToState({ boardsToAdd, boardsToUpdate, boardIdsToDelete })`
 
-**File:** `src/components/Board/Board.actions.js:568-613`
+**File:** `src/components/Board/Board.actions.js:579`
 
-Applies the classified changes to Redux state:
+Applies the classified changes to Redux state in three steps. Because the
+manifest is authoritative for existence, deletions need no server round-trip,
+and the bodies for every new/changed board are fetched in **one** request.
 
-**Additions:**
-
-```
-dispatch(addBoards(boardsToAdd))
-```
-
-The `ADD_BOARDS` reducer assigns `SYNCED` status to server boards and `PENDING` to local boards.
-
-**Updates:**
-
-```
-dispatch(updateBoard(board, fromRemote=true))
-```
-
-The `fromRemote=true` flag causes the reducer to set syncMeta status to `SYNCED`.
-
-**Deletions — Verification Protocol:**
-
-Boards that appear deleted on the server are **not immediately removed**. Instead, each is individually verified:
+**Step 1 — Deletions (no fetch):**
 
 ```
 For each boardId in boardIdsToDelete:
-  │
-  ├── GET /board/{boardId}
-  │
-  ├── If 404 → Board confirmed deleted on server
-  │      └── dispatch(deleteApiBoardSuccess({ id: boardId }))
-  │          (hard delete from Redux: removes board + syncMeta)
-  │
-  ├── If board returned → Board still exists on server
-  │      ├── Check: was SYNCED before fetch but became PENDING during fetch?
-  │      │     └── YES: User edited while verifying → skip (don't overwrite)
-  │      │     └── NO:  Update local with server version
-  │      └── dispatch(updateBoard(res, fromRemote=true))
-  │
-  └── If other error → Log and skip
+  └── dispatch(deleteApiBoardSuccess({ id: boardId }))
+      (hard delete from Redux: removes board + syncMeta)
 ```
 
-This verification prevents data loss when:
+A board absent from the manifest has been deleted on the server, full stop.
+There is no per-id verification — the manifest already _is_ the complete server
+truth. (This replaces the old `GET /board/{id}` 404-verification protocol.)
 
-- The API's paginated response omits a board (pagination edge case).
-- A concurrent edit occurred between fetching the board list and processing deletions.
+**Step 2 — Fetch new/changed bodies in a single request:**
+
+```
+idsToFetch = [...boardsToAdd, ...boardsToUpdate].map(b => b.id)
+if idsToFetch is empty → return (deletions already applied)
+
+try:
+  res = API.getBoardsByIds(idsToFetch)   ◄── POST /board/byids { ids }
+  if res.data is not an Array → throw   (malformed shape = bug, surface it)
+  bodiesById = Map(res.data, keyed by id)
+catch:
+  console.error(...) and RETURN          ◄── see failure handling below
+```
+
+`getBoardsByIds` is a **POST** (not GET) so a large id list — e.g. a fresh
+device where every board is an "add" — can't blow past URL-length limits. One
+request resolves every body regardless of how many boards changed; there is no
+per-id `getBoard()` storm and no body-count threshold.
+
+**Step 3 — Apply adds and updates from the fetched bodies:**
+
+```
+resolveBody(id):
+  body = bodiesById.get(id) ?? null
+  if !body → null                        (id missing from response → skip)
+  if was SYNCED before fetch but became PENDING during fetch → null
+  else → body
+
+addedBoards = boardsToAdd.map(b => resolveBody(b.id)).filter(Boolean)
+if addedBoards.length → dispatch(addBoards(addedBoards))
+
+for each b in boardsToUpdate:
+  body = resolveBody(b.id)
+  if body → dispatch(updateBoard(body, fromRemote=true))
+```
+
+- `ADD_BOARDS` assigns `SYNCED` to server boards and `PENDING` to local boards.
+- `updateBoard(body, fromRemote=true)` sets syncMeta status to `SYNCED`.
+- **Concurrent-edit guard:** if the user marked a board `PENDING` while its body
+  was being fetched, `resolveBody` returns `null` and the local edit is not
+  overwritten. (Deletions in Step 1 are unaffected — they are authoritative.)
+- **Missing id ⇒ skip:** a requested id absent from the response (board deleted
+  in the race window between manifest and fetch) is skipped and self-heals on
+  the next sync.
+
+**Failure handling (the `catch` in Step 2):**
+
+If the bulk body fetch fails (network, timeout, 5xx), the engine logs and
+returns **without throwing**:
+
+- Deletions (Step 1) are **already applied** and stay applied — they derive from
+  the manifest, not from this fetch.
+- Adds and updates are **deferred to the next sync**, never partially applied.
+- The cycle is _not_ aborted, so the PUSH phase still runs and local edits can
+  still upload. (A read failure usually implies writes fail too, so this mainly
+  matters when reads fail but writes succeed — e.g. a read replica is down.)
+
+A malformed response shape (not transient) still throws, surfacing a genuine
+contract break rather than silently syncing garbage.
 
 ---
 
@@ -622,12 +658,30 @@ The `syncMeta` object tracks each board's sync status. Here's how every reducer 
 This section documents each trigger point where board synchronization occurs.
 Add new subsections as new lifecycle integrations are implemented.
 
-### 11.1 App Mount (Login)
+All triggers funnel through `App.container.js → handleDataRefresh(source)`,
+which is guarded by: logged-in, online, and a **2-minute throttle**
+(`THROTTLE_MS`, bypassed when there are pending local sync boards). When it
+passes, it dispatches `getApiObjects() → getApiMyBoards() → syncBoards(manifest)`.
 
-- **Trigger:** Board component mounts when user is logged in and online.
-- **Flow:** `Board.container.js` → `getApiObjects()` → `getApiMyBoards()` → `syncBoards(res.data)`
-- **Scope:** Full sync — all boards pulled and pushed.
-- **Notes:** This is currently the only lifecycle where sync runs.
+### 11.1 Sync triggers
+
+| Trigger             | Event                                  | `source` label        |
+| ------------------- | -------------------------------------- | --------------------- |
+| App start           | `componentDidMount`                    | `App started`         |
+| Tab focused         | `visibilitychange` (web)               | `Tab focused`         |
+| Connection restored | `online` event                        | `Connection restored` |
+| App resumed         | Cordova `onCvaResume`                  | `App resumed`         |
+| Manual sync         | `SyncButton` → `getApiObjects()`       | (component)           |
+
+- **Scope:** Every trigger runs the **same full manifest reconciliation** — the
+  complete board list is compared via `getBoardsSync()`, then only new/changed
+  bodies are fetched and only PENDING boards are pushed.
+- **Important:** there is **no** request that re-downloads all board _bodies_ on
+  a routine sync. A full-body download only happens implicitly on a fresh
+  device / first login, where every manifest entry classifies as an add and
+  `getBoardsByIds()` fetches them all in one request. Steady-state syncs transfer
+  only deltas. This is by design — the manifest is the "full pull"; bodies follow
+  for changes only.
 
 <!--
 ### 11.X [Template for new lifecycles]
@@ -687,27 +741,28 @@ USER ACTION (edit board / create tile / delete board)
   Redux Reducer marks syncMeta[boardId] = PENDING
        │
        ▼
-  [Later] App triggers getApiMyBoards()
+  [Later] App trigger → getApiMyBoards()
        │
        ▼
-  API.getMyBoards({ limit: 500 })
+  API.getBoardsSync()  ─── { id, lastEdited } manifest (all boards)
        │
        ▼
-  syncBoards(remoteBoards) ─── dispatches SYNC_BOARDS_STARTED
+  syncBoards(manifest) ─── dispatches SYNC_BOARDS_STARTED
        │
        ├──────────────── PHASE 1: PULL ────────────────┐
        │                                                │
-       │  classifyRemoteBoards(local, remote, syncMeta) │
+       │  classifyRemoteBoards(local, manifest, syncMeta)│
        │       │                                        │
-       │       ├── boardsToAdd (new from server)        │
+       │       ├── boardsToAdd (new on server)          │
        │       ├── boardsToUpdate (server is newer)     │
-       │       └── boardIdsToDelete (missing on server) │
+       │       └── boardIdsToDelete (absent from manifest)│
        │                                                │
        │  applyRemoteChangesToState()                   │
+       │       ├── delete absent boards (no fetch)      │
+       │       ├── API.getBoardsByIds(new+changed ids)  │
+       │       │     (single POST /board/byids)         │
        │       ├── addBoards → syncMeta = SYNCED        │
-       │       ├── updateBoard(fromRemote) → SYNCED     │
-       │       └── verify deletions → hard delete or    │
-       │           update                               │
+       │       └── updateBoard(fromRemote) → SYNCED     │
        │                                                │
        ├──────────────── PHASE 2: PUSH ────────────────┐
        │                                                │
@@ -738,14 +793,16 @@ USER ACTION (edit board / create tile / delete board)
 
 | Scenario                            | Handling                                                                                 | Location                   |
 | ----------------------------------- | ---------------------------------------------------------------------------------------- | -------------------------- |
-| `syncBoards()` throws               | Catches error, dispatches `SYNC_BOARDS_FAILURE`, returns `{ success: false }`            | `Board.actions.js:816-819` |
-| Individual board push fails         | `console.error`, continues to next board. Failed board remains `PENDING` for next sync.  | `Board.actions.js:751-753` |
-| Board delete fails with non-404     | `console.error`, continues. Board remains marked `isDeleted` for next sync.              | `Board.actions.js:772-773` |
-| Board delete fails with 404         | Treated as success — board already gone from server. Dispatches `deleteApiBoardSuccess`. | `Board.actions.js:768-771` |
-| Deletion verification returns 404   | Confirmed deleted — hard delete locally.                                                 | `Board.actions.js:600-601` |
-| Deletion verification returns board | Board still exists — update locally instead of deleting.                                 | `Board.actions.js:597`     |
+| `syncBoards()` throws               | Catches error, dispatches `SYNC_BOARDS_FAILURE`, returns `{ success: false }`            | `Board.actions.js:848`     |
+| Bulk body fetch fails (PULL)        | `console.error`, **returns without throwing**. Deletions stay applied; adds/updates deferred to next sync; PUSH still runs. | `Board.actions.js:605`     |
+| Bulk body fetch returns bad shape   | Throws `'Bulk board fetch returned an unexpected shape'` — surfaces a contract break.    | `Board.actions.js:597`     |
+| Board absent from manifest          | Hard delete locally — no verification fetch (manifest is authoritative).                 | `Board.actions.js:588`     |
+| Requested id missing from body fetch | Skipped (board deleted in race window); self-heals on next sync.                        | `Board.actions.js:579`     |
+| Individual board push fails         | `console.error`, continues to next board. Failed board remains `PENDING` for next sync.  | `Board.actions.js:783`     |
+| Board delete fails with non-404     | `console.error`, continues. Board remains marked `isDeleted` for next sync.              | `Board.actions.js:803`     |
+| Board delete fails with 404         | Treated as success — board already gone from server. Dispatches `deleteApiBoardSuccess`. | `Board.actions.js:799-800` |
 | 403 from any API call               | Axios interceptor triggers automatic logout.                                             | Global API config          |
-| No `userEmail` in state             | `pushLocalChangesToApi` returns immediately — no push occurs.                            | `Board.actions.js:706`     |
+| No `userEmail` in state             | `pushLocalChangesToApi` returns immediately — no push occurs.                            | `Board.actions.js:733`     |
 
 ### Known Edge Cases
 
@@ -753,7 +810,8 @@ USER ACTION (edit board / create tile / delete board)
 | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
 | **ID-length heuristic**                          | A locally-generated ID that happens to be >= 14 chars would be misclassified as a server board.                                | `shortid` output is typically 7-12 chars, making collision extremely unlikely.                                             |
 | **`moment.js` timestamp precision**              | Two edits within the same second could have identical `lastEdited` values, causing `isAfter` to return false.                  | `isSameOrBefore` in graduation uses inclusive comparison. Last-write-wins is acceptable for the conflict resolution model. |
-| **Concurrent edit during deletion verification** | User edits a board while `applyRemoteChangesToState` is verifying its deletion.                                                | Pre/post fetch `syncMeta` comparison detects the SYNCED→PENDING transition and skips the overwrite.                        |
+| **Concurrent edit during body fetch**            | User edits a board (SYNCED→PENDING) while `applyRemoteChangesToState` is fetching its body for an add/update.                  | `resolveBody` compares pre/post-fetch `syncMeta`; on a SYNCED→PENDING transition it returns `null` and skips the overwrite, preserving the local edit.       |
+| **Stale `lastEdited` on the server**             | A board body changes server-side without bumping `lastEdited`.                                                                 | Not detected — the manifest comparison sees no change and never re-pulls. The freshness model depends on every write bumping `lastEdited` (see §5.1).       |
 | **`updateApiObjectsNoChild` recursive cascade**  | `updateApiMarkedBoards` → `updateApiObjectsNoChild` → `updateApiMarkedBoards` can recurse for deeply nested board hierarchies. | Recursion terminates naturally when no more boards are marked. Assumes finite board hierarchy depth.                       |
 | **Stale board references in push loop**          | A prior iteration's API call may change board IDs in state via `CREATE_API_BOARD_SUCCESS`.                                     | The push loop re-reads each board from `getState()` before every API call.                                                 |
 | **Communicator always persisted**                | `upsertApiCommunicator` is called even when the communicator didn't change.                                                    | No functional impact, but causes unnecessary API calls.                                                                    |
@@ -764,9 +822,10 @@ USER ACTION (edit board / create tile / delete board)
 
 | Component                 | Path                                      | Key Lines                                                                                                                                                                                                    |
 | ------------------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Actions (sync engine)** | `src/components/Board/Board.actions.js`   | `syncBoards` (782), `applyRemoteChangesToState` (568), `classifyBoardsForPush` (623), `pushLocalChangesToApi` (703), `updateApiObjectsNoChild` (992), `updateApiMarkedBoards` (1040), `getApiMyBoards` (530) |
+| **Actions (sync engine)** | `src/components/Board/Board.actions.js`   | `syncBoards` (817), `applyRemoteChangesToState` (579), `classifyBoardsForPush` (654), `pushLocalChangesToApi` (734), `updateApiObjectsNoChild` (1027), `updateApiMarkedBoards` (1075), `getApiMyBoards` (532) |
 | **Utilities**             | `src/components/Board/Board.utils.js`     | `classifyRemoteBoards` (78), `isLocalBoard` (26), `isServerBoard` (27), `transformBoardForUser` (60), `isUnloggedCreatedBoard` (32), `hasDefaultOrNoEmail` (29), `isDefaultBoard` (23)                       |
 | **Reducer**               | `src/components/Board/Board.reducer.js`   | `syncMeta` handling throughout, `CREATE_API_BOARD_SUCCESS` cascade (363), `SYNC_BOARDS_*` (521-537)                                                                                                          |
 | **Constants**             | `src/components/Board/Board.constants.js` | `SYNC_STATUS` (50), `SHORT_ID_MAX_LENGTH` (48), `DEFAULT_BOARD_EMAIL` (55)                                                                                                                                   |
-| **API**                   | `src/api/api.js`                          | `getMyBoards`, `getBoard`, `createBoard`, `updateBoard`, `deleteBoard`                                                                                                                                       |
+| **API**                   | `src/api/api.js`                          | `getBoardsSync` (280, `GET /board/sync/:email` manifest), `getBoardsByIds` (262, `POST /board/byids`), `getMyBoards`, `getBoard`, `createBoard`, `updateBoard`, `deleteBoard`                                 |
+| **Sync triggers**         | `src/components/App/App.container.js`     | `handleDataRefresh` (142), trigger handlers (171-185), `THROTTLE_MS` (138)                                                                                                                                   |
 | **Container**             | `src/components/Board/Board.container.js` | `getApiObjects` dispatch on mount                                                                                                                                                                            |

--- a/src/api/__mocks__/api.js
+++ b/src/api/__mocks__/api.js
@@ -73,6 +73,20 @@ class API {
     });
   }
 
+  getBoardsByIds(ids = []) {
+    return Promise.resolve({
+      total: ids.length,
+      data: ids.map(id => ({ ...mockBoard, id }))
+    });
+  }
+
+  getBoardsSync() {
+    return Promise.resolve({
+      total: 1,
+      data: [{ id: mockBoard.id, lastEdited: mockBoard.lastEdited }]
+    });
+  }
+
   createBoard(board) {
     return new Promise((resolve, reject) => {
       if (board.hasOwnProperty('error')) {

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -256,6 +256,44 @@ class API {
     return data;
   }
 
+  // Fetch the full bodies of a specific set of boards in a single request.
+  // POST (not GET) because the id list can be large enough to blow past URL
+  // length limits on a fresh-device sync.
+  async getBoardsByIds(ids = []) {
+    const authToken = getAuthToken();
+    if (!(authToken && authToken.length)) {
+      throw new Error('Need to be authenticated to perform this request');
+    }
+
+    const headers = {
+      Authorization: `Bearer ${authToken}`
+    };
+
+    const { data } = await this.axiosInstance.post(
+      `/board/byids`,
+      { ids },
+      { headers }
+    );
+    return data;
+  }
+
+  async getBoardsSync() {
+    const authToken = getAuthToken();
+    if (!(authToken && authToken.length)) {
+      throw new Error('Need to be authenticated to perform this request');
+    }
+
+    const { email } = getUserData();
+    const headers = {
+      Authorization: `Bearer ${authToken}`
+    };
+
+    const { data } = await this.axiosInstance.get(`/board/sync/${email}`, {
+      headers
+    });
+    return data;
+  }
+
   async getCommunicators({
     page = 1,
     limit = 10,

--- a/src/components/Board/Board.actions.js
+++ b/src/components/Board/Board.actions.js
@@ -73,8 +73,6 @@ import { DEFAULT_BOARDS } from '../../helpers';
 import history from './../../history';
 import { improvePhraseAbortController } from '../../api/api';
 
-const BOARDS_PAGE_LIMIT = 500;
-
 export function addBoards(boards) {
   return {
     type: ADD_BOARDS,
@@ -535,7 +533,7 @@ export function getApiMyBoards() {
   return async dispatch => {
     dispatch(getApiMyBoardsStarted());
     try {
-      const res = await API.getMyBoards({ limit: BOARDS_PAGE_LIMIT });
+      const res = await API.getBoardsSync();
       dispatch(getApiMyBoardsSuccess(res));
       if (res?.data && Array.isArray(res.data)) {
         try {
@@ -567,7 +565,16 @@ export function syncBoardsFailure(error) {
 
 /**
  * PULL: Apply remote changes to local Redux state.
- * Adds new remote boards and updates boards where remote is newer.
+ *
+ * Classification runs against the lightweight sync manifest ({ id, lastEdited }
+ * only), which is the authoritative list of the boards that exist on the
+ * server (getBoardsSync returns the complete, unpaged set).
+ *
+ * - Deletions: a board absent from the manifest has been deleted on the server,
+ *   so it is removed locally directly — no verification fetch.
+ * - Adds / updates: the full bodies (with tiles) for every new/changed board
+ *   are fetched in a single getBoardsByIds() request, then applied from the
+ *   resulting in-memory map. One request regardless of how many boards changed.
  */
 export function applyRemoteChangesToState({
   boardsToAdd,
@@ -575,44 +582,60 @@ export function applyRemoteChangesToState({
   boardIdsToDelete = []
 }) {
   return async (dispatch, getState) => {
-    if (boardsToAdd.length > 0) {
-      dispatch(addBoards(boardsToAdd));
-    }
-    for (const board of boardsToUpdate) {
-      const fromRemote = true; //sets syncStatus to SYNCED
-      dispatch(updateBoard(board, fromRemote));
-    }
-
     const preFetchSyncMeta = getState().board.syncMeta;
 
-    // Verify boards that appear deleted on server (concurrent)
-    await Promise.all(
-      boardIdsToDelete.map(async boardId => {
-        try {
-          const res = await API.getBoard(boardId);
-          if (res) {
-            const postFetchMeta = getState().board.syncMeta;
-            const wasPending =
-              preFetchSyncMeta[boardId]?.status === SYNC_STATUS.PENDING;
-            const isNowPending =
-              postFetchMeta[boardId]?.status === SYNC_STATUS.PENDING;
-            // User edited the board while we were verifying — skip overwrite
-            if (!wasPending && isNowPending) return;
-            dispatch(updateBoard(res, true));
-          }
-        } catch (e) {
-          if (e.response?.status === 404) {
-            dispatch(deleteApiBoardSuccess({ id: boardId }));
-          } else {
-            console.error(
-              'Failed to verify board deletion on server:',
-              boardId,
-              e
-            );
-          }
-        }
-      })
-    );
+    boardIdsToDelete.forEach(boardId => {
+      dispatch(deleteApiBoardSuccess({ id: boardId }));
+    });
+
+    const idsToFetch = [...boardsToAdd, ...boardsToUpdate].map(b => b.id);
+    if (idsToFetch.length === 0) return;
+
+    let bodiesById;
+    try {
+      const res = await API.getBoardsByIds(idsToFetch);
+      if (!Array.isArray(res?.data)) {
+        throw new Error('Bulk board fetch returned an unexpected shape');
+      }
+      bodiesById = new Map(res.data.map(b => [b.id, b]));
+    } catch (e) {
+      // Transient/server failure: defer adds & updates to the next sync. The
+      // deletions above are already applied (manifest-authoritative) and the
+      // PUSH phase can still upload local edits, so we don't abort the cycle.
+      console.error('Bulk board body fetch failed; deferring adds/updates:', e);
+      return;
+    }
+
+    // Resolve a fetched body, honoring a concurrent local edit: if the user
+    // marked the board PENDING while we were fetching, skip overwriting their
+    // changes. A requested id missing from the response (deleted in the race
+    // window between the manifest and this fetch) resolves to null and is
+    // skipped — it self-heals on the next sync.
+    const postFetchSyncMeta = getState().board.syncMeta;
+    const resolveBody = boardId => {
+      const body = bodiesById.get(boardId) ?? null;
+      if (!body) return null;
+      const wasPending =
+        preFetchSyncMeta[boardId]?.status === SYNC_STATUS.PENDING;
+      const isNowPending =
+        postFetchSyncMeta[boardId]?.status === SYNC_STATUS.PENDING;
+      if (!wasPending && isNowPending) return null;
+      return body;
+    };
+
+    // New boards on the server: add the ones we got bodies for.
+    const addedBoards = boardsToAdd.map(b => resolveBody(b.id)).filter(Boolean);
+    if (addedBoards.length > 0) {
+      dispatch(addBoards(addedBoards));
+    }
+
+    // Changed boards on the server: update the ones we got bodies for.
+    boardsToUpdate.forEach(b => {
+      const body = resolveBody(b.id);
+      if (body) {
+        dispatch(updateBoard(body, true)); //sets syncStatus to SYNCED
+      }
+    });
   };
 }
 

--- a/src/components/Board/__tests__/Board.actions.test.js
+++ b/src/components/Board/__tests__/Board.actions.test.js
@@ -1040,12 +1040,20 @@ describe('pushLocalChangesToApi', () => {
 });
 
 describe('applyRemoteChangesToState', () => {
-  it('should dispatch addBoards for new remote boards', async () => {
+  it('should fetch full bodies in one request and dispatch addBoards for new remote boards', async () => {
+    const API = require('../../../api/api').default;
+    const fullBoards = {
+      'new-board-1': { id: 'new-board-1', name: 'New Board', tiles: [] },
+      'new-board-2': { id: 'new-board-2', name: 'Another New Board', tiles: [] }
+    };
+    // A single bulk request returns every requested body.
+    API.getBoardsByIds = jest.fn(ids =>
+      Promise.resolve({ data: ids.map(id => fullBoards[id]) })
+    );
+
     const store = mockStore(initialState);
-    const boardsToAdd = [
-      { id: 'new-board-1', name: 'New Board' },
-      { id: 'new-board-2', name: 'Another New Board' }
-    ];
+    // Manifest entries only carry { id, lastEdited }.
+    const boardsToAdd = [{ id: 'new-board-1' }, { id: 'new-board-2' }];
 
     await store.dispatch(
       actions.applyRemoteChangesToState({
@@ -1054,20 +1062,32 @@ describe('applyRemoteChangesToState', () => {
         boardIdsToDelete: []
       })
     );
-    const dispatchedActions = store.getActions();
+    const addAction = store.getActions().find(a => a.type === types.ADD_BOARDS);
 
-    expect(dispatchedActions).toContainEqual({
-      type: types.ADD_BOARDS,
-      boards: boardsToAdd
-    });
+    expect(API.getBoardsByIds).toHaveBeenCalledTimes(1);
+    expect(API.getBoardsByIds).toHaveBeenCalledWith([
+      'new-board-1',
+      'new-board-2'
+    ]);
+    expect(addAction).toBeDefined();
+    expect(addAction.boards).toEqual([
+      fullBoards['new-board-1'],
+      fullBoards['new-board-2']
+    ]);
   });
 
-  it('should dispatch updateBoard for each board to update', async () => {
+  it('should fetch full bodies in one request and dispatch updateBoard for each changed board', async () => {
+    const API = require('../../../api/api').default;
+    const fullBoards = {
+      '1': { id: '1', name: 'Updated Board 1', tiles: [] },
+      '2': { id: '2', name: 'Updated Board 2', tiles: [] }
+    };
+    API.getBoardsByIds = jest.fn(ids =>
+      Promise.resolve({ data: ids.map(id => fullBoards[id]) })
+    );
+
     const store = mockStore(initialState);
-    const boardsToUpdate = [
-      { id: '1', name: 'Updated Board 1' },
-      { id: '2', name: 'Updated Board 2' }
-    ];
+    const boardsToUpdate = [{ id: '1' }, { id: '2' }];
 
     await store.dispatch(
       actions.applyRemoteChangesToState({
@@ -1076,11 +1096,11 @@ describe('applyRemoteChangesToState', () => {
         boardIdsToDelete: []
       })
     );
-    const dispatchedActions = store.getActions();
-    const updateActions = dispatchedActions.filter(
-      a => a.type === types.UPDATE_BOARD
-    );
+    const updateActions = store
+      .getActions()
+      .filter(a => a.type === types.UPDATE_BOARD);
 
+    expect(API.getBoardsByIds).toHaveBeenCalledTimes(1);
     expect(updateActions).toHaveLength(2);
   });
 
@@ -1099,12 +1119,12 @@ describe('applyRemoteChangesToState', () => {
     expect(actionTypes).not.toContain(types.ADD_BOARDS);
   });
 
-  it('should dispatch deleteApiBoardSuccess for boards confirmed deleted (404)', async () => {
+  it('should dispatch deleteApiBoardSuccess for boards missing from the manifest, without fetching them', async () => {
     const API = require('../../../api/api').default;
     const boardId = '12345678901234567890';
-    API.getBoard = jest.fn().mockRejectedValue({
-      response: { status: 404 }
-    });
+    // The manifest is authoritative for existence, so a board classified for
+    // deletion is removed without any per-id verification fetch.
+    API.getBoard = jest.fn();
 
     const store = mockStore(initialState);
 
@@ -1117,17 +1137,21 @@ describe('applyRemoteChangesToState', () => {
     );
     const dispatchedActions = store.getActions();
 
+    expect(API.getBoard).not.toHaveBeenCalled();
     expect(dispatchedActions).toContainEqual({
       type: types.DELETE_API_BOARD_SUCCESS,
       board: { id: boardId }
     });
   });
 
-  it('should dispatch updateBoard when board still exists on server', async () => {
+  it('should delete a board missing from the manifest, not update it, even if the server still has it', async () => {
     const API = require('../../../api/api').default;
     const boardId = '12345678901234567890';
-    const serverBoard = { id: boardId, name: 'Server Board' };
-    API.getBoard = jest.fn().mockResolvedValue(serverBoard);
+    // Even though a fetch would show the board still exists, we trust the
+    // manifest: absence means deleted, so we never consult the server.
+    API.getBoard = jest
+      .fn()
+      .mockResolvedValue({ id: boardId, name: 'Server Board' });
 
     const store = mockStore(initialState);
 
@@ -1138,11 +1162,42 @@ describe('applyRemoteChangesToState', () => {
         boardIdsToDelete: [boardId]
       })
     );
-    const updateActions = store
-      .getActions()
-      .filter(a => a.type === types.UPDATE_BOARD);
+    const dispatchedActions = store.getActions();
 
-    expect(updateActions).toHaveLength(1);
+    expect(API.getBoard).not.toHaveBeenCalled();
+    expect(
+      dispatchedActions.filter(a => a.type === types.UPDATE_BOARD)
+    ).toHaveLength(0);
+    expect(dispatchedActions).toContainEqual({
+      type: types.DELETE_API_BOARD_SUCCESS,
+      board: { id: boardId }
+    });
+  });
+
+  it('should still apply deletions and not throw when the bulk body fetch fails', async () => {
+    const API = require('../../../api/api').default;
+    API.getBoardsByIds = jest.fn().mockRejectedValue(new Error('network down'));
+
+    const store = mockStore(initialState);
+
+    await expect(
+      store.dispatch(
+        actions.applyRemoteChangesToState({
+          boardsToAdd: [{ id: 'new-board-1' }],
+          boardsToUpdate: [],
+          boardIdsToDelete: ['12345678901234567890']
+        })
+      )
+    ).resolves.toBeUndefined();
+
+    const dispatchedActions = store.getActions();
+    // Deletions are manifest-authoritative: applied regardless of the fetch.
+    expect(dispatchedActions).toContainEqual({
+      type: types.DELETE_API_BOARD_SUCCESS,
+      board: { id: '12345678901234567890' }
+    });
+    // Adds/updates are deferred to the next sync, not partially applied.
+    expect(dispatchedActions.map(a => a.type)).not.toContain(types.ADD_BOARDS);
   });
 });
 
@@ -1160,10 +1215,17 @@ describe('syncBoards', () => {
   });
 
   it('should apply remote changes and push local changes', async () => {
+    const API = require('../../../api/api').default;
     const remoteBoard = { id: 'new-remote-board', name: 'From Server' };
+    // PULL fetches the full bodies for new/changed manifest entries in bulk.
+    API.getBoardsByIds = jest.fn().mockResolvedValue({ data: [remoteBoard] });
     const store = mockStore(initialState);
 
-    await store.dispatch(actions.syncBoards([remoteBoard]));
+    await store.dispatch(
+      actions.syncBoards([
+        { id: remoteBoard.id, lastEdited: '2024-01-01T00:00:00Z' }
+      ])
+    );
     const actionTypes = store.getActions().map(a => a.type);
 
     // PULL: should add the new remote board
@@ -1196,8 +1258,16 @@ describe('syncBoards', () => {
         }
       }
     });
+    const updatedRemote = {
+      ...localBoard,
+      name: 'Updated',
+      lastEdited: '2024-01-02T00:00:00Z'
+    };
+    const API = require('../../../api/api').default;
+    API.getBoardsByIds = jest.fn().mockResolvedValue({ data: [updatedRemote] });
+    // Manifest entry: id + newer lastEdited triggers the update.
     const remoteBoards = [
-      { ...localBoard, name: 'Updated', lastEdited: '2024-01-02T00:00:00Z' }
+      { id: localBoard.id, lastEdited: '2024-01-02T00:00:00Z' }
     ];
 
     await store.dispatch(actions.syncBoards(remoteBoards));
@@ -1208,11 +1278,10 @@ describe('syncBoards', () => {
     expect(updateActions).toHaveLength(1);
   });
 
-  it('should handle boards deleted on server with 404 (PULL)', async () => {
+  it('should delete local boards missing from the manifest (PULL)', async () => {
     const API = require('../../../api/api').default;
-    API.getBoard = jest.fn().mockRejectedValue({
-      response: { status: 404 }
-    });
+    // Absent from the manifest ([]) => deleted on server; no fetch to verify.
+    API.getBoard = jest.fn();
 
     const localBoard = { ...mockBoard, id: '12345678901234567890' };
     const store = mockStore({
@@ -1235,10 +1304,16 @@ describe('syncBoards', () => {
     });
   });
 
-  it('should update board when server still has it despite not being in remote list (PULL)', async () => {
+  it('should delete a board absent from the manifest even if the server still has it (PULL)', async () => {
     const API = require('../../../api/api').default;
-    const serverBoard = { id: '12345678901234567890', name: 'Still on server' };
-    API.getBoard = jest.fn().mockResolvedValue(serverBoard);
+    // The manifest ([]) is authoritative: even though getBoard would resolve
+    // the board, its absence from the manifest means it was deleted remotely.
+    API.getBoard = jest
+      .fn()
+      .mockResolvedValue({
+        id: '12345678901234567890',
+        name: 'Still on server'
+      });
 
     const localBoard = { ...mockBoard, id: '12345678901234567890' };
     const store = mockStore({
@@ -1253,11 +1328,16 @@ describe('syncBoards', () => {
     });
 
     await store.dispatch(actions.syncBoards([]));
-    const updateActions = store
-      .getActions()
-      .filter(a => a.type === types.UPDATE_BOARD);
+    const dispatchedActions = store.getActions();
 
-    expect(updateActions).toHaveLength(1);
+    expect(API.getBoard).not.toHaveBeenCalled();
+    expect(
+      dispatchedActions.filter(a => a.type === types.UPDATE_BOARD)
+    ).toHaveLength(0);
+    expect(dispatchedActions).toContainEqual({
+      type: types.DELETE_API_BOARD_SUCCESS,
+      board: { id: '12345678901234567890' }
+    });
   });
 
   it('should push locally modified boards with syncMeta PENDING (PUSH)', async () => {
@@ -1328,6 +1408,11 @@ describe('syncBoards', () => {
   it('should execute PULL before PUSH in correct order', async () => {
     const pendingBoard = { ...mockBoard, id: '12345678901234567890' };
     const newRemoteBoard = { id: 'new-remote-board', name: 'From Server' };
+    const API = require('../../../api/api').default;
+    // PULL fetches the full bodies for new/changed manifest entries in bulk.
+    API.getBoardsByIds = jest
+      .fn()
+      .mockResolvedValue({ data: [newRemoteBoard] });
     const store = mockStore({
       ...initialState,
       board: {
@@ -1353,10 +1438,12 @@ describe('syncBoards', () => {
 });
 
 describe('getApiMyBoards', () => {
-  it('should trigger syncBoards when API returns data array', async () => {
+  it('should trigger syncBoards when the sync manifest returns a data array', async () => {
     const API = require('../../../api/api').default;
-    const remoteBoards = [{ id: 'remote-board-1', name: 'Remote Board' }];
-    API.getMyBoards = jest.fn().mockResolvedValue({ data: remoteBoards });
+    API.getBoardsSync = jest.fn().mockResolvedValue({
+      total: 1,
+      data: [{ id: 'remote-board-1', lastEdited: '2020-01-01T00:00:00.000Z' }]
+    });
 
     const store = mockStore(initialState);
     await store.dispatch(actions.getApiMyBoards());
@@ -1365,9 +1452,9 @@ describe('getApiMyBoards', () => {
     expect(actionTypes).toContain(types.SYNC_BOARDS_STARTED);
   });
 
-  it('should not trigger syncBoards when API returns data: null', async () => {
+  it('should not trigger syncBoards when the sync manifest returns data: null', async () => {
     const API = require('../../../api/api').default;
-    API.getMyBoards = jest.fn().mockResolvedValue({ data: null });
+    API.getBoardsSync = jest.fn().mockResolvedValue({ data: null });
 
     const store = mockStore(initialState);
     await store.dispatch(actions.getApiMyBoards());


### PR DESCRIPTION
## What

Replaces the board sync PULL phase's full-list fetch with a lightweight **sync manifest** + a single bulk body fetch.

This is the **frontend** half of #2213. The matching backend endpoints (`GET /board/sync/:email`, `POST /board/byids`) ship in a separate cboard-api PR referencing the same issue.

## Why

PULL previously called `API.getMyBoards({ limit: 500 })` on every sync, re-downloading **all** board bodies even when nothing changed, and verified each server-side deletion with its own `getBoard()` request.

The hard-coded `limit: 500` also **silently broke accounts with more than 500 boards** — boards past the 500th were never returned, so they never synced.

## How

- `getApiMyBoards()` now pulls the `{ id, lastEdited }` manifest via `getBoardsSync()` (complete, unpaged — no 500 cap).
- `applyRemoteChangesToState()` is now single-path:
  - **Deletions** — a board absent from the manifest is deleted locally directly; the manifest is authoritative for existence, so the per-id `getBoard()` 404-verification is removed.
  - **Adds/updates** — full bodies for all new/changed boards are fetched in **one** `getBoardsByIds()` request (POST `/board/byids`, so a large id list can't exceed URL limits MAX 3000) and applied from an in-memory map.
  - **Concurrent-edit guard** preserved — a board the user marks PENDING mid-fetch is not overwritten.
  - **Failure handling** — on a bulk-fetch failure the engine logs and returns without throwing: manifest-driven deletions stay applied, adds/updates defer to the next sync, and PUSH still runs.

Net effect: steady-state syncs transfer only deltas; a full-body download happens only implicitly on a fresh device / first login; accounts with >500 boards sync fully.

## Design dependency

Freshness is detected solely via `lastEdited`, so every server-side board mutation must bump it. Documented in `docs/sync-engine.md`.

## Commits

- `feat(api)` — `getBoardsSync` + `getBoardsByIds` (+ mocks)
- `refactor(sync)` — manifest-driven PULL with one bulk body fetch
- `test(sync)` — manifest-trust deletions + bulk-fetch failure path
- `docs(sync)` — update `sync-engine.md`

## Testing

`Board.actions.test.js` — 93/93 pass.

Close #2213
