### PR TITLE
Use audio MIME type for sound upload filenames

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -17,6 +17,22 @@ const BASE_URL = API_URL;
 const LOCAL_COMMUNICATOR_ID = 'cboard_default';
 export let improvePhraseAbortController;
 
+const audioExtensionByMimeType = {
+  'audio/mp3': 'mp3',
+  'audio/mpeg': 'mp3',
+  'audio/mp4': 'mp4',
+  'audio/ogg': 'ogg',
+  'audio/webm': 'webm'
+};
+
+const audioExtensionFromDataURL = dataURL => {
+  const mimeType = dataURL.match(/^data:(audio\/[^;,]+)/i)?.[1].toLowerCase();
+  if (!mimeType) {
+    return 'mp3';
+  }
+  return audioExtensionByMimeType[mimeType] || mimeType.split('/')[1] || 'mp3';
+};
+
 const getUserData = () => {
   const store = getStore();
   const {
@@ -494,7 +510,11 @@ class API {
 
   async uploadTileSoundMedia(tile) {
     if (isDataURL(tile.sound)) {
-      const url = await this.uploadFromDataURL(tile.sound, `${tile.id}.mp3`);
+      const extension = audioExtensionFromDataURL(tile.sound);
+      const url = await this.uploadFromDataURL(
+        tile.sound,
+        `${tile.id}.${extension}`
+      );
       return { attempted: true, url };
     }
 

--- a/src/api/api.test.js
+++ b/src/api/api.test.js
@@ -9,6 +9,7 @@ import { isAndroid } from '../cordova-util';
 
 jest.mock('../store');
 jest.mock('../cordova-util', () => ({
+  isCordova: jest.fn(() => false),
   isAndroid: jest.fn(() => false)
 }));
 
@@ -318,6 +319,30 @@ describe('Cboard API calls', () => {
         'https://cdn.example.com/sound.mp3'
       );
       expect(sanitized.tiles[1].sound).toBe('https://cdn.example.com/keep.mp3');
+    });
+
+    it('uses the sound data URL MIME type for uploaded filenames', async () => {
+      jest
+        .spyOn(API, 'uploadFromDataURL')
+        .mockResolvedValue('https://cdn.example.com/sound.webm');
+
+      const board = {
+        id: 'b1',
+        tiles: [{ id: 't1', sound: 'data:audio/webm;base64,AAAA' }]
+      };
+
+      const { board: sanitized, hadFailure } = await API.uploadBoardLocalMedia(
+        board
+      );
+
+      expect(hadFailure).toBe(false);
+      expect(API.uploadFromDataURL).toHaveBeenCalledWith(
+        'data:audio/webm;base64,AAAA',
+        't1.webm'
+      );
+      expect(sanitized.tiles[0].sound).toBe(
+        'https://cdn.example.com/sound.webm'
+      );
     });
 
     it('replaces both image and sound on the same tile', async () => {


### PR DESCRIPTION
## Summary

- derive uploaded tile sound filename extensions from the sound data URL MIME type
- keep the shared image upload path unchanged
- add a regression test for `audio/webm` producing a `.webm` filename

## Notes

This follows the self-contained API path from #2250. I left the older board component upload path unchanged to keep this PR focused.

## Test

- `yarn test src/api/api.test.js --watchAll=false --runInBand --testNamePattern=uploadBoardLocalMedia`

Closes #2250