### PR TITLE
feat(board): show unauthenticated edit modal only once per session

### DIFF
--- a/src/components/App/App.actions.js
+++ b/src/components/App/App.actions.js
@@ -7,6 +7,7 @@ import {
   DISABLE_TOUR,
   ENABLE_ALL_TOURS,
   SET_UNLOGGED_USER_LOCATION,
+  SET_UNAUTH_EDIT_MODAL_DISMISSED,
   UPDATE_SYMBOLS_SETTINGS,
   UPDATE_CONNECTIVITY
 } from './App.constants';
@@ -73,6 +74,13 @@ export function setUnloggedUserLocation(location) {
   return {
     type: SET_UNLOGGED_USER_LOCATION,
     location
+  };
+}
+
+export function setUnauthEditModalDismissed(dismissed = true) {
+  return {
+    type: SET_UNAUTH_EDIT_MODAL_DISMISSED,
+    payload: dismissed
   };
 }
 

--- a/src/components/App/App.constants.js
+++ b/src/components/App/App.constants.js
@@ -10,6 +10,8 @@ export const UPDATE_NAVIGATION_SETTINGS =
 export const UPDATE_USER_DATA = 'cboard/App/UPDATE_USER_DATA';
 export const SET_UNLOGGED_USER_LOCATION =
   'cboard/App/SET_UNLOGGED_USER_LOCATION';
