### PR TITLE
fix(sync): keep default boards untracked at login (consistent graduation)

### DIFF
--- a/docs/sync-engine.md
+++ b/docs/sync-engine.md
@@ -409,6 +409,26 @@ After Pass 2 completes, every board that was untracked either:
 
 On the next sync cycle, these boards will be handled by **Pass 1** (the standard PENDING tracking path) instead of Pass 2, because they now have `syncMeta` entries. Pass 2 effectively runs once per board — it's a one-time migration.
 
+### 7.1 `syncMeta` initialization at login
+
+`LOGIN_SUCCESS` (`Board.reducer.js`) has two branches, selected by
+`discardLocalChanges = hasRemoteCommunicators` (`Login.actions.js`):
+
+- **Discard** (user already has remote communicators): local state is replaced
+  by the server boards. Only the remote (server) boards are graduated to
+  `SYNCED`; the shipped defaults that aren't on the server are left untracked.
+- **Merge** (no remote communicators): server boards are merged into local
+  state and classified (`PENDING`/`SYNCED`); pre-existing local boards keep
+  their current `syncMeta`.
+
+**Decision:** default boards are never added to `syncMeta` at login (either
+branch). They stay untracked, consistent with the merge branch and the sync
+engine, which never push or track default boards. Untracked and `SYNCED` behave
+identically in the UI — only `PENDING` is surfaced (see §12) — and untracked
+defaults are protected from deletion by their short ID (`localHasSyncStatus`,
+§5.1). A default board only enters `syncMeta` once the user edits it (→
+`PENDING`), at which point it is transformed and pushed.
+
 ---
 
 ## 8. `updateApiObjectsNoChild()` Deep Dive

--- a/src/components/Board/Board.reducer.js
+++ b/src/components/Board/Board.reducer.js
@@ -151,7 +151,7 @@ function boardReducer(state = initialState, action) {
         return {
           ...state,
           boards: allBoards,
-          syncMeta: allBoards.reduce((acc, b) => {
+          syncMeta: remoteBoards.reduce((acc, b) => {
             acc[b.id] = { status: SYNC_STATUS.SYNCED };
             return acc;
           }, {}),


### PR DESCRIPTION
## What

Makes `syncMeta` initialization at login consistent: shipped **default boards are never added to `syncMeta` at login** (in either the discard or merge branch), matching the merge branch and the sync engine, which already leave defaults untracked.

Previously the `LOGIN_SUCCESS` **discard** branch rebuilt `syncMeta` marking **all** boards `SYNCED` — including the shipped defaults — so graduation behavior depended on whether the user already had remote communicators.

## Change

- `Board.reducer.js`: the discard branch now graduates only the **remote** boards to `SYNCED`; shipped defaults are left untracked.
- `docs/sync-engine.md`: added §7.1 documenting `syncMeta` initialization at login and this decision.

## Why it's safe

- Untracked and `SYNCED` behave identically in the UI — only `PENDING` is surfaced (selectors / `SyncButton`).
- Untracked defaults are protected from server-side deletion by their short ID (`localHasSyncStatus` guard in `classifyRemoteBoards`).
- A default board only enters `syncMeta` once the user edits it (→ `PENDING`), at which point it is transformed and pushed.

## Scope

- One-line behavior change + docs. Feature not yet deployed.
- Out of scope: a future direction to drive all sync off `syncMeta` and remove the untracked state (would invert this decision).
- Found while reviewing this area: a separate logged-out import bug (#2231) — not addressed here.

Closes #2232

🤖 Generated with [Claude Code](https://claude.com/claude-code)
