### PR TITLE
feat(sync): add rollout telemetry and surface silent sync failures

### DIFF
--- a/docs/sync-telemetry.md
+++ b/docs/sync-telemetry.md
@@ -1,0 +1,348 @@
+# Sync Engine Telemetry — Operations Guide
+
+How to read the operational telemetry that ships with the [board sync engine](./sync-engine.md).
+
+Use this doc when you want to answer, from production data: is the rollout reaching users, does
+first sync *complete*, do local boards *graduate* without jamming, and how often does sync throw.
+It documents the events the engine emits, where they fire, the Kusto queries that interpret them,
+and the alerts that watch them.
+
+> **What this telemetry is.** It is **observational** — it records what the engine does, it does
+> not change how the engine runs. See §0 for the one consequence of that worth keeping in mind.
+
+---
+
+## 0. What this telemetry can and cannot tell you
+
+This telemetry is read-only instrumentation. That bounds what it delivers:
+
+- ✅ It tells you, across the fleet, **whether the rollout is reaching users**, whether first
+  sync **completes**, whether **graduation** jams, and **how often sync throws**.
+- ❌ It does **not** prevent board data loss. A bad manifest can still mass-delete graduated
+  boards; `Sync_RemoteDeletions` (§4.4) is a smoke detector that fires *after* the delete and
+  cannot recover an already-purged local board.
+
+If preventing local-board loss becomes a priority, that is a **separate** change (a
+manifest-sanity guard in the engine) — not something this telemetry does on its own.
+
+---
+
+## 1. Events the engine emits
+
+All events go through `trackSyncEvent` / `trackSyncException` in
+[`src/components/Board/Board.sync.analytics.js`](../src/components/Board/Board.sync.analytics.js),
+thin wrappers over `appInsights` (auto-disabled in dev; `user_Id` / `session_Id` already attached
+via `setAuthenticatedUserContext` on login).
+
+**Convention:** numeric counts live in `measurements` (`customMeasurements` in Kusto);
+categorical context lives in `properties` (`customDimensions`). Every event and exception carries
+`feature: "sync"`, so the `customEvents` and `exceptions` tables join cleanly. There is **no
+`appVersion` dimension** — cohort by time instead (see §3).
+
+### `Sync_FirstRun`
+The first onboarding sync of a device — fires at the top of `syncBoards()` when `syncMeta` is
+empty but boards exist. (It fires again if that first sync fails before `syncMeta` is written;
+`dcount(user_Id)` in the queries dedupes, so adoption counts stay correct.)
+
+| field | bag | meaning |
+|---|---|---|
+| `totalBoards` | measurements | boards at first sync |
+| `localBoards` | measurements | short-id boards |
+| `serverBoards` | measurements | objectId boards |
+
+### `Sync_Graduation`
+Once per cycle, in `classifyBoardsForPush`, whenever any untracked board was seen.
+
+| field | bag | meaning |
+|---|---|---|
+| `untrackedSeen` | measurements | untracked boards entering Pass 2 |
+| `graduated` | measurements | remote exists + same/older → SYNCED, no API call |
+| `pushedNew` | measurements | `needsCreate: true` |
+| `pushedUpdate` | measurements | `needsCreate: false` |
+
+### `Sync_Completed`
+On every cycle, success or failure.
+
+| field | bag | meaning |
+|---|---|---|
+| `outcome` | properties | `success` \| `failure` |
+| `durationMs` | measurements | wall time of the cycle |
+| `pendingBefore` | measurements | PENDING boards pre-sync |
+| `pendingAfter` | measurements | PENDING boards post-sync |
+
+### `Sync_RemoteDeletions` — passive data-loss detector
+Once per cycle in `syncBoards()`, after `classifyRemoteBoards`, **only when `boardIdsToDelete` is
+non-empty**. PULL deletions are manifest-authoritative and hard-delete graduated boards; this
+event makes the fleet-wide volume of those deletions visible, so an anomalous spike (e.g. an
+empty/corrupt manifest mass-deleting) is caught the day it deploys. It **counts** what the cycle
+is about to delete — it does not stop it.
+
+| field | bag | meaning |
+|---|---|---|
+| `deletedCount` | measurements | boards this cycle will hard-delete via PULL |
+| `manifestSize` | measurements | boards in the remote manifest (`remoteBoards.length`) |
+| `localServerBoards` | measurements | local boards with a server id, pre-delete (deletion denominator) |
+
+### Sync exceptions
+Three failure paths additionally call `trackSyncException`, each tagged with a `phase` so you can
+tell them apart in the `exceptions` table:
+
+| `phase` | where | was previously |
+|---|---|---|
+| `pullBulkFetch` | bulk board-body fetch catch | `console.error` only (invisible in cloud) |
+| `pushBoard` | per-board push catch (also carries `boardId`) | `console.error` only |
+| `syncBoards` | top-level cycle catch | `console.error` only |
+
+These were silent before — surfacing them in the cloud is the highest-value part of this
+telemetry.
+
+---
+
+## 2. Where each signal fires
+
+| Event / signal | File / function |
+|---|---|
+| `Sync_FirstRun` | `Board.actions.js` → `syncBoards()`, after the pre-PULL `getState().board` read |
+| `Sync_Graduation` | `Board.actions.js` → `classifyBoardsForPush`, before the batched `markBoardsSynced` |
+| `Sync_Completed` | `Board.actions.js` → `syncBoards()` success & catch |
+| `Sync_RemoteDeletions` | `Board.actions.js` → `syncBoards()`, after `classifyRemoteBoards`, guarded by `boardIdsToDelete.length > 0` |
+| `trackSyncException` | `Board.actions.js` → the three sync `catch` blocks (`pullBulkFetch`, `pushBoard`, `syncBoards`) |
+
+The helper lives in `Board.sync.analytics.js` and is kept in the actions layer because these
+events need computed before/after state and timing that the redux-beacon `eventsMap` can't
+express. It mirrors the existing `StorageMigration_*` pattern in `src/reducers.js`.
+
+---
+
+## 3. Cohorting by time (why there is no `appVersion`)
+
+The app has **no maintained version source**: `package.json` is stale (`0.1.1`) and CRA does not
+expose it to the browser. So **cohort by time** instead — releases are discrete deploys, so
+`bin(timestamp, 1d)` plus the known deploy date of each ring is enough to read the rollout.
+
+> **If you want per-version cohorting later:** inject a build version from CI
+> (`REACT_APP_VERSION=$(git rev-parse --short HEAD)`), read it in `src/constants.js`, add it back
+> as a `properties.appVersion` dimension, and swap the `bin(timestamp,1d)` cohorting below for
+> `by appVersion`. Not required to use the telemetry as shipped.
+
+```kusto
+// customMeasurements values are dynamic — cast with todouble(...) before aggregating.
+```
+
+---
+
+## 4. Queries
+
+Paste these into App Insights → Logs. Adjust the `ago(...)` lookbacks to your window.
+
+### 4.1 Adoption — is the rollout reaching users?
+
+```kusto
+customEvents
+| where timestamp > ago(30d) and name == "Sync_FirstRun"
+| summarize firstRunUsers = dcount(user_Id) by bin(timestamp, 1d)
+| render timechart
+```
+
+Cumulative adoption S-curve:
+
+```kusto
+customEvents
+| where timestamp > ago(30d) and name == "Sync_FirstRun"
+| summarize users = dcount(user_Id) by day = bin(timestamp, 1d)
+| order by day asc
+| extend cumulativeUsers = row_cumsum(users)
+| render timechart
+```
+
+### 4.2 Completion funnel — did first sync finish?
+
+```kusto
+let lookback = 14d;
+let firstRuns =
+    customEvents
+    | where timestamp > ago(lookback) and name == "Sync_FirstRun"
+    | project user_Id, session_Id;
+let completions =
+    customEvents
+    | where timestamp > ago(lookback) and name == "Sync_Completed"
+    | extend outcome = tostring(customDimensions.outcome)
+    | project user_Id, session_Id, outcome;
+firstRuns
+| join kind=leftouter completions on user_Id, session_Id
+| summarize
+    started        = dcount(user_Id),
+    completedOk    = dcountif(user_Id, outcome == "success"),
+    completedFail  = dcountif(user_Id, outcome == "failure"),
+    neverCompleted = dcountif(user_Id, isempty(outcome))
+| extend completionRatePct = round(100.0 * completedOk / started, 1)
+```
+
+Healthy: `completionRatePct` near 100, `neverCompleted` ≈ 0.
+
+### 4.3 Graduation-stuck detector
+
+A board seen untracked in one cycle should be tracked by the next. The same user reporting
+`untrackedSeen > 0` across ≥2 cycles means graduation has jammed.
+
+```kusto
+let lookback = 7d;
+customEvents
+| where timestamp > ago(lookback) and name == "Sync_Graduation"
+| extend untrackedSeen = todouble(customMeasurements.untrackedSeen)
+| where untrackedSeen > 0
+| summarize cyclesStuck = count(), lastSeen = max(timestamp), maxUntracked = max(untrackedSeen)
+    by user_Id
+| where cyclesStuck >= 2
+| order by cyclesStuck desc
+```
+
+Graduate-vs-push distribution (sanity that Pass 2 takes the no-API graduation path):
+
+```kusto
+customEvents
+| where timestamp > ago(14d) and name == "Sync_Graduation"
+| extend
+    graduated    = todouble(customMeasurements.graduated),
+    pushedNew    = todouble(customMeasurements.pushedNew),
+    pushedUpdate = todouble(customMeasurements.pushedUpdate)
+| summarize totalGraduated = sum(graduated), totalPushedNew = sum(pushedNew), totalPushedUpdate = sum(pushedUpdate)
+    by bin(timestamp, 1d)
+```
+
+### 4.4 Remote deletions — is the engine deleting more than expected?
+
+The smoke detector for the one open data-loss path (bad manifest → mass delete). Watch for a
+spike the day a release deploys, or any cycle where `deletedCount` is large relative to
+`manifestSize` (a near-empty manifest deleting many local server boards is the danger shape).
+
+```kusto
+customEvents
+| where timestamp > ago(30d) and name == "Sync_RemoteDeletions"
+| extend
+    deletedCount      = todouble(customMeasurements.deletedCount),
+    manifestSize      = todouble(customMeasurements.manifestSize),
+    localServerBoards = todouble(customMeasurements.localServerBoards)
+| summarize
+    cycles          = count(),
+    usersAffected   = dcount(user_Id),
+    boardsDeleted   = sum(deletedCount),
+    maxDeletedInOne = max(deletedCount)
+    by bin(timestamp, 1d)
+| render timechart
+```
+
+Suspicious-cycle drill-down (manifest implausibly small vs. what's being deleted):
+
+```kusto
+customEvents
+| where timestamp > ago(30d) and name == "Sync_RemoteDeletions"
+| extend
+    deletedCount      = todouble(customMeasurements.deletedCount),
+    manifestSize      = todouble(customMeasurements.manifestSize),
+    localServerBoards = todouble(customMeasurements.localServerBoards)
+| where deletedCount >= 5 and manifestSize <= localServerBoards * 0.5
+| project timestamp, user_Id, deletedCount, manifestSize, localServerBoards
+| order by deletedCount desc
+```
+
+### 4.5 Stuck PENDING — boards that never finish pushing
+
+`Sync_Completed` reports `success` even when a per-board push silently failed (that path emits a
+`pushBoard` exception but the cycle still succeeds). A user whose `pendingAfter` stays > 0 across
+cycles has boards stuck local.
+
+```kusto
+let lookback = 7d;
+customEvents
+| where timestamp > ago(lookback) and name == "Sync_Completed"
+| extend pendingAfter = todouble(customMeasurements.pendingAfter)
+| where pendingAfter > 0
+| summarize cyclesStuck = count(), lastSeen = max(timestamp), maxPending = max(pendingAfter)
+    by user_Id
+| where cyclesStuck >= 3
+| order by maxPending desc
+```
+
+Cross-reference a stuck user against their `pushBoard` exceptions:
+
+```kusto
+exceptions
+| where timestamp > ago(7d)
+    and tostring(customDimensions.feature) == "sync"
+    and tostring(customDimensions.phase) == "pushBoard"
+| project timestamp, user_Id, boardId = tostring(customDimensions.boardId), problemId, outerMessage
+| order by timestamp desc
+```
+
+### 4.6 Health — sync error rate
+
+```kusto
+let lookback = 14d;
+let syncEvents =
+    customEvents
+    | where timestamp > ago(lookback) and name startswith "Sync_"
+    | summarize cycles = count() by day = bin(timestamp, 1d);
+let syncErrors =
+    exceptions
+    | where timestamp > ago(lookback) and tostring(customDimensions.feature) == "sync"
+    | summarize errors = count() by day = bin(timestamp, 1d);
+syncEvents
+| join kind=leftouter syncErrors on day
+| extend errors = coalesce(errors, 0), errorRatePct = round(100.0 * coalesce(errors,0) / cycles, 2)
+| project day, cycles, errors, errorRatePct
+| order by day asc
+| render timechart
+```
+
+---
+
+## 5. Alerts to configure
+
+Set up one scheduled log alert (run every 1h, fire when result count > 0) per critical signal:
+
+| Alert | Query basis | Means |
+|---|---|---|
+| **Mass remote deletion** | §4.4 drill-down, any row in last 1h | a cycle deleted many boards against a tiny manifest — the open data-loss shape; investigate the manifest source immediately |
+| **Graduation stuck** | §4.3 with `cyclesStuck >= 2` over last 2h | a user can't onboard their boards |
+| **Sync error spike** | §4.6 `errorRatePct` over threshold | sync is throwing more than baseline |
+
+> The mass-deletion alert is the highest priority: with no engine guard in place it fires *after*
+> the delete, so treat any trip as a signal to **halt the ramp** and inspect the manifest, not
+> just to observe. If it trips repeatedly, the durable fix is a manifest-sanity guard in the
+> engine, not more watching.
+
+---
+
+## 6. Dashboard layout
+
+One Workbook, three tiles:
+
+1. **Adoption** — §4.1 timechart.
+2. **Health** — §4.2 funnel + §4.5 stuck-PENDING + §4.6 error rate.
+3. **Safety & graduation** — §4.4 remote-deletions timechart + §4.3 graduation-stuck detector.
+
+---
+
+## 7. Retention — how long to keep each signal
+
+Two tiers, deliberately:
+
+- **Rollout/migration events** (`Sync_FirstRun`, `Sync_Graduation`): keep through the ramp
+  **plus a ~2–4 week stabilization tail** with the stuck signal flat. Then retire or sample down
+  — they answer a one-time migration question that expires.
+- **Health/safety telemetry** (`Sync_Completed`, `Sync_RemoteDeletions`, all sync exceptions):
+  **keep.** These are invariants of the engine, not rollout metrics, and should outlive the
+  release — `Sync_RemoteDeletions` especially, since it is the only observability over the
+  unmitigated mass-deletion path.
+
+Operational notes:
+
+- Payloads are scalar counts and short ids only. These events ride authenticated user context —
+  treat as personal data; no labels/emails.
+- App Insights / Kusto is the store; don't export — exporting a transient ops signal creates a
+  governance obligation.
+- Consider excluding `Sync_*` names from ingestion sampling during the ramp so counts are exact
+  rather than estimated.
+</content>
+</invoke>

--- a/src/components/Board/Board.actions.js
+++ b/src/components/Board/Board.actions.js
@@ -73,6 +73,11 @@ import { isAndroid, writeCvaFile } from '../../cordova-util';
 import { DEFAULT_BOARDS } from '../../helpers';
 import history from './../../history';
 import { improvePhraseAbortController } from '../../api/api';
+import {
+  trackSyncEvent,
+  trackSyncException,
+  countPendingBoards
+} from './Board.sync.analytics';
 
 export function addBoards(boards) {
   return {
@@ -614,6 +619,7 @@ export function applyRemoteChangesToState({
       // deletions above are already applied (manifest-authoritative) and the
       // PUSH phase can still upload local edits, so we don't abort the cycle.
       console.error('Bulk board body fetch failed; deferring adds/updates:', e);
+      trackSyncException(e, { phase: 'pullBulkFetch' });
       return;
     }
 
@@ -702,9 +708,15 @@ function classifyBoardsForPush({
   // or were created when the user was unlogged (empty email) or have the default email.
   const remoteBoardMap = new Map(remoteBoards.map(b => [b.id, b]));
 
+  let untrackedSeen = 0;
+  let pushedNew = 0;
+  let pushedUpdate = 0;
+
   for (const b of boards) {
     if (syncMeta[b.id] || (b.email !== userEmail && !isUnloggedCreatedBoard(b)))
       continue;
+
+    untrackedSeen++;
 
     const remote = remoteBoardMap.get(b.id);
     if (remote && moment(b.lastEdited).isSameOrBefore(remote.lastEdited)) {
@@ -713,10 +725,19 @@ function classifyBoardsForPush({
       continue;
     }
 
-    const wasTransformed = transformAndTrack(b);
-    boardsToSync.push({
-      boardId: b.id,
-      needsCreate: wasTransformed || isLocalBoard(b)
+    const needsCreate = transformAndTrack(b) || isLocalBoard(b);
+    needsCreate ? pushedNew++ : pushedUpdate++;
+    boardsToSync.push({ boardId: b.id, needsCreate });
+  }
+
+  if (untrackedSeen > 0) {
+    trackSyncEvent('Sync_Graduation', {
+      measurements: {
+        untrackedSeen,
+        graduated: boardsToGraduate.length,
+        pushedNew,
+        pushedUpdate
+      }
     });
   }
 
@@ -803,6 +824,7 @@ export function pushLocalChangesToApi(remoteBoards = []) {
         }
       } catch (e) {
         console.error('Failed to push board to API:', board.id, e);
+        trackSyncException(e, { phase: 'pushBoard', boardId: board.id });
       }
     }
 
@@ -836,15 +858,38 @@ export function syncBoards(remoteBoards) {
   return async (dispatch, getState) => {
     dispatch(syncBoardsStarted());
 
-    try {
-      const { boards: localBoards, syncMeta } = getState().board;
+    const startedAt = Date.now();
+    const { boards: localBoards, syncMeta } = getState().board;
+    const pendingBefore = countPendingBoards(syncMeta);
 
+    if (Object.keys(syncMeta).length === 0 && localBoards.length > 0) {
+      const serverBoards = localBoards.filter(isServerBoard).length;
+      trackSyncEvent('Sync_FirstRun', {
+        measurements: {
+          totalBoards: localBoards.length,
+          localBoards: localBoards.length - serverBoards,
+          serverBoards
+        }
+      });
+    }
+
+    try {
       // 1. Classify boards for PULL (remote changes + remote deletions)
       const {
         boardsToAdd,
         boardsToUpdate,
         boardIdsToDelete
       } = classifyRemoteBoards(localBoards, remoteBoards, syncMeta);
+
+      if (boardIdsToDelete.length > 0) {
+        trackSyncEvent('Sync_RemoteDeletions', {
+          measurements: {
+            deletedCount: boardIdsToDelete.length,
+            manifestSize: remoteBoards.length,
+            localServerBoards: localBoards.filter(isServerBoard).length
+          }
+        });
+      }
 
       // 2. PULL: Apply remote changes to local state (includes remote deletions)
       await dispatch(
@@ -865,10 +910,27 @@ export function syncBoards(remoteBoards) {
       await dispatch(pushLocalChangesToApi(remoteBoards));
 
       dispatch(syncBoardsSuccess());
+      trackSyncEvent('Sync_Completed', {
+        properties: { outcome: 'success' },
+        measurements: {
+          durationMs: Date.now() - startedAt,
+          pendingBefore,
+          pendingAfter: countPendingBoards(getState().board.syncMeta)
+        }
+      });
       return { success: true };
     } catch (error) {
       console.error('Sync boards failed:', error);
       dispatch(syncBoardsFailure(error));
+      trackSyncEvent('Sync_Completed', {
+        properties: { outcome: 'failure' },
+        measurements: {
+          durationMs: Date.now() - startedAt,
+          pendingBefore,
+          pendingAfter: countPendingBoards(getState().board.syncMeta)
+        }
+      });
+      trackSyncException(error, { phase: 'syncBoards' });
       return { success: false, error };
     }
   };

--- a/src/components/Board/Board.sync.analytics.js
+++ b/src/components/Board/Board.sync.analytics.js
@@ -1,0 +1,37 @@
+import { appInsights } from '../../appInsights';
+import { SYNC_STATUS } from './Board.constants';
+
+// All sync telemetry carries `feature: "sync"` so customEvents and exceptions
+// join cleanly in Kusto. appInsights auto-disables in development.
+const FEATURE = 'sync';
+
+/**
+ * Thin wrapper over appInsights.trackEvent for the sync engine rollout telemetry.
+ * Numeric counts go in `measurements` (customMeasurements); categorical context
+ * goes in `properties` (customDimensions). See docs/sync-telemetry.md.
+ */
+export function trackSyncEvent(name, { properties = {}, measurements } = {}) {
+  appInsights.trackEvent({
+    name,
+    properties: { feature: FEATURE, ...properties },
+    measurements
+  });
+}
+
+/**
+ * Surface a sync failure in the cloud `exceptions` table. The sync catch blocks
+ * otherwise only console.error, which is invisible once deployed.
+ */
+export function trackSyncException(error, properties = {}) {
+  appInsights.trackException({
+    exception: error instanceof Error ? error : new Error(String(error)),
+    properties: { feature: FEATURE, ...properties }
+  });
+}
+
+/** Count boards currently marked PENDING (not deleted) in a syncMeta map. */
+export function countPendingBoards(syncMeta = {}) {
+  return Object.values(syncMeta).filter(
+    meta => meta?.status === SYNC_STATUS.PENDING && !meta?.isDeleted
+  ).length;
+}


### PR DESCRIPTION
Closes #2234

## What

Adds **observational** App Insights telemetry for the sync engine progressive rollout. **No behavior change to the engine** — this is read-only instrumentation.

## Why

We're shipping the sync engine behind a rollout with no production visibility: sync failures only `console.error` (invisible in the cloud), and we can't tell whether the rollout reaches users, whether first sync completes, whether graduation jams, or whether the manifest-authoritative PULL deletion path is over-deleting. See #2234.

## Changes

- **Surface silent failures.** The three sync `catch` blocks (bulk board-body fetch, per-board push, top-level cycle) now also `trackException`, tagged `feature: "sync"` + a `phase` (`pullBulkFetch` / `pushBoard` / `syncBoards`). They previously only `console.error`d.
- **Rollout events** (`Board.actions.js`):
  - `Sync_FirstRun` — first onboarding sync of a device (`totalBoards`, `localBoards`, `serverBoards`)
  - `Sync_Graduation` — per cycle when untracked boards are seen (`untrackedSeen`, `graduated`, `pushedNew`, `pushedUpdate`)
  - `Sync_Completed` — every cycle, success/failure (`durationMs`, `pendingBefore`, `pendingAfter`)
  - `Sync_RemoteDeletions` — passive data-loss detector, only when a cycle is about to hard-delete (`deletedCount`, `manifestSize`, `localServerBoards`)
- **Helper:** `Board.sync.analytics.js` — thin `trackSyncEvent` / `trackSyncException` / `countPendingBoards` wrappers over `appInsights`, mirroring the existing `StorageMigration_*` pattern.
- **Docs:** `docs/sync-telemetry.md` — event schema, instrumentation points, Kusto queries, alerts, dashboard, and retention guidance for operating the telemetry after release.

## Notes / non-goals

- This does **not** prevent data loss. `Sync_RemoteDeletions` is a smoke detector that fires *after* the delete; preventing local-board loss would need a manifest-sanity guard in the engine (out of scope, called out in the doc).
- Payloads are scalar counts and short ids only — no labels/emails — since events ride authenticated user context. `appInsights` auto-disables in dev.

## Test plan

- [ ] Verify events appear in App Insights `customEvents` with `feature: "sync"` after a sync cycle
- [ ] Force a sync failure and confirm an entry lands in `exceptions` with the expected `phase`
- [ ] Confirm no telemetry is emitted in development (appInsights disabled)
