### PR TITLE
feat(telemetry): set App Insights authenticated user context for per-user tracing

### DIFF
--- a/src/components/Account/Login/Login.actions.js
+++ b/src/components/Account/Login/Login.actions.js
@@ -18,6 +18,7 @@ import {
 import { getVoiceURI } from '../../../i18n';
 import { isCordova, isElectron } from '../../../cordova-util';
 import tts from '../../../providers/SpeechProvider/tts';
+import { appInsights } from '../../../appInsights';
 
 export function loginSuccess(payload) {
   return dispatch => {
@@ -36,6 +37,12 @@ export function loginSuccess(payload) {
     }
     if (!isCordova() && typeof window?.gtag === 'function')
       window.gtag('set', { user_id: payload.id });
+
+    try {
+      appInsights.setAuthenticatedUserContext(payload.id);
+    } catch (err) {
+      console.error(err);
+    }
   };
 }
 
@@ -58,6 +65,12 @@ export function logout() {
 
   if (!isCordova() && typeof window?.gtag === 'function') {
     window.gtag('set', { user_id: null });
+  }
+
+  try {
+    appInsights.clearAuthenticatedUserContext();
+  } catch (err) {
+    console.error(err);
   }
 
   return async dispatch => {

--- a/src/components/Account/Login/Login.actions.test.js
+++ b/src/components/Account/Login/Login.actions.test.js
@@ -8,6 +8,15 @@ const mockStore = configureMockStore(middlewares);
 
 jest.mock('../../../api/api');
 
+jest.mock('../../../appInsights', () => ({
+  appInsights: {
+    setAuthenticatedUserContext: jest.fn(),
+    clearAuthenticatedUserContext: jest.fn()
+  }
+}));
+
+const { appInsights } = require('../../../appInsights');
+
 const mockBoard = {
   name: 'tewt',
   id: '12345678901234567',
@@ -388,4 +397,24 @@ it('should set google analytics user id after login - ANDROID IOS', async () => 
 
   await store.dispatch(actions.login(user, 'local'));
   expect(window.FirebasePlugin.setUserId).toHaveBeenCalledWith(userData.id);
+});
+
+it('should set App Insights authenticated user context with the user id on login', async () => {
+  appInsights.setAuthenticatedUserContext.mockClear();
+  const store = mockStore(initialState);
+
+  store.dispatch(actions.loginSuccess(userData));
+
+  expect(appInsights.setAuthenticatedUserContext).toHaveBeenCalledWith(
+    userData.id
+  );
+});
+
+it('should clear App Insights authenticated user context on logout', async () => {
+  appInsights.clearAuthenticatedUserContext.mockClear();
+  const store = mockStore(initialState);
+
+  await store.dispatch(actions.logout());
+
+  expect(appInsights.clearAuthenticatedUserContext).toHaveBeenCalled();
 });

--- a/src/components/App/App.container.js
+++ b/src/components/App/App.container.js
@@ -24,6 +24,7 @@ import {
   onCvaResume,
   cleanUpCvaOnResume
 } from '../../cordova-util';
+import { appInsights } from '../../appInsights';
 
 export class AppContainer extends Component {
   static propTypes = {
@@ -97,6 +98,20 @@ export class AppContainer extends Component {
       }
     };
 
+    const initAppInsightsUserContext = () => {
+      const { isLogged, userId } = this.props;
+      // The App Insights authenticated user context is per-session, so it must
+      // be re-applied on each launch for returning users. Use the Mongo user
+      // _id (never the email, which is PII).
+      if (isLogged && userId) {
+        try {
+          appInsights.setAuthenticatedUserContext(userId);
+        } catch (err) {
+          console.error(err);
+        }
+      }
+    };
+
     registerServiceWorker(
       this.handleNewContentAvailable,
       this.handleContentCached
@@ -105,6 +120,8 @@ export class AppContainer extends Component {
     localizeUser();
 
     initGoogleAnalytics();
+
+    initAppInsightsUserContext();
 
     // Set initial connection status and register event listeners
     if (!navigator.onLine) {


### PR DESCRIPTION
Closes #2206

## What

Sets the Application Insights **authenticated user context** so that **all** telemetry (`requests`, `dependencies`, `exceptions`, `customEvents`, `traces`, `pageViews`) carries a `user_AuthenticatedId`, making per-user tracing trivial:

```kql
union requests, dependencies, exceptions, customEvents, traces
| where timestamp > ago(90d)
| where user_AuthenticatedId == "<USER_ID>"
| order by timestamp asc
```

Previously the only user identifier was on the Firebase side, so finding a user's telemetry in App Insights meant fragile string-matching of the id/email inside dependency URLs — and events/exceptions/traces/page views couldn't be tied to a user at all.

## Changes

- **`Login.actions.js`**
  - `loginSuccess`: `appInsights.setAuthenticatedUserContext(payload.id)` on login success (alongside the existing `FirebasePlugin.setUserId`).
  - `logout`: `appInsights.clearAuthenticatedUserContext()`. This also covers the People logout path, which dispatches the same `logout()` action.
- **`App.container.js`**: re-apply `setAuthenticatedUserContext(userId)` on app start for already-logged-in users, since the context is per-session and must be re-applied on each launch. Placed in its own block (not inside the Cordova-only analytics init) because the context applies to web telemetry too.
- All calls are wrapped in `try/catch` to mirror the existing defensive Firebase/gtag handling.
- Tests added for the login (set) and logout (clear) behavior.

## Important: identifier choice

Uses the Mongo user `_id` (the same value already passed to `FirebasePlugin.setUserId`), **never the email**. The email is PII and would be persisted in Azure; the opaque `_id` is the correct identifier.

## Compatibility

`@microsoft/applicationinsights-web@2.8.18` (the pinned version) exposes both `setAuthenticatedUserContext` and `clearAuthenticatedUserContext` on the main `ApplicationInsights` class — verified against the package typings.

## Acceptance criteria

- [x] `user_AuthenticatedId` is populated on telemetry for logged-in users (requests, dependencies, exceptions, custom events, traces, page views).
- [x] The identifier used is the Mongo `_id`, not the email.
- [x] Context is set on login and re-applied on app start for already-logged-in users.
- [x] Context is cleared on logout.

## Testing

`yarn test --watchAll=false --testPathPattern="Login.actions"` → 15 passed (incl. 2 new tests).

## Follow-up (out of scope)

The `UserData_EmailLost` instrumentation noted in the issue is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)