+export const SET_UNAUTH_EDIT_MODAL_DISMISSED =
+  'cboard/App/SET_UNAUTH_EDIT_MODAL_DISMISSED';
 // language constants
 export const DEFAULT_LANG = 'en-US';
 export const APP_LANGS = [

--- a/src/components/App/App.reducer.js
+++ b/src/components/App/App.reducer.js
@@ -8,6 +8,7 @@ import {
   DISABLE_TOUR,
   ENABLE_ALL_TOURS,
   SET_UNLOGGED_USER_LOCATION,
+  SET_UNAUTH_EDIT_MODAL_DISMISSED,
   USER_DATA_PROPERTIES
 } from './App.constants';
 import { LOGIN_SUCCESS, LOGOUT } from '../Account/Login/Login.constants';
@@ -61,7 +62,8 @@ const initialState = {
   symbolsSettings: {
     arasaacActive: false
   },
-  userData: {}
+  userData: {},
+  unauthEditModalDismissed: false
 };
 
 const getKeysFromApiUserDataResponse = payload => {
@@ -168,6 +170,7 @@ function appReducer(state = initialState, action) {
       return {
         ...state,
         userData: {},
+        unauthEditModalDismissed: false,
         navigationSettings: {
           ...state.navigationSettings,
           pinLockEnabled: false,
@@ -185,6 +188,11 @@ function appReducer(state = initialState, action) {
       return {
         ...state,
         unloggedUserLocation: action.location
+      };
+    case SET_UNAUTH_EDIT_MODAL_DISMISSED:
+      return {
+        ...state,
+        unauthEditModalDismissed: action.payload
       };
     default:
       return state;

--- a/src/components/App/App.selectors.js
+++ b/src/components/App/App.selectors.js
@@ -3,3 +3,5 @@ import isEmpty from 'lodash/isEmpty';
 export const getUser = state => state.app.userData;
 export const isLogged = state => !isEmpty(getUser(state));
 export const isFirstVisit = state => state.app.isFirstVisit;
+export const isUnauthEditModalDismissed = state =>
+  state.app.unauthEditModalDismissed;

--- a/src/components/App/__tests__/App.actions.test.js
+++ b/src/components/App/__tests__/App.actions.test.js
@@ -1,6 +1,11 @@
 import * as actions from '../App.actions';
 import * as types from '../App.constants';
-import { getUser, isFirstVisit, isLogged } from '../App.selectors';
+import {
+  getUser,
+  isFirstVisit,
+  isLogged,
+  isUnauthEditModalDismissed
+} from '../App.selectors';
 
 describe('actions', () => {
   it('Checks selectors', () => {
@@ -58,5 +63,30 @@ describe('actions', () => {
       type: types.FINISH_FIRST_VISIT
     };
     expect(actions.finishFirstVisit()).toEqual(expectedAction);
+  });
+
+  it('should create an action to dismiss the unauth edit modal', () => {
+    const expectedAction = {
+      type: types.SET_UNAUTH_EDIT_MODAL_DISMISSED,
+      payload: true
+    };
+    expect(actions.setUnauthEditModalDismissed(true)).toEqual(expectedAction);
+  });
+
+  it('should default the unauth edit modal dismiss payload to true', () => {
+    const expectedAction = {
+      type: types.SET_UNAUTH_EDIT_MODAL_DISMISSED,
+      payload: true
+    };
+    expect(actions.setUnauthEditModalDismissed()).toEqual(expectedAction);
+  });
+
+  it('isUnauthEditModalDismissed reads the app flag', () => {
+    expect(
+      isUnauthEditModalDismissed({ app: { unauthEditModalDismissed: true } })
+    ).toBe(true);
+    expect(
+      isUnauthEditModalDismissed({ app: { unauthEditModalDismissed: false } })
+    ).toBe(false);
   });
 });

--- a/src/components/App/__tests__/App.reducer.test.js
+++ b/src/components/App/__tests__/App.reducer.test.js
@@ -6,7 +6,8 @@ import {
   FINISH_FIRST_VISIT,
   UPDATE_CONNECTIVITY,
   UPDATE_DISPLAY_SETTINGS,
-  UPDATE_NAVIGATION_SETTINGS
+  UPDATE_NAVIGATION_SETTINGS,
+  SET_UNAUTH_EDIT_MODAL_DISMISSED
 } from '../App.constants';
 import appReducer from '../App.reducer';
 
@@ -56,7 +57,8 @@ describe('reducer', () => {
       symbolsSettings: {
         arasaacActive: false
       },
-      userData: {}
+      userData: {},
+      unauthEditModalDismissed: false
     };
     uData = { name: 'martin bedouret', email: 'anything@cboard.io' };
     mockApp = {
@@ -127,6 +129,28 @@ describe('reducer', () => {
         pinLockEnabled: false,
         pinCode: ''
       }
+    });
+  });
+  it('should handle setUnauthEditModalDismissed', () => {
+    const action = {
+      type: SET_UNAUTH_EDIT_MODAL_DISMISSED,
+      payload: true
+    };
+    expect(appReducer(initialState, action)).toEqual({
+      ...initialState,
+      unauthEditModalDismissed: true
+    });
+  });
+  it('should reset unauthEditModalDismissed on logout', () => {
+    const dismissedState = {
+      ...initialState,
+      userData: uData,
+      unauthEditModalDismissed: true
+    };
+    expect(appReducer(dismissedState, { type: LOGOUT })).toEqual({
+      ...dismissedState,
+      userData: {},
+      unauthEditModalDismissed: false
     });
   });
   it('should handle updateDisplaySettings', () => {

--- a/src/components/Board/Board.container.js
+++ b/src/components/Board/Board.container.js
@@ -53,8 +53,8 @@ import {
   addBoardCommunicator,
   verifyAndUpsertCommunicator
 } from '../Communicator/Communicator.actions';
-import { disableTour } from '../App/App.actions';
-import { isLogged } from '../App/App.selectors';
+import { disableTour, setUnauthEditModalDismissed } from '../App/App.actions';
+import { isLogged, isUnauthEditModalDismissed } from '../App/App.selectors';
 import { showPremiumRequired } from '../../providers/SubscriptionProvider/SubscriptionProvider.actions';
 import { isSubscriptionRequired } from '../../providers/SubscriptionProvider/SubscriptionProvider.selectors';
 import UnauthenticatedEditModal from '../LoggedInFeature/UnauthenticatedEditModal';
@@ -191,7 +191,16 @@ export class BoardContainer extends Component {
     isSymbolSearchTourEnabled: PropTypes.bool,
     disableTour: PropTypes.func,
     isLiveMode: PropTypes.bool,
-    changeDefaultBoard: PropTypes.func
+    changeDefaultBoard: PropTypes.func,
+    /**
+     * Whether the unauthenticated edit modal has already been dismissed
+     * for the current logged-out session
+     */
+    unauthEditModalDismissed: PropTypes.bool,
+    /**
+     * Persist that the unauthenticated edit modal was dismissed
+     */
+    setUnauthEditModalDismissed: PropTypes.func
   };
 
   state = {
@@ -807,7 +816,11 @@ export class BoardContainer extends Component {
       return;
     }
 
-    if (this.state.isLocked && !this.props.isLogged) {
+    if (
+      this.state.isLocked &&
+      !this.props.isLogged &&
+      !this.props.unauthEditModalDismissed
+    ) {
       this.setState({ showUnauthEditModal: true });
       return;
     }
@@ -1829,8 +1842,10 @@ export class BoardContainer extends Component {
             const {
               showPremiumRequired,
               isSubscriptionRequired,
-              setIsSaving
+              setIsSaving,
+              setUnauthEditModalDismissed
             } = this.props;
+            setUnauthEditModalDismissed(true);
             this.setState(
               {
                 showUnauthEditModal: false,
@@ -1907,7 +1922,8 @@ export const mapStateToProps = state => {
     isPremiumRequiredModalOpen: premiumRequiredModalState?.open,
     improvedPhrase: board.improvedPhrase,
     isSubscriptionRequired: isSubscriptionRequired(state),
-    isLogged: isLogged(state)
+    isLogged: isLogged(state),
+    unauthEditModalDismissed: isUnauthEditModalDismissed(state)
   };
 };
 
@@ -1942,7 +1958,8 @@ const mapDispatchToProps = {
   changeDefaultBoard,
   verifyAndUpsertCommunicator,
   showPremiumRequired,
-  setIsSaving
+  setIsSaving,
+  setUnauthEditModalDismissed
 };
 
 export default connect(

--- a/src/components/Board/__tests__/Board.container.test.js
+++ b/src/components/Board/__tests__/Board.container.test.js
@@ -1,4 +1,4 @@
-import { mapStateToProps } from '../Board.container';
+import { mapStateToProps, BoardContainer } from '../Board.container';
 import { SYNC_STATUS } from '../Board.constants';
 
 jest.mock('ogv', () => ({ OGVLoader: { base: '' } }));
@@ -67,6 +67,65 @@ describe('Board.container', () => {
 
       // Note: Basic getVisibleBoards() filtering logic is tested in Board.selectors.test.js
       // This test covers the container-specific behavior: board: getVisibleBoards(state).find(board => board.id === activeBoardId)
+    });
+
+    it('maps unauthEditModalDismissed from the app state', () => {
+      const boards = [{ id: 'board-1' }];
+      const base = createState(boards);
+      const state = {
+        ...base,
+        app: { ...base.app, unauthEditModalDismissed: true }
+      };
+
+      const props = mapStateToProps(state);
+
+      expect(props.unauthEditModalDismissed).toBe(true);
+    });
+  });
+
+  describe('handleLockClick (unauthenticated edit modal gating)', () => {
+    const buildInstance = props => {
+      const instance = new BoardContainer({
+        showPremiumRequired: jest.fn(),
+        isSubscriptionRequired: false,
+        setIsSaving: jest.fn(),
+        navigationSettings: {},
+        isLogged: false,
+        unauthEditModalDismissed: false,
+        ...props
+      });
+      instance.state = { ...instance.state, isLocked: true };
+      instance.setState = jest.fn();
+      return instance;
+    };
+
+    it('opens the modal when logged out and it has not been dismissed', () => {
+      const instance = buildInstance({
+        isLogged: false,
+        unauthEditModalDismissed: false
+      });
+
+      instance.handleLockClick();
+
+      expect(instance.setState).toHaveBeenCalledWith({
+        showUnauthEditModal: true
+      });
+    });
+
+    it('unlocks directly when logged out but already dismissed', () => {
+      const instance = buildInstance({
+        isLogged: false,
+        unauthEditModalDismissed: true
+      });
+
+      instance.handleLockClick();
+
+      // Should not open the modal...
+      expect(instance.setState).not.toHaveBeenCalledWith({
+        showUnauthEditModal: true
+      });
+      // ...but go straight to the unlock updater (a function argument).
+      expect(typeof instance.setState.mock.calls[0][0]).toBe('function');
     });
   });
 });

--- a/src/components/UI/LockToggle/childProof.js
+++ b/src/components/UI/LockToggle/childProof.js
@@ -77,15 +77,16 @@ function withChildProof(WrappedComponent) {
       if (this.count === clicksToUnlock) {
         onToggle();
         this.deactivateLock();
+        // Reset immediately so the unlock gesture is self-contained. If the
+        // parent intercepts onToggle (e.g. shows the unauthenticated edit
+        // modal or the PIN dialog) instead of actually unlocking, the next
+        // attempt must repeat the full gesture rather than fire on a single
+        // click.
+        this.resetCount();
 
         setTimeout(() => {
           this.activateLock();
         }, 1000);
-      }
-
-      if (this.count === clicksToUnlock + 1) {
-        this.resetCount();
-        onToggle();
       }
     }
 


### PR DESCRIPTION
Closes #2228

## What

Show the `UnauthenticatedEditModal` only **once** per logged-out session instead of on every unlock. Once the user presses **Continue**, it stays suppressed until they log out.

Also fixes a related lock-gesture desync surfaced while investigating.

## Changes

### Show the modal once (global redux flag)
- New `app` redux state `unauthEditModalDismissed` with `setUnauthEditModalDismissed` action, `isUnauthEditModalDismissed` selector, and `SET_UNAUTH_EDIT_MODAL_DISMISSED` constant.
- Reducer resets the flag to `false` on `LOGOUT`, so a fresh logged-out session shows the modal again.
- `Board.container`: the modal only opens when `isLocked && !isLogged && !unauthEditModalDismissed`; **Continue** dispatches `setUnauthEditModalDismissed(true)` and unlocks. The transient "is the dialog open" state stays local (`showUnauthEditModal`) — only the dismissal is global.

### Fix lock-gesture desync (`childProof.js`)
The lock needs 4 clicks to unlock. When the 4th click triggered a modal/dialog **instead of unlocking** (unauth edit modal or PIN dialog), the internal click count stayed at the threshold, so a single subsequent click re-fired the toggle. The count is now reset when the threshold fires, making the gesture self-contained — dismissing the modal requires repeating the full 4-click gesture. This also fixes the same issue for the PIN dialog.

## Tests
- `App.reducer.test.js`: `SET_UNAUTH_EDIT_MODAL_DISMISSED` case + logout reset.
- `App.actions.test.js`: action creator (explicit + default payload) and selector.
- `Board.container.test.js`: `mapStateToProps` mapping + `handleLockClick` gating (logged-out & not dismissed → opens modal; logged-out & dismissed → unlocks directly).

## Notes
- `unauthEditModalDismissed` lives in the persisted `app` slice, so dismissal survives a page reload until logout. Happy to exclude it from persistence if reload-resets-it is preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)