### PR TITLE
fix: sanitize local tile images before board create/update

### DIFF
--- a/src/api/__mocks__/api.js
+++ b/src/api/__mocks__/api.js
@@ -126,6 +126,11 @@ class API {
       }
     });
   }
+
+  async uploadBoardLocalImages(board) {
+    return { board, hadFailure: false };
+  }
+
   async arasaacPictogramsSearch(locale, searchText) {
     return [];
   }

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -9,7 +9,7 @@ import {
   AZURE_SPEECH_SUBSCR_KEY
 } from '../constants';
 import { getStore } from '../store';
-import { dataURLtoFile } from '../helpers';
+import { dataURLtoFile, isDataURL, isLocalFileURL } from '../helpers';
 import { logout } from '../components/Account/Login/Login.actions.js';
 import { isAndroid } from '../cordova-util';
 
@@ -455,14 +455,77 @@ class API {
   }
 
   async uploadFromDataURL(dataURL, filename, checkExtension = false) {
-    const file = dataURLtoFile(dataURL, filename, checkExtension);
-
     let url = null;
     try {
+      const file = dataURLtoFile(dataURL, filename, checkExtension);
       url = await this.uploadFile(file, filename);
     } catch (e) {}
 
     return url;
+  }
+
+  async uploadBoardLocalImages(board) {
+    const tiles = board?.tiles || [];
+    const targets = tiles.filter(
+      tile => isDataURL(tile?.image) || isLocalFileURL(tile?.image)
+    );
+
+    if (!targets.length) {
+      return { board, hadFailure: false };
+    }
+
+    const urlByTileId = {};
+    let hadFailure = false;
+
+    const uploadTarget = async tile => {
+      try {
+        let url = null;
+        if (isDataURL(tile.image)) {
+          url = await this.uploadFromDataURL(tile.image, tile.id, true);
+        } else if (isLocalFileURL(tile.image) && isAndroid()) {
+          const file = await new Promise(resolve => {
+            window.resolveLocalFileSystemURL(
+              tile.image,
+              fileEntry => {
+                fileEntry.file(file => resolve(file), () => resolve(null));
+              },
+              () => resolve(null)
+            );
+          });
+          if (file) {
+            const segments = tile.image.split('/');
+            const name = segments[segments.length - 1] || tile.id;
+            url = await this.uploadFile(file, name);
+          }
+        } else {
+          return;
+        }
+
+        if (url) {
+          urlByTileId[tile.id] = url;
+        } else {
+          hadFailure = true;
+        }
+      } catch (e) {
+        hadFailure = true;
+      }
+    };
+
+    const CONCURRENCY = 5;
+    for (let i = 0; i < targets.length; i += CONCURRENCY) {
+      await Promise.all(targets.slice(i, i + CONCURRENCY).map(uploadTarget));
+    }
+
+    const sanitizedBoard = {
+      ...board,
+      tiles: tiles.map(tile =>
+        urlByTileId[(tile?.id)]
+          ? { ...tile, image: urlByTileId[tile.id] }
+          : tile
+      )
+    };
+
+    return { board: sanitizedBoard, hadFailure };
   }
 
   async uploadFile(file, filename) {

--- a/src/api/api.test.js
+++ b/src/api/api.test.js
@@ -5,8 +5,12 @@ import thunk from 'redux-thunk';
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
 import { getStore } from '../store';
+import { isAndroid } from '../cordova-util';
 
 jest.mock('../store');
+jest.mock('../cordova-util', () => ({
+  isAndroid: jest.fn(() => false)
+}));
 
 const mockBoard = {
   name: 'tewt',
@@ -187,6 +191,108 @@ describe('Cboard API calls', () => {
       .catch(catchFn);
     mockAxios.mockResponse(mockBoard);
   });
+  describe('uploadBoardLocalImages', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+      isAndroid.mockReturnValue(false);
+    });
+
+    it('returns the board untouched when no tiles have local images', async () => {
+      const board = {
+        id: 'b1',
+        tiles: [
+          { id: 't1', image: 'https://cdn.example.com/a.png' },
+          { id: 't2' }
+        ]
+      };
+      const uploadFromDataURL = jest.spyOn(API, 'uploadFromDataURL');
+      const uploadFile = jest.spyOn(API, 'uploadFile');
+
+      const result = await API.uploadBoardLocalImages(board);
+
+      expect(result).toEqual({ board, hadFailure: false });
+      expect(uploadFromDataURL).not.toHaveBeenCalled();
+      expect(uploadFile).not.toHaveBeenCalled();
+    });
+
+    it('replaces base64 and file images with uploaded urls on success', async () => {
+      isAndroid.mockReturnValue(true);
+      const file = new File(['x'], 'img.png');
+      window.resolveLocalFileSystemURL = jest.fn((url, success) =>
+        success({ file: cb => cb(file) })
+      );
+      jest
+        .spyOn(API, 'uploadFromDataURL')
+        .mockResolvedValue('https://cdn.example.com/base64.png');
+      jest
+        .spyOn(API, 'uploadFile')
+        .mockResolvedValue('https://cdn.example.com/file.png');
+
+      const board = {
+        id: 'b1',
+        tiles: [
+          { id: 't1', image: 'data:image/png;base64,iVBORw0KGgo=' },
+          { id: 't2', image: 'file:///storage/emulated/0/img.png' },
+          { id: 't3', image: 'https://cdn.example.com/keep.png' }
+        ]
+      };
+
+      const { board: sanitized, hadFailure } = await API.uploadBoardLocalImages(
+        board
+      );
+
+      expect(hadFailure).toBe(false);
+      expect(sanitized.tiles[0].image).toBe(
+        'https://cdn.example.com/base64.png'
+      );
+      expect(sanitized.tiles[1].image).toBe('https://cdn.example.com/file.png');
+      expect(sanitized.tiles[2].image).toBe('https://cdn.example.com/keep.png');
+    });
+
+    it('commits successes and flags hadFailure on partial failure', async () => {
+      jest
+        .spyOn(API, 'uploadFromDataURL')
+        .mockResolvedValueOnce('https://cdn.example.com/ok.png')
+        .mockResolvedValueOnce(null);
+
+      const board = {
+        id: 'b1',
+        tiles: [
+          { id: 't1', image: 'data:image/png;base64,AAAA' },
+          { id: 't2', image: 'data:image/png;base64,BBBB' }
+        ]
+      };
+
+      const { board: sanitized, hadFailure } = await API.uploadBoardLocalImages(
+        board
+      );
+
+      expect(hadFailure).toBe(true);
+      expect(sanitized.tiles[0].image).toBe('https://cdn.example.com/ok.png');
+      expect(sanitized.tiles[1].image).toBe('data:image/png;base64,BBBB');
+    });
+
+    it('leaves file images untouched on non-android platforms', async () => {
+      isAndroid.mockReturnValue(false);
+      const uploadFile = jest.spyOn(API, 'uploadFile');
+
+      const board = {
+        id: 'b1',
+        tiles: [{ id: 't1', image: 'file:///storage/emulated/0/img.png' }]
+      };
+
+      const { board: sanitized, hadFailure } = await API.uploadBoardLocalImages(
+        board
+      );
+
+      expect(hadFailure).toBe(false);
+      expect(uploadFile).not.toHaveBeenCalled();
+      expect(sanitized.tiles[0].image).toBe(
+        'file:///storage/emulated/0/img.png'
+      );
+    });
+  });
+
   it('fetches results from unauthorized api', () => {
     let catchFn = jest.fn(),
       thenFn = jest.fn();

--- a/src/components/Board/Board.actions.js
+++ b/src/components/Board/Board.actions.js
@@ -951,6 +951,21 @@ export function syncBoards(remoteBoards) {
   };
 }
 
+export function sanitizeBoardImages(board) {
+  return async dispatch => {
+    const { board: sanitized, hadFailure } = await API.uploadBoardLocalImages(
+      board
+    );
+    if (sanitized !== board) {
+      dispatch(updateBoard(sanitized));
+    }
+    if (hadFailure) {
+      throw new Error('image upload failed');
+    }
+    return sanitized;
+  };
+}
+
 export function createApiBoard(boardData, boardId) {
   return async dispatch => {
     dispatch(createApiBoardStarted());
@@ -958,6 +973,12 @@ export function createApiBoard(boardData, boardId) {
       ...boardData,
       isPublic: false
     };
+    try {
+      boardData = await dispatch(sanitizeBoardImages(boardData));
+    } catch (err) {
+      dispatch(createApiBoardFailure(err.message));
+      throw new Error(err.message);
+    }
     return API.createBoard(boardData)
       .then(res => {
         dispatch(createApiBoardSuccess(res, boardId));
@@ -973,6 +994,12 @@ export function createApiBoard(boardData, boardId) {
 export function updateApiBoard(boardData) {
   return async dispatch => {
     dispatch(updateApiBoardStarted());
+    try {
+      boardData = await dispatch(sanitizeBoardImages(boardData));
+    } catch (err) {
+      dispatch(updateApiBoardFailure(err.message));
+      throw new Error(err.message);
+    }
     return API.updateBoard(boardData)
       .then(res => {
         dispatch(updateApiBoardSuccess(res));

--- a/src/components/Board/__tests__/Board.actions.test.js
+++ b/src/components/Board/__tests__/Board.actions.test.js
@@ -1537,3 +1537,118 @@ describe('getApiMyBoards', () => {
     expect(actionTypes).not.toContain(types.SYNC_BOARDS_STARTED);
   });
 });
+
+describe('sanitizeBoardImages', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('dispatches updateBoard with the sanitized board', async () => {
+    const sanitized = {
+      id: 'b1',
+      tiles: [{ id: 't1', image: 'https://cdn.example.com/a.png' }]
+    };
+    API.uploadBoardLocalImages = jest
+      .fn()
+      .mockResolvedValue({ board: sanitized, hadFailure: false });
+    const store = mockStore({});
+
+    const result = await store.dispatch(
+      actions.sanitizeBoardImages({ id: 'b1', tiles: [] })
+    );
+
+    expect(result).toBe(sanitized);
+    expect(store.getActions()).toContainEqual({
+      type: types.UPDATE_BOARD,
+      boardData: sanitized,
+      fromRemote: false
+    });
+  });
+
+  it('commits partial successes then rethrows on hadFailure', async () => {
+    const sanitized = {
+      id: 'b1',
+      tiles: [{ id: 't1', image: 'data:image/png;base64,AAAA' }]
+    };
+    API.uploadBoardLocalImages = jest
+      .fn()
+      .mockResolvedValue({ board: sanitized, hadFailure: true });
+    const store = mockStore({});
+
+    await expect(
+      store.dispatch(actions.sanitizeBoardImages({ id: 'b1', tiles: [] }))
+    ).rejects.toThrow('image upload failed');
+
+    expect(store.getActions()).toContainEqual({
+      type: types.UPDATE_BOARD,
+      boardData: sanitized,
+      fromRemote: false
+    });
+  });
+});
+
+describe('createApiBoard sanitization', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('sends url-only tiles to createBoard for a board with local images', async () => {
+    const sanitized = {
+      id: 'b1',
+      isPublic: false,
+      tiles: [{ id: 't1', image: 'https://cdn.example.com/a.png' }]
+    };
+    API.uploadBoardLocalImages = jest
+      .fn()
+      .mockResolvedValue({ board: sanitized, hadFailure: false });
+    API.createBoard = jest.fn().mockResolvedValue(sanitized);
+    const store = mockStore({});
+
+    await store.dispatch(
+      actions.createApiBoard(
+        {
+          id: 'b1',
+          tiles: [{ id: 't1', image: 'data:image/png;base64,AAAA' }]
+        },
+        'b1'
+      )
+    );
+
+    expect(API.createBoard).toHaveBeenCalledWith(sanitized);
+    const payload = API.createBoard.mock.calls[0][0];
+    payload.tiles.forEach(tile => {
+      expect(tile.image.startsWith('data:')).toBe(false);
+      expect(/^(file|cdvfile):/i.test(tile.image)).toBe(false);
+    });
+    expect(store.getActions()).toContainEqual(
+      expect.objectContaining({ type: types.CREATE_API_BOARD_SUCCESS })
+    );
+  });
+
+  it('does not call createBoard when sanitization fails', async () => {
+    const sanitized = {
+      id: 'b1',
+      isPublic: false,
+      tiles: [{ id: 't1', image: 'data:image/png;base64,AAAA' }]
+    };
+    API.uploadBoardLocalImages = jest
+      .fn()
+      .mockResolvedValue({ board: sanitized, hadFailure: true });
+    API.createBoard = jest.fn();
+    const store = mockStore({});
+
+    await expect(
+      store.dispatch(
+        actions.createApiBoard(
+          {
+            id: 'b1',
+            tiles: [{ id: 't1', image: 'data:image/png;base64,AAAA' }]
+          },
+          'b1'
+        )
+      )
+    ).rejects.toThrow('image upload failed');
+
+    expect(API.createBoard).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Communicator/CommunicatorDialog/CommunicatorDialog.container.js
+++ b/src/components/Communicator/CommunicatorDialog/CommunicatorDialog.container.js
@@ -442,8 +442,12 @@ class CommunicatorDialogContainer extends React.Component {
     // Loggedin user?
     if ('name' in userData && 'email' in userData) {
       try {
-        const boardResponse = await API.updateBoard(boardData);
-        replaceBoard(boardData, boardResponse);
+        const { board: sanitized } = await API.uploadBoardLocalImages(
+          boardData
+        );
+        replaceBoard(boardData, sanitized);
+        const boardResponse = await API.updateBoard(sanitized);
+        replaceBoard(sanitized, boardResponse);
       } catch (err) {}
     }
   }

--- a/src/components/Settings/Import/Import.container.js
+++ b/src/components/Settings/Import/Import.container.js
@@ -92,7 +92,10 @@ export class ImportContainer extends PureComponent {
             boardToCreate.name = 'unknow';
           }
           try {
-            const response = await API.createBoard(boardToCreate);
+            const { board: sanitized } = await API.uploadBoardLocalImages(
+              boardToCreate
+            );
+            const response = await API.createBoard(sanitized);
             if (board.id) {
               response.prevId = board.id;
             }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -8,6 +8,12 @@ export const DEFAULT_BOARDS = {
 
 export const deepCopy = obj => JSON.parse(JSON.stringify(obj));
 
+export const isDataURL = str =>
+  typeof str === 'string' && str.startsWith('data:');
+
+export const isLocalFileURL = str =>
+  typeof str === 'string' && /^(file|cdvfile):/i.test(str);
+
 export const dataURLtoFile = (dataurl, filename, checkExtension = false) => {
   // https://stackoverflow.com/a/38936042
   const arr = dataurl.split(',');

--- a/src/helpers.test.js
+++ b/src/helpers.test.js
@@ -1,0 +1,45 @@
+import { isDataURL, isLocalFileURL } from './helpers';
+
+describe('isDataURL', () => {
+  it('returns true for data URLs', () => {
+    expect(isDataURL('data:image/png;base64,iVBORw0KGgo=')).toBe(true);
+    expect(isDataURL('data:text/plain;charset=utf-8;base64,dGVzdA==')).toBe(
+      true
+    );
+  });
+
+  it('returns false for non-data URLs', () => {
+    expect(isDataURL('https://example.com/image.png')).toBe(false);
+    expect(isDataURL('http://example.com/image.png')).toBe(false);
+    expect(isDataURL('file:///storage/img.png')).toBe(false);
+    expect(isDataURL('cdvfile://localhost/persistent/img.png')).toBe(false);
+    expect(isDataURL('iVBORw0KGgo=')).toBe(false);
+  });
+
+  it('returns false for non-strings', () => {
+    expect(isDataURL(null)).toBe(false);
+    expect(isDataURL(undefined)).toBe(false);
+    expect(isDataURL(123)).toBe(false);
+    expect(isDataURL({})).toBe(false);
+  });
+});
+
+describe('isLocalFileURL', () => {
+  it('returns true for file and cdvfile URLs', () => {
+    expect(isLocalFileURL('file:///storage/emulated/0/img.png')).toBe(true);
+    expect(isLocalFileURL('cdvfile://localhost/persistent/img.png')).toBe(true);
+    expect(isLocalFileURL('FILE:///storage/img.png')).toBe(true);
+  });
+
+  it('returns false for non-local URLs', () => {
+    expect(isLocalFileURL('https://example.com/image.png')).toBe(false);
+    expect(isLocalFileURL('http://example.com/image.png')).toBe(false);
+    expect(isLocalFileURL('data:image/png;base64,iVBORw0KGgo=')).toBe(false);
+  });
+
+  it('returns false for non-strings', () => {
+    expect(isLocalFileURL(null)).toBe(false);
+    expect(isLocalFileURL(undefined)).toBe(false);
+    expect(isLocalFileURL(123)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

Closes #2241.

Tiles can carry a **local-only image** in `tile.image`:

- **base64 data URL** — when the `/media` upload fails while logged in, or when offline, `TileEditor` falls back to `blobToBase64`.
- **`file://` / `cdvfile://` nativeURL** — on Android while not logged in, `TileEditor` writes the blob to the device and stores `fEntry.nativeURL`.

Both reach the server on sync. `POST /board` rejects base64 with **409** (and cannot resolve a device `file://` path at all), so the board never gets created: its `syncMeta` status stays `PENDING` and every sync cycle retries the same failing create — a poison loop. `PUT /board/:id` tolerates base64 but still cannot use a device `file://` path.

## Approach

Make it impossible for a local-only image (base64 **or** Android `file://`) to reach `POST /board` / `PUT /board/:id`. Upload it to `/media` first, and replace the tile image with the resulting URL in **both** local state and the server payload from the **same** uploaded URL, so the two never diverge.

- **Chokepoint:** the `createApiBoard` / `updateApiBoard` thunks — all sync sub-paths funnel through them.
- **Direct callers** (Import `syncBoardsWithAPI`, CommunicatorDialog `publishBoard`) call the pure `uploadBoardLocalImages` uploader directly, since they build local state from the post-upload result.
- **Two source types, one destination:** base64 uploads via `uploadFromDataURL`; `file://`/`cdvfile://` (Android only) reads the device file via `resolveLocalFileSystemURL` → `File` → `uploadFile`. Non-Android `file://` is left untouched.
- **Concurrency:** up to 5 images in parallel within a board.
- **Failure policy:** upload-first + deferral. On any tile failure, partial successes are committed locally and the board is deferred (stays `PENDING`, retried next cycle).

## Changes

- `src/helpers.js` — `isDataURL` / `isLocalFileURL` predicates.
- `src/api/api.js` — harden `uploadFromDataURL` (malformed data URL returns `null` instead of throwing); new `uploadBoardLocalImages(board)` returning `{ board, hadFailure }`.
- `src/components/Board/Board.actions.js` — new `sanitizeBoardImages` thunk (commits partial successes, rethrows on failure); wired into `createApiBoard` / `updateApiBoard` before the API call.
- `src/components/Settings/Import/Import.container.js` — sanitize before `API.createBoard` in `syncBoardsWithAPI`.
- `src/components/Communicator/CommunicatorDialog/CommunicatorDialog.container.js` — sanitize before `API.updateBoard` in `publishBoard`.

`sanitizeBoardImages` only dispatches `updateBoard` when the board actually changed (`uploadBoardLocalImages` returns the same reference when there are no local images), avoiding a redundant local write on every sync push.

## Tests

- `src/helpers.test.js` — `isDataURL` / `isLocalFileURL` truth tables.
- `uploadBoardLocalImages` in `src/api/api.test.js` — no-op, all-success (both source types), partial failure, non-Android `file://` left untouched.
- `sanitizeBoardImages` + `createApiBoard` sanitization in `src/components/Board/__tests__/Board.actions.test.js` — dispatch/rethrow behavior, and the regression that a previously-409'ing board reaches `createBoard` with URL-only tiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)