### PR TITLE
fix(media): reliable Android tile media upload + stop PENDING-forever boards

### DIFF
--- a/src/__test__/helpers.test.js
+++ b/src/__test__/helpers.test.js
@@ -1,13 +1,9 @@
 import * as helpers from '../helpers';
 describe('helpers', () => {
-  it('should create a file from data', () => {
+  it('should create a blob from a data URL', () => {
     const dataUrl = 'data:text/plain;charset=utf-8;base64,dGVzdGluZw==';
-    const file = helpers.dataURLtoFile(dataUrl, 'myfile');
-    expect(file.name).toBe('myfile');
-  });
-  it('should create a file with ext from data', () => {
-    const dataUrl = 'data:text/plain;charset=utf-8;base64,dGVzdGluZw==';
-    const file = helpers.dataURLtoFile(dataUrl, 'myfile.txt', true);
-    expect(file.name).toBe('myfile.txt.plain');
+    const blob = helpers.dataURLtoBlob(dataUrl);
+    expect(blob.type).toBe('text/plain');
+    expect(blob.size).toBe(7);
   });
 });

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -20,6 +20,12 @@ import { cvaFileToBlob, isAndroid } from '../cordova-util';
 
 const BASE_URL = API_URL;
 const LOCAL_COMMUNICATOR_ID = 'cboard_default';
+
+const FILE_NOT_FOUND_ERR = 1;
+const FILE_ENCODING_ERR = 5;
+const isUnrecoverableFileError = error =>
+  !!error &&
+  (error.code === FILE_NOT_FOUND_ERR || error.code === FILE_ENCODING_ERR);
 export let improvePhraseAbortController;
 
 const getUserData = () => {
@@ -499,22 +505,29 @@ class API {
     }
 
     if (isLocalFileURL(tile.image) && isAndroid()) {
-      const file = await new Promise(resolve => {
+      const resolved = await new Promise(resolve => {
         window.resolveLocalFileSystemURL(
           tile.image,
           fileEntry => {
-            fileEntry.file(file => resolve(file), () => resolve(null));
+            fileEntry.file(
+              file => resolve({ file }),
+              error => resolve({ error })
+            );
           },
-          () => resolve(null)
+          error => resolve({ error })
         );
       });
-      if (!file) {
-        return { attempted: true, url: null, unrecoverable: true };
+      if (!resolved.file) {
+        return {
+          attempted: true,
+          url: null,
+          unrecoverable: isUnrecoverableFileError(resolved.error)
+        };
       }
 
       let realBlob;
       try {
-        realBlob = await cvaFileToBlob(file, 'image/png');
+        realBlob = await cvaFileToBlob(resolved.file, 'image/png');
       } catch (e) {
         return { attempted: true, url: null, unrecoverable: true };
       }

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -459,25 +459,43 @@ class API {
     return data;
   }
 
-  async uploadFromDataURL(dataURL, filename, checkExtension = false) {
-    let url = null;
+  async tryUploadDataURL(dataURL, filename, checkExtension = false) {
+    let blob;
     try {
-      const blob = dataURLtoBlob(dataURL);
-      let name = filename;
-      if (checkExtension) {
-        const extension = (blob.type.split('/')[1] || 'png').toLowerCase();
-        name = `${filename}.${extension}`;
-      }
-      url = await this.uploadFile(blob, name);
-    } catch (e) {}
+      blob = dataURLtoBlob(dataURL);
+    } catch (e) {
+      return { url: null, unrecoverable: true };
+    }
+    let name = filename;
+    if (checkExtension) {
+      const extension = (blob.type.split('/')[1] || 'png').toLowerCase();
+      name = `${filename}.${extension}`;
+    }
+    try {
+      const url = await this.uploadFile(blob, name);
+      return { url, unrecoverable: false };
+    } catch (e) {
+      return { url: null, unrecoverable: false };
+    }
+  }
 
+  async uploadFromDataURL(dataURL, filename, checkExtension = false) {
+    const { url } = await this.tryUploadDataURL(
+      dataURL,
+      filename,
+      checkExtension
+    );
     return url;
   }
 
   async uploadTileImageMedia(tile) {
     if (isDataURL(tile.image)) {
-      const url = await this.uploadFromDataURL(tile.image, tile.id, true);
-      return { attempted: true, url };
+      const { url, unrecoverable } = await this.tryUploadDataURL(
+        tile.image,
+        tile.id,
+        true
+      );
+      return { attempted: true, url, unrecoverable };
     }
 
     if (isLocalFileURL(tile.image) && isAndroid()) {
@@ -490,34 +508,48 @@ class API {
           () => resolve(null)
         );
       });
-      if (file) {
+      if (!file) {
+        return { attempted: true, url: null, unrecoverable: true };
+      }
+
+      let realBlob;
+      try {
         const arrayBuffer = await new Promise((resolve, reject) => {
           const reader = new FileReader();
           reader.onloadend = () => resolve(reader.result);
           reader.onerror = () => reject(reader.error);
           reader.readAsArrayBuffer(file);
         });
-        const realBlob = new Blob([arrayBuffer], {
+        realBlob = new Blob([arrayBuffer], {
           type: file.type || 'image/png'
         });
+      } catch (e) {
+        return { attempted: true, url: null, unrecoverable: true };
+      }
+
+      try {
         const segments = tile.image.split('/');
         const name = segments[segments.length - 1] || tile.id;
         const url = await this.uploadFile(realBlob, name);
-        return { attempted: true, url };
+        return { attempted: true, url, unrecoverable: false };
+      } catch (e) {
+        return { attempted: true, url: null, unrecoverable: false };
       }
-      return { attempted: true, url: null };
     }
 
-    return { attempted: false, url: null };
+    return { attempted: false, url: null, unrecoverable: false };
   }
 
   async uploadTileSoundMedia(tile) {
     if (isDataURL(tile.sound)) {
-      const url = await this.uploadFromDataURL(tile.sound, `${tile.id}.mp3`);
-      return { attempted: true, url };
+      const { url, unrecoverable } = await this.tryUploadDataURL(
+        tile.sound,
+        `${tile.id}.mp3`
+      );
+      return { attempted: true, url, unrecoverable };
     }
 
-    return { attempted: false, url: null };
+    return { attempted: false, url: null, unrecoverable: false };
   }
 
   async uploadBoardLocalMedia(board) {
@@ -535,6 +567,8 @@ class API {
 
     const imageUrlByTileId = {};
     const soundUrlByTileId = {};
+    const clearImageTileIds = new Set();
+    const clearSoundTileIds = new Set();
     let hadFailure = false;
 
     const uploadTarget = async tile => {
@@ -547,6 +581,8 @@ class API {
         if (image.attempted) {
           if (image.url) {
             imageUrlByTileId[tile.id] = image.url;
+          } else if (image.unrecoverable) {
+            clearImageTileIds.add(tile.id);
           } else {
             hadFailure = true;
           }
@@ -555,6 +591,8 @@ class API {
         if (sound.attempted) {
           if (sound.url) {
             soundUrlByTileId[tile.id] = sound.url;
+          } else if (sound.unrecoverable) {
+            clearSoundTileIds.add(tile.id);
           } else {
             hadFailure = true;
           }
@@ -574,13 +612,15 @@ class API {
       tiles: tiles.map(tile => {
         const imageUrl = imageUrlByTileId[(tile?.id)];
         const soundUrl = soundUrlByTileId[(tile?.id)];
-        if (!imageUrl && !soundUrl) {
+        const clearImage = clearImageTileIds.has(tile?.id);
+        const clearSound = clearSoundTileIds.has(tile?.id);
+        if (!imageUrl && !soundUrl && !clearImage && !clearSound) {
           return tile;
         }
         return {
           ...tile,
-          ...(imageUrl ? { image: imageUrl } : {}),
-          ...(soundUrl ? { sound: soundUrl } : {})
+          ...(imageUrl ? { image: imageUrl } : clearImage ? { image: '' } : {}),
+          ...(soundUrl ? { sound: soundUrl } : clearSound ? { sound: '' } : {})
         };
       })
     };

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -9,7 +9,12 @@ import {
   AZURE_SPEECH_SUBSCR_KEY
 } from '../constants';
 import { getStore } from '../store';
-import { dataURLtoFile, isDataURL, isLocalFileURL } from '../helpers';
+import {
+  convertMediaUrlToCDN,
+  dataURLtoBlob,
+  isDataURL,
+  isLocalFileURL
+} from '../helpers';
 import { logout } from '../components/Account/Login/Login.actions.js';
 import { isAndroid } from '../cordova-util';
 
@@ -457,8 +462,13 @@ class API {
   async uploadFromDataURL(dataURL, filename, checkExtension = false) {
     let url = null;
     try {
-      const file = dataURLtoFile(dataURL, filename, checkExtension);
-      url = await this.uploadFile(file, filename);
+      const blob = dataURLtoBlob(dataURL);
+      let name = filename;
+      if (checkExtension) {
+        const extension = (blob.type.split('/')[1] || 'png').toLowerCase();
+        name = `${filename}.${extension}`;
+      }
+      url = await this.uploadFile(blob, name);
     } catch (e) {}
 
     return url;
@@ -481,9 +491,18 @@ class API {
         );
       });
       if (file) {
+        const arrayBuffer = await new Promise((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onloadend = () => resolve(reader.result);
+          reader.onerror = () => reject(reader.error);
+          reader.readAsArrayBuffer(file);
+        });
+        const realBlob = new Blob([arrayBuffer], {
+          type: file.type || 'image/png'
+        });
         const segments = tile.image.split('/');
         const name = segments[segments.length - 1] || tile.id;
-        const url = await this.uploadFile(file, name);
+        const url = await this.uploadFile(realBlob, name);
         return { attempted: true, url };
       }
       return { attempted: true, url: null };
@@ -586,7 +605,8 @@ class API {
       headers
     });
 
-    return response.data.url;
+    const url = response.data.url;
+    return (url && convertMediaUrlToCDN(url)) || url;
   }
 
   async createCommunicator(communicator) {

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -16,7 +16,7 @@ import {
   isLocalFileURL
 } from '../helpers';
 import { logout } from '../components/Account/Login/Login.actions.js';
-import { isAndroid } from '../cordova-util';
+import { cvaFileToBlob, isAndroid } from '../cordova-util';
 
 const BASE_URL = API_URL;
 const LOCAL_COMMUNICATOR_ID = 'cboard_default';
@@ -514,15 +514,7 @@ class API {
 
       let realBlob;
       try {
-        const arrayBuffer = await new Promise((resolve, reject) => {
-          const reader = new FileReader();
-          reader.onloadend = () => resolve(reader.result);
-          reader.onerror = () => reject(reader.error);
-          reader.readAsArrayBuffer(file);
-        });
-        realBlob = new Blob([arrayBuffer], {
-          type: file.type || 'image/png'
-        });
+        realBlob = await cvaFileToBlob(file, 'image/png');
       } catch (e) {
         return { attempted: true, url: null, unrecoverable: true };
       }
@@ -565,10 +557,7 @@ class API {
       return { board, hadFailure: false };
     }
 
-    const imageUrlByTileId = {};
-    const soundUrlByTileId = {};
-    const clearImageTileIds = new Set();
-    const clearSoundTileIds = new Set();
+    const tileUpdates = {};
     let hadFailure = false;
 
     const uploadTarget = async tile => {
@@ -578,11 +567,12 @@ class API {
           this.uploadTileSoundMedia(tile)
         ]);
 
+        const update = {};
         if (image.attempted) {
           if (image.url) {
-            imageUrlByTileId[tile.id] = image.url;
+            update.image = image.url;
           } else if (image.unrecoverable) {
-            clearImageTileIds.add(tile.id);
+            update.image = '';
           } else {
             hadFailure = true;
           }
@@ -590,12 +580,16 @@ class API {
 
         if (sound.attempted) {
           if (sound.url) {
-            soundUrlByTileId[tile.id] = sound.url;
+            update.sound = sound.url;
           } else if (sound.unrecoverable) {
-            clearSoundTileIds.add(tile.id);
+            update.sound = '';
           } else {
             hadFailure = true;
           }
+        }
+
+        if (Object.keys(update).length) {
+          tileUpdates[tile.id] = update;
         }
       } catch (e) {
         hadFailure = true;
@@ -610,18 +604,8 @@ class API {
     const sanitizedBoard = {
       ...board,
       tiles: tiles.map(tile => {
-        const imageUrl = imageUrlByTileId[(tile?.id)];
-        const soundUrl = soundUrlByTileId[(tile?.id)];
-        const clearImage = clearImageTileIds.has(tile?.id);
-        const clearSound = clearSoundTileIds.has(tile?.id);
-        if (!imageUrl && !soundUrl && !clearImage && !clearSound) {
-          return tile;
-        }
-        return {
-          ...tile,
-          ...(imageUrl ? { image: imageUrl } : clearImage ? { image: '' } : {}),
-          ...(soundUrl ? { sound: soundUrl } : clearSound ? { sound: '' } : {})
-        };
+        const update = tileUpdates[(tile?.id)];
+        return update ? { ...tile, ...update } : tile;
       })
     };
 

--- a/src/api/api.test.js
+++ b/src/api/api.test.js
@@ -221,9 +221,10 @@ describe('Cboard API calls', () => {
       window.resolveLocalFileSystemURL = jest.fn((url, success) =>
         success({ file: cb => cb(file) })
       );
-      jest
-        .spyOn(API, 'uploadFromDataURL')
-        .mockResolvedValue('https://cdn.example.com/base64.png');
+      jest.spyOn(API, 'tryUploadDataURL').mockResolvedValue({
+        url: 'https://cdn.example.com/base64.png',
+        unrecoverable: false
+      });
       jest
         .spyOn(API, 'uploadFile')
         .mockResolvedValue('https://cdn.example.com/file.png');
@@ -251,9 +252,12 @@ describe('Cboard API calls', () => {
 
     it('commits successes and flags hadFailure on partial failure', async () => {
       jest
-        .spyOn(API, 'uploadFromDataURL')
-        .mockResolvedValueOnce('https://cdn.example.com/ok.png')
-        .mockResolvedValueOnce(null);
+        .spyOn(API, 'tryUploadDataURL')
+        .mockResolvedValueOnce({
+          url: 'https://cdn.example.com/ok.png',
+          unrecoverable: false
+        })
+        .mockResolvedValueOnce({ url: null, unrecoverable: false });
 
       const board = {
         id: 'b1',
@@ -293,9 +297,10 @@ describe('Cboard API calls', () => {
     });
 
     it('replaces base64 sounds with uploaded urls on success', async () => {
-      jest
-        .spyOn(API, 'uploadFromDataURL')
-        .mockResolvedValue('https://cdn.example.com/sound.mp3');
+      jest.spyOn(API, 'tryUploadDataURL').mockResolvedValue({
+        url: 'https://cdn.example.com/sound.mp3',
+        unrecoverable: false
+      });
 
       const board = {
         id: 'b1',
@@ -310,7 +315,7 @@ describe('Cboard API calls', () => {
       );
 
       expect(hadFailure).toBe(false);
-      expect(API.uploadFromDataURL).toHaveBeenCalledWith(
+      expect(API.tryUploadDataURL).toHaveBeenCalledWith(
         'data:audio/mp3;base64,AAAA',
         't1.mp3'
       );
@@ -322,9 +327,15 @@ describe('Cboard API calls', () => {
 
     it('replaces both image and sound on the same tile', async () => {
       jest
-        .spyOn(API, 'uploadFromDataURL')
-        .mockResolvedValueOnce('https://cdn.example.com/img.png')
-        .mockResolvedValueOnce('https://cdn.example.com/sound.mp3');
+        .spyOn(API, 'tryUploadDataURL')
+        .mockResolvedValueOnce({
+          url: 'https://cdn.example.com/img.png',
+          unrecoverable: false
+        })
+        .mockResolvedValueOnce({
+          url: 'https://cdn.example.com/sound.mp3',
+          unrecoverable: false
+        });
 
       const board = {
         id: 'b1',
@@ -349,7 +360,9 @@ describe('Cboard API calls', () => {
     });
 
     it('commits successes and flags hadFailure when a sound upload fails', async () => {
-      jest.spyOn(API, 'uploadFromDataURL').mockResolvedValue(null);
+      jest
+        .spyOn(API, 'tryUploadDataURL')
+        .mockResolvedValue({ url: null, unrecoverable: false });
 
       const board = {
         id: 'b1',
@@ -362,6 +375,49 @@ describe('Cboard API calls', () => {
 
       expect(hadFailure).toBe(true);
       expect(sanitized.tiles[0].sound).toBe('data:audio/mp3;base64,AAAA');
+    });
+
+    it('clears media and does not flag failure when it cannot be retrieved', async () => {
+      jest
+        .spyOn(API, 'tryUploadDataURL')
+        .mockResolvedValue({ url: null, unrecoverable: true });
+
+      const board = {
+        id: 'b1',
+        tiles: [
+          { id: 't1', image: 'data:image/png;base64,@@@' },
+          { id: 't2', sound: 'data:audio/mp3;base64,@@@' }
+        ]
+      };
+
+      const { board: sanitized, hadFailure } = await API.uploadBoardLocalMedia(
+        board
+      );
+
+      expect(hadFailure).toBe(false);
+      expect(sanitized.tiles[0].image).toBe('');
+      expect(sanitized.tiles[1].sound).toBe('');
+    });
+
+    it('clears an unresolvable file image and does not flag failure', async () => {
+      isAndroid.mockReturnValue(true);
+      window.resolveLocalFileSystemURL = jest.fn((url, success, error) =>
+        error()
+      );
+      const uploadFile = jest.spyOn(API, 'uploadFile');
+
+      const board = {
+        id: 'b1',
+        tiles: [{ id: 't1', image: 'file:///storage/emulated/0/gone.png' }]
+      };
+
+      const { board: sanitized, hadFailure } = await API.uploadBoardLocalMedia(
+        board
+      );
+
+      expect(hadFailure).toBe(false);
+      expect(uploadFile).not.toHaveBeenCalled();
+      expect(sanitized.tiles[0].image).toBe('');
     });
   });
 

--- a/src/api/api.test.js
+++ b/src/api/api.test.js
@@ -400,10 +400,10 @@ describe('Cboard API calls', () => {
       expect(sanitized.tiles[1].sound).toBe('');
     });
 
-    it('clears an unresolvable file image and does not flag failure', async () => {
+    it('clears a not-found file image and does not flag failure', async () => {
       isAndroid.mockReturnValue(true);
       window.resolveLocalFileSystemURL = jest.fn((url, success, error) =>
-        error()
+        error({ code: 1 })
       );
       const uploadFile = jest.spyOn(API, 'uploadFile');
 
@@ -419,6 +419,29 @@ describe('Cboard API calls', () => {
       expect(hadFailure).toBe(false);
       expect(uploadFile).not.toHaveBeenCalled();
       expect(sanitized.tiles[0].image).toBe('');
+    });
+
+    it('keeps a file image and flags failure on a transient resolve error', async () => {
+      isAndroid.mockReturnValue(true);
+      window.resolveLocalFileSystemURL = jest.fn((url, success, error) =>
+        error({ code: 2 })
+      );
+      const uploadFile = jest.spyOn(API, 'uploadFile');
+
+      const board = {
+        id: 'b1',
+        tiles: [{ id: 't1', image: 'file:///storage/emulated/0/img.png' }]
+      };
+
+      const { board: sanitized, hadFailure } = await API.uploadBoardLocalMedia(
+        board
+      );
+
+      expect(hadFailure).toBe(true);
+      expect(uploadFile).not.toHaveBeenCalled();
+      expect(sanitized.tiles[0].image).toBe(
+        'file:///storage/emulated/0/img.png'
+      );
     });
   });
 

--- a/src/api/api.test.js
+++ b/src/api/api.test.js
@@ -9,6 +9,7 @@ import { isAndroid } from '../cordova-util';
 
 jest.mock('../store');
 jest.mock('../cordova-util', () => ({
+  ...jest.requireActual('../cordova-util'),
   isAndroid: jest.fn(() => false)
 }));
 

--- a/src/components/Board/TileEditor/TileEditor.component.js
+++ b/src/components/Board/TileEditor/TileEditor.component.js
@@ -38,10 +38,9 @@ import API from '../../../api';
 import {
   isAndroid,
   isCordova,
-  requestCvaPermissions,
-  writeCvaFile
+  requestCvaPermissions
 } from '../../../cordova-util';
-import { convertImageUrlToCatchable, resolveBoardName } from '../../../helpers';
+import { resolveBoardName } from '../../../helpers';
 import PremiumFeature from '../../PremiumFeature';
 import LoadBoardEditor from './LoadBoardEditor/LoadBoardEditor';
 import { Typography } from '@material-ui/core';
@@ -228,30 +227,13 @@ export class TileEditor extends Component {
     const { userData } = this.props;
     const user = userData.email ? userData : null;
     if (user) {
-      // this.setState({
-      //   loading: true
-      // });
       try {
-        const imageUrl = await API.uploadFile(blob, fileName);
-        // console.log('imagen guardada en servidor', imageUrl);
-        return convertImageUrlToCatchable(imageUrl) || imageUrl;
+        return await API.uploadFile(blob, fileName);
       } catch (error) {
-        //console.log('imagen no guardad en servidor');
-        return await this.blobToBase64(blob);
-      }
-      // } finally {
-      //   this.setState({
-      //     loading: false
-      //   });
-    } else {
-      if (isAndroid()) {
-        const filePath = '/Android/data/com.unicef.cboard/files/' + fileName;
-        const fEntry = await writeCvaFile(filePath, blob);
-        return fEntry.nativeURL;
-      } else {
         return await this.blobToBase64(blob);
       }
     }
+    return await this.blobToBase64(blob);
   };
 
   blobToBase64 = async blob => {

--- a/src/cordova-util.js
+++ b/src/cordova-util.js
@@ -209,6 +209,15 @@ export const readCvaFile = async name => {
   }
 };
 
+export const cvaFileToBlob = (file, fallbackType) =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () =>
+      resolve(new Blob([reader.result], { type: file.type || fallbackType }));
+    reader.onerror = () => reject(reader.error);
+    reader.readAsArrayBuffer(file);
+  });
+
 export const writeCvaFile = async (name, blob) => {
   if (isCordova()) {
     return new Promise(function(resolve, reject) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -14,28 +14,33 @@ export const isDataURL = str =>
 export const isLocalFileURL = str =>
   typeof str === 'string' && /^(file|cdvfile):/i.test(str);
 
-export const dataURLtoFile = (dataurl, filename, checkExtension = false) => {
-  // https://stackoverflow.com/a/38936042
+export const dataURLtoBlob = dataurl => {
   const arr = dataurl.split(',');
   const type = arr[0].match(/:(.*?);/)[1];
   const bstr = atob(arr[1]);
   let n = bstr.length;
   const u8arr = new Uint8Array(n);
 
-  let name = filename;
-  if (checkExtension) {
-    const extension = type.split('/')[1].toLowerCase();
-    name = `${name}.${extension}`;
-  }
-
   while (n--) {
     u8arr[n] = bstr.charCodeAt(n);
   }
 
-  return new File([u8arr], name, { type });
+  return new Blob([u8arr], { type });
 };
 
-export const convertImageUrlToCatchable = imageUrl => {
+export const dataURLtoFile = (dataurl, filename, checkExtension = false) => {
+  const blob = dataURLtoBlob(dataurl);
+
+  let name = filename;
+  if (checkExtension) {
+    const extension = blob.type.split('/')[1].toLowerCase();
+    name = `${name}.${extension}`;
+  }
+
+  return new File([blob], name, { type: blob.type });
+};
+
+export const convertMediaUrlToCDN = imageUrl => {
   const CBOARD_PRODUCTION_BLOB_CONTAINER_HOSTNAME =
     'cboardgroupdiag483.blob.core.windows.net';
   const PROTOCOL_LENGHT = 8;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -28,18 +28,6 @@ export const dataURLtoBlob = dataurl => {
   return new Blob([u8arr], { type });
 };
 
-export const dataURLtoFile = (dataurl, filename, checkExtension = false) => {
-  const blob = dataURLtoBlob(dataurl);
-
-  let name = filename;
-  if (checkExtension) {
-    const extension = blob.type.split('/')[1].toLowerCase();
-    name = `${name}.${extension}`;
-  }
-
-  return new File([blob], name, { type: blob.type });
-};
-
 export const convertMediaUrlToCDN = imageUrl => {
   const CBOARD_PRODUCTION_BLOB_CONTAINER_HOSTNAME =
     'cboardgroupdiag483.blob.core.windows.net';


### PR DESCRIPTION
Closes #2253

## What

Fixes two Android media-sync problems:

1. **Uploads fail with `status 0` / 0 bytes.** Tile media stored as base64 (`data:`) or `file://` was uploaded as a `File` reconstructed from a `Uint8Array` (or a raw Cordova `File`), which the Android WebView does not serialize into the multipart body. Now everything is uploaded as a real `Blob`:
   - base64 → `dataURLtoBlob` (decode with `atob`, CSP-safe — no `fetch` of `data:` URLs, which the CSP blocks).
   - `file://` → read bytes via `FileReader.readAsArrayBuffer` → `Blob`.
2. **Boards stuck in `PENDING` forever.** Media that can never be retrieved on this device (a `file://` from another device that doesn't resolve/read, or an undecodable base64) is now replaced with `''` instead of flagging a failure, so the board syncs. Genuine transient upload/network failures still keep the board `PENDING` and retry.

## How

- `tryUploadDataURL` splits decode (unrecoverable) from upload (transient) and returns `{ url, unrecoverable }`.
- `uploadTileImageMedia` / `uploadTileSoundMedia` thread the `unrecoverable` flag; `file://` resolve/read failures are unrecoverable, POST failures are transient.
- `uploadBoardLocalMedia` clears unrecoverable media to `''` (no `hadFailure`) and only flags `hadFailure` for transient failures.
- `updateTileImgURL` (TileEditor) simplified: no longer generates new `file://` images; always falls back to base64 when not logged in.
- CDN URL rewriting (`convertMediaUrlToCDN`) centralized in `uploadFile`, so images **and** sounds pass through it.

## Notes

- The `file://` read branch is kept as a migration path for tiles saved by older app versions.
- Tests updated in `api.test.js` (mock `tryUploadDataURL`; new cases: undecodable base64 → `''`, unresolvable `file://` → `''`, both without `hadFailure`).

## Follow-up (out of scope)

- Persistent server rejection of valid bytes still loops as PENDING — a retry cap could be added later.
- `Board.container.uploadTileSound` duplicates the base64→Blob sound-upload path; consolidate on `dataURLtoBlob` (tech debt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)