### PR TITLE
fix(board): sanitize base64 tile sounds before board create/update

### DIFF
--- a/src/api/__mocks__/api.js
+++ b/src/api/__mocks__/api.js
@@ -127,7 +127,7 @@ class API {
     });
   }
 
-  async uploadBoardLocalImages(board) {
+  async uploadBoardLocalMedia(board) {
     return { board, hadFailure: false };
   }
 

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -464,47 +464,81 @@ class API {
     return url;
   }
 
+  async uploadTileImageMedia(tile) {
+    if (isDataURL(tile.image)) {
+      const url = await this.uploadFromDataURL(tile.image, tile.id, true);
+      return { attempted: true, url };
+    }
+
+    if (isLocalFileURL(tile.image) && isAndroid()) {
+      const file = await new Promise(resolve => {
+        window.resolveLocalFileSystemURL(
+          tile.image,
+          fileEntry => {
+            fileEntry.file(file => resolve(file), () => resolve(null));
+          },
+          () => resolve(null)
+        );
+      });
+      if (file) {
+        const segments = tile.image.split('/');
+        const name = segments[segments.length - 1] || tile.id;
+        const url = await this.uploadFile(file, name);
+        return { attempted: true, url };
+      }
+      return { attempted: true, url: null };
+    }
+
+    return { attempted: false, url: null };
+  }
+
+  async uploadTileSoundMedia(tile) {
+    if (isDataURL(tile.sound)) {
+      const url = await this.uploadFromDataURL(tile.sound, `${tile.id}.mp3`);
+      return { attempted: true, url };
+    }
+
+    return { attempted: false, url: null };
+  }
+
   async uploadBoardLocalMedia(board) {
     const tiles = board?.tiles || [];
     const targets = tiles.filter(
-      tile => isDataURL(tile?.image) || isLocalFileURL(tile?.image)
+      tile =>
+        isDataURL(tile?.image) ||
+        isLocalFileURL(tile?.image) ||
+        isDataURL(tile?.sound)
     );
 
     if (!targets.length) {
       return { board, hadFailure: false };
     }
 
-    const urlByTileId = {};
+    const imageUrlByTileId = {};
+    const soundUrlByTileId = {};
     let hadFailure = false;
 
     const uploadTarget = async tile => {
       try {
-        let url = null;
-        if (isDataURL(tile.image)) {
-          url = await this.uploadFromDataURL(tile.image, tile.id, true);
-        } else if (isLocalFileURL(tile.image) && isAndroid()) {
-          const file = await new Promise(resolve => {
-            window.resolveLocalFileSystemURL(
-              tile.image,
-              fileEntry => {
-                fileEntry.file(file => resolve(file), () => resolve(null));
-              },
-              () => resolve(null)
-            );
-          });
-          if (file) {
-            const segments = tile.image.split('/');
-            const name = segments[segments.length - 1] || tile.id;
-            url = await this.uploadFile(file, name);
+        const [image, sound] = await Promise.all([
+          this.uploadTileImageMedia(tile),
+          this.uploadTileSoundMedia(tile)
+        ]);
+
+        if (image.attempted) {
+          if (image.url) {
+            imageUrlByTileId[tile.id] = image.url;
+          } else {
+            hadFailure = true;
           }
-        } else {
-          return;
         }
 
-        if (url) {
-          urlByTileId[tile.id] = url;
-        } else {
-          hadFailure = true;
+        if (sound.attempted) {
+          if (sound.url) {
+            soundUrlByTileId[tile.id] = sound.url;
+          } else {
+            hadFailure = true;
+          }
         }
       } catch (e) {
         hadFailure = true;
@@ -518,11 +552,18 @@ class API {
 
     const sanitizedBoard = {
       ...board,
-      tiles: tiles.map(tile =>
-        urlByTileId[(tile?.id)]
-          ? { ...tile, image: urlByTileId[tile.id] }
-          : tile
-      )
+      tiles: tiles.map(tile => {
+        const imageUrl = imageUrlByTileId[(tile?.id)];
+        const soundUrl = soundUrlByTileId[(tile?.id)];
+        if (!imageUrl && !soundUrl) {
+          return tile;
+        }
+        return {
+          ...tile,
+          ...(imageUrl ? { image: imageUrl } : {}),
+          ...(soundUrl ? { sound: soundUrl } : {})
+        };
+      })
     };
 
     return { board: sanitizedBoard, hadFailure };

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -464,7 +464,7 @@ class API {
     return url;
   }
 
-  async uploadBoardLocalImages(board) {
+  async uploadBoardLocalMedia(board) {
     const tiles = board?.tiles || [];
     const targets = tiles.filter(
       tile => isDataURL(tile?.image) || isLocalFileURL(tile?.image)

--- a/src/api/api.test.js
+++ b/src/api/api.test.js
@@ -291,6 +291,78 @@ describe('Cboard API calls', () => {
         'file:///storage/emulated/0/img.png'
       );
     });
+
+    it('replaces base64 sounds with uploaded urls on success', async () => {
+      jest
+        .spyOn(API, 'uploadFromDataURL')
+        .mockResolvedValue('https://cdn.example.com/sound.mp3');
+
+      const board = {
+        id: 'b1',
+        tiles: [
+          { id: 't1', sound: 'data:audio/mp3;base64,AAAA' },
+          { id: 't2', sound: 'https://cdn.example.com/keep.mp3' }
+        ]
+      };
+
+      const { board: sanitized, hadFailure } = await API.uploadBoardLocalMedia(
+        board
+      );
+
+      expect(hadFailure).toBe(false);
+      expect(API.uploadFromDataURL).toHaveBeenCalledWith(
+        'data:audio/mp3;base64,AAAA',
+        't1.mp3'
+      );
+      expect(sanitized.tiles[0].sound).toBe(
+        'https://cdn.example.com/sound.mp3'
+      );
+      expect(sanitized.tiles[1].sound).toBe('https://cdn.example.com/keep.mp3');
+    });
+
+    it('replaces both image and sound on the same tile', async () => {
+      jest
+        .spyOn(API, 'uploadFromDataURL')
+        .mockResolvedValueOnce('https://cdn.example.com/img.png')
+        .mockResolvedValueOnce('https://cdn.example.com/sound.mp3');
+
+      const board = {
+        id: 'b1',
+        tiles: [
+          {
+            id: 't1',
+            image: 'data:image/png;base64,AAAA',
+            sound: 'data:audio/mp3;base64,BBBB'
+          }
+        ]
+      };
+
+      const { board: sanitized, hadFailure } = await API.uploadBoardLocalMedia(
+        board
+      );
+
+      expect(hadFailure).toBe(false);
+      expect(sanitized.tiles[0].image).toBe('https://cdn.example.com/img.png');
+      expect(sanitized.tiles[0].sound).toBe(
+        'https://cdn.example.com/sound.mp3'
+      );
+    });
+
+    it('commits successes and flags hadFailure when a sound upload fails', async () => {
+      jest.spyOn(API, 'uploadFromDataURL').mockResolvedValue(null);
+
+      const board = {
+        id: 'b1',
+        tiles: [{ id: 't1', sound: 'data:audio/mp3;base64,AAAA' }]
+      };
+
+      const { board: sanitized, hadFailure } = await API.uploadBoardLocalMedia(
+        board
+      );
+
+      expect(hadFailure).toBe(true);
+      expect(sanitized.tiles[0].sound).toBe('data:audio/mp3;base64,AAAA');
+    });
   });
 
   it('fetches results from unauthorized api', () => {

--- a/src/api/api.test.js
+++ b/src/api/api.test.js
@@ -191,7 +191,7 @@ describe('Cboard API calls', () => {
       .catch(catchFn);
     mockAxios.mockResponse(mockBoard);
   });
-  describe('uploadBoardLocalImages', () => {
+  describe('uploadBoardLocalMedia', () => {
     afterEach(() => {
       jest.restoreAllMocks();
       isAndroid.mockReturnValue(false);
@@ -208,7 +208,7 @@ describe('Cboard API calls', () => {
       const uploadFromDataURL = jest.spyOn(API, 'uploadFromDataURL');
       const uploadFile = jest.spyOn(API, 'uploadFile');
 
-      const result = await API.uploadBoardLocalImages(board);
+      const result = await API.uploadBoardLocalMedia(board);
 
       expect(result).toEqual({ board, hadFailure: false });
       expect(uploadFromDataURL).not.toHaveBeenCalled();
@@ -237,7 +237,7 @@ describe('Cboard API calls', () => {
         ]
       };
 
-      const { board: sanitized, hadFailure } = await API.uploadBoardLocalImages(
+      const { board: sanitized, hadFailure } = await API.uploadBoardLocalMedia(
         board
       );
 
@@ -263,7 +263,7 @@ describe('Cboard API calls', () => {
         ]
       };
 
-      const { board: sanitized, hadFailure } = await API.uploadBoardLocalImages(
+      const { board: sanitized, hadFailure } = await API.uploadBoardLocalMedia(
         board
       );
 
@@ -281,7 +281,7 @@ describe('Cboard API calls', () => {
         tiles: [{ id: 't1', image: 'file:///storage/emulated/0/img.png' }]
       };
 
-      const { board: sanitized, hadFailure } = await API.uploadBoardLocalImages(
+      const { board: sanitized, hadFailure } = await API.uploadBoardLocalMedia(
         board
       );
 

--- a/src/components/Board/Board.actions.js
+++ b/src/components/Board/Board.actions.js
@@ -960,7 +960,7 @@ export function sanitizeBoardMedia(board) {
       dispatch(updateBoard(sanitized));
     }
     if (hadFailure) {
-      throw new Error('image upload failed');
+      throw new Error('media upload failed');
     }
     return sanitized;
   };

--- a/src/components/Board/Board.actions.js
+++ b/src/components/Board/Board.actions.js
@@ -951,9 +951,9 @@ export function syncBoards(remoteBoards) {
   };
 }
 
-export function sanitizeBoardImages(board) {
+export function sanitizeBoardMedia(board) {
   return async dispatch => {
-    const { board: sanitized, hadFailure } = await API.uploadBoardLocalImages(
+    const { board: sanitized, hadFailure } = await API.uploadBoardLocalMedia(
       board
     );
     if (sanitized !== board) {
@@ -974,7 +974,7 @@ export function createApiBoard(boardData, boardId) {
       isPublic: false
     };
     try {
-      boardData = await dispatch(sanitizeBoardImages(boardData));
+      boardData = await dispatch(sanitizeBoardMedia(boardData));
     } catch (err) {
       dispatch(createApiBoardFailure(err.message));
       throw new Error(err.message);
@@ -995,7 +995,7 @@ export function updateApiBoard(boardData) {
   return async dispatch => {
     dispatch(updateApiBoardStarted());
     try {
-      boardData = await dispatch(sanitizeBoardImages(boardData));
+      boardData = await dispatch(sanitizeBoardMedia(boardData));
     } catch (err) {
       dispatch(updateApiBoardFailure(err.message));
       throw new Error(err.message);

--- a/src/components/Board/__tests__/Board.actions.test.js
+++ b/src/components/Board/__tests__/Board.actions.test.js
@@ -1538,7 +1538,7 @@ describe('getApiMyBoards', () => {
   });
 });
 
-describe('sanitizeBoardImages', () => {
+describe('sanitizeBoardMedia', () => {
   afterEach(() => {
     jest.restoreAllMocks();
   });
@@ -1548,13 +1548,13 @@ describe('sanitizeBoardImages', () => {
       id: 'b1',
       tiles: [{ id: 't1', image: 'https://cdn.example.com/a.png' }]
     };
-    API.uploadBoardLocalImages = jest
+    API.uploadBoardLocalMedia = jest
       .fn()
       .mockResolvedValue({ board: sanitized, hadFailure: false });
     const store = mockStore({});
 
     const result = await store.dispatch(
-      actions.sanitizeBoardImages({ id: 'b1', tiles: [] })
+      actions.sanitizeBoardMedia({ id: 'b1', tiles: [] })
     );
 
     expect(result).toBe(sanitized);
@@ -1570,13 +1570,13 @@ describe('sanitizeBoardImages', () => {
       id: 'b1',
       tiles: [{ id: 't1', image: 'data:image/png;base64,AAAA' }]
     };
-    API.uploadBoardLocalImages = jest
+    API.uploadBoardLocalMedia = jest
       .fn()
       .mockResolvedValue({ board: sanitized, hadFailure: true });
     const store = mockStore({});
 
     await expect(
-      store.dispatch(actions.sanitizeBoardImages({ id: 'b1', tiles: [] }))
+      store.dispatch(actions.sanitizeBoardMedia({ id: 'b1', tiles: [] }))
     ).rejects.toThrow('image upload failed');
 
     expect(store.getActions()).toContainEqual({
@@ -1598,7 +1598,7 @@ describe('createApiBoard sanitization', () => {
       isPublic: false,
       tiles: [{ id: 't1', image: 'https://cdn.example.com/a.png' }]
     };
-    API.uploadBoardLocalImages = jest
+    API.uploadBoardLocalMedia = jest
       .fn()
       .mockResolvedValue({ board: sanitized, hadFailure: false });
     API.createBoard = jest.fn().mockResolvedValue(sanitized);
@@ -1631,7 +1631,7 @@ describe('createApiBoard sanitization', () => {
       isPublic: false,
       tiles: [{ id: 't1', image: 'data:image/png;base64,AAAA' }]
     };
-    API.uploadBoardLocalImages = jest
+    API.uploadBoardLocalMedia = jest
       .fn()
       .mockResolvedValue({ board: sanitized, hadFailure: true });
     API.createBoard = jest.fn();

--- a/src/components/Board/__tests__/Board.actions.test.js
+++ b/src/components/Board/__tests__/Board.actions.test.js
@@ -1577,8 +1577,30 @@ describe('sanitizeBoardMedia', () => {
 
     await expect(
       store.dispatch(actions.sanitizeBoardMedia({ id: 'b1', tiles: [] }))
-    ).rejects.toThrow('image upload failed');
+    ).rejects.toThrow('media upload failed');
 
+    expect(store.getActions()).toContainEqual({
+      type: types.UPDATE_BOARD,
+      boardData: sanitized,
+      fromRemote: false
+    });
+  });
+
+  it('dispatches updateBoard with the sanitized sound', async () => {
+    const sanitized = {
+      id: 'b1',
+      tiles: [{ id: 't1', sound: 'https://cdn.example.com/sound.mp3' }]
+    };
+    API.uploadBoardLocalMedia = jest
+      .fn()
+      .mockResolvedValue({ board: sanitized, hadFailure: false });
+    const store = mockStore({});
+
+    const result = await store.dispatch(
+      actions.sanitizeBoardMedia({ id: 'b1', tiles: [] })
+    );
+
+    expect(result).toBe(sanitized);
     expect(store.getActions()).toContainEqual({
       type: types.UPDATE_BOARD,
       boardData: sanitized,
@@ -1647,7 +1669,7 @@ describe('createApiBoard sanitization', () => {
           'b1'
         )
       )
-    ).rejects.toThrow('image upload failed');
+    ).rejects.toThrow('media upload failed');
 
     expect(API.createBoard).not.toHaveBeenCalled();
   });

--- a/src/components/Communicator/CommunicatorDialog/CommunicatorDialog.container.js
+++ b/src/components/Communicator/CommunicatorDialog/CommunicatorDialog.container.js
@@ -442,9 +442,7 @@ class CommunicatorDialogContainer extends React.Component {
     // Loggedin user?
     if ('name' in userData && 'email' in userData) {
       try {
-        const { board: sanitized } = await API.uploadBoardLocalImages(
-          boardData
-        );
+        const { board: sanitized } = await API.uploadBoardLocalMedia(boardData);
         replaceBoard(boardData, sanitized);
         const boardResponse = await API.updateBoard(sanitized);
         replaceBoard(sanitized, boardResponse);

--- a/src/components/Settings/Import/Import.container.js
+++ b/src/components/Settings/Import/Import.container.js
@@ -92,7 +92,7 @@ export class ImportContainer extends PureComponent {
             boardToCreate.name = 'unknow';
           }
           try {
-            const { board: sanitized } = await API.uploadBoardLocalImages(
+            const { board: sanitized } = await API.uploadBoardLocalMedia(
               boardToCreate
             );
             const response = await API.createBoard(sanitized);

--- a/src/components/Settings/Import/Import.container.js
+++ b/src/components/Settings/Import/Import.container.js
@@ -55,7 +55,10 @@ export class ImportContainer extends PureComponent {
         let boardToBeUpdated = board;
         if (shouldUpdate && updated) {
           try {
-            boardToBeUpdated = await API.updateBoard(boardToBeUpdated);
+            const { board: sanitized } = await API.uploadBoardLocalMedia(
+              boardToBeUpdated
+            );
+            boardToBeUpdated = await API.updateBoard(sanitized);
           } catch (err) {
             console.error(err.message);
           }


### PR DESCRIPTION
## Summary

Follow-up to #2242. That PR added a board-media sanitizer that uploads local-only tile **images** to `/media` before a board is created/updated on sync. It only inspected `tile.image`, so base64 **sounds** were left unhandled.

Recorded tile sounds are stored as base64 `data:` URLs (`VoiceRecorder` uses `FileReader.readAsDataURL`). A base64 `tile.sound` can reach the server on sync — the same failure class #2242 fixed for images — leaving the board `PENDING` and retried every cycle. The existing `Board.container.js#uploadTileSound` only converts sound on the interactive, logged-in edit path; anything that bypasses it (sound recorded offline / not logged in, or `uploadTileSound` failing silently) slips through.

Fixes #2245.

## Changes

- **`refactor(board)`** — rename `uploadBoardLocalImages` → `uploadBoardLocalMedia` and `sanitizeBoardImages` → `sanitizeBoardMedia` (pure rename, no behavior change).
- **`fix(board)`** — extend the sanitizer to also upload base64 `tile.sound` to `/media` and swap in the URL, with the same partial-success / defer-on-failure semantics used for images. Per-tile image and sound uploads run in parallel via dedicated `uploadTileImageMedia` / `uploadTileSoundMedia` helpers; the orchestrator keeps the 5-tile concurrency batching, `hadFailure` aggregation, and board reconstruction.

Sound is only ever a base64 `data:` URL (recordings are never `file://`), so it uses the data-URL path only.

## Behavior on failure (unchanged from #2242)

- A single failed upload leaves that field un-replaced and sets `hadFailure`; other tiles still process.
- Partial successes are committed locally via `updateBoard` before deferring.
- If anything failed, the board's server create/update is skipped this cycle and stays `PENDING`, retried next cycle.

## Testing

- `uploadBoardLocalMedia`: added cases for base64 sound replacement, a tile carrying both image + sound, and sound-upload failure flagging `hadFailure`.
- `sanitizeBoardMedia`: added a sanitized-sound dispatch case.
- New media-sanitizer tests pass locally; the pre-existing `axios`-mock cases in `api.test.js` are unchanged (the cordova-util mock is left identical to master).

## Notes

- The redundant `Board.container.js#uploadTileSound` fast-path is left in place (immediate local-state update); the chokepoint sanitizer now acts as the safety net. Possible future consolidation.
- Assumes the server rejects base64 `sound` like it rejects base64 `image` — the existence of `uploadTileSound` is the evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
