### PR TITLE
feat: add profile-based multi-step signup flow (#2248)

### DIFF
--- a/src/components/Account/SignUp/SignUp.component.js
+++ b/src/components/Account/SignUp/SignUp.component.js
@@ -11,9 +11,13 @@ import DialogContent from '@material-ui/core/DialogContent';
 import DialogActions from '@material-ui/core/DialogActions';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox from '@material-ui/core/Checkbox';
+import MenuItem from '@material-ui/core/MenuItem';
 import { TextField } from '../../UI/FormItems';
 import LoadingIcon from '../../UI/LoadingIcon';
-import validationSchema from './validationSchema';
+import {
+  validationSchemaStep1,
+  validationSchemaStep2
+} from './validationSchema';
 import { signUp } from './SignUp.actions';
 import messages from './SignUp.messages';
 import './SignUp.css';
@@ -24,6 +28,7 @@ function SignUp(props) {
 
   const [isSigningUp, setIsSigningUp] = useState(false);
   const [signUpStatus, setSignUpStatus] = useState({});
+  const [step, setStep] = useState(1);
 
   const isButtonDisabled = isSigningUp || !!signUpStatus.success;
 
@@ -31,12 +36,20 @@ function SignUp(props) {
     () => {
       if (isDialogOpen) {
         setSignUpStatus({});
+        setStep(1);
       }
     },
     [isDialogOpen]
   );
 
-  async function handleSubmit(values) {
+  async function handleSubmit(values, formikActions) {
+    if (step === 1) {
+      setStep(2);
+      formikActions.setTouched({});
+      formikActions.setSubmitting(false);
+      return;
+    }
+
     const { passwordConfirm, ...formValues } = values;
 
     setIsSigningUp(true);
@@ -53,17 +66,24 @@ function SignUp(props) {
       setSignUpStatus({ success: false, message });
     } finally {
       setIsSigningUp(false);
+      formikActions.setSubmitting(false);
     }
   }
 
   const { dialogStyle, dialogContentStyle } = dialogWithKeyboardStyle ?? {};
-  const values = {
+  const initialValues = {
     name: '',
     email: '',
     password: '',
     passwordConfirm: '',
-    isTermsAccepted: false
+    isTermsAccepted: false,
+    role: '',
+    age: '',
+    pathology: []
   };
+
+  const currentValidationSchema =
+    step === 1 ? validationSchemaStep1 : validationSchemaStep2;
 
   return (
     <Dialog
@@ -87,93 +107,219 @@ function SignUp(props) {
         {signUpStatus && !signUpStatus.success && (
           <Formik
             onSubmit={handleSubmit}
-            validationSchema={validationSchema}
-            initialValues={values}
+            validationSchema={currentValidationSchema}
+            initialValues={initialValues}
           >
-            {({ errors, handleChange, handleSubmit }) => (
+            {({ errors, handleChange, handleSubmit, values }) => (
               <form className="SignUp__form" onSubmit={handleSubmit}>
-                <TextField
-                  name="name"
-                  label={intl.formatMessage(messages.name)}
-                  error={errors.name}
-                  onChange={handleChange}
-                />
-                <TextField
-                  name="email"
-                  label={intl.formatMessage(messages.email)}
-                  error={errors.email}
-                  onChange={handleChange}
-                />
-                <PasswordTextField
-                  error={errors.password}
-                  label={intl.formatMessage(messages.createYourPassword)}
-                  name="password"
-                  onChange={handleChange}
-                />
-                <PasswordTextField
-                  error={errors.passwordConfirm}
-                  label={intl.formatMessage(messages.confirmYourPassword)}
-                  name="passwordConfirm"
-                  onChange={handleChange}
-                />
-                <FormControlLabel
-                  control={
-                    <Checkbox
-                      type="checkbox"
-                      name="isTermsAccepted"
+                {step === 1 && (
+                  <>
+                    <TextField
+                      fullWidth
+                      name="name"
+                      label={intl.formatMessage(messages.name)}
+                      error={errors.name}
+                      value={values.name}
                       onChange={handleChange}
-                      color="primary"
                     />
-                  }
-                  label={
-                    <FormattedMessage
-                      {...messages.agreement}
-                      values={{
-                        terms: (
-                          <a
-                            href="https://www.cboard.io/terms-of-use/"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                          >
-                            {intl.formatMessage(messages.termsAndConditions)}
-                          </a>
-                        ),
-                        privacy: (
-                          <a
-                            href="https://www.cboard.io/privacy/"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                          >
-                            {intl.formatMessage(messages.privacy)}
-                          </a>
-                        )
+                    <TextField
+                      fullWidth
+                      name="email"
+                      label={intl.formatMessage(messages.email)}
+                      error={errors.email}
+                      value={values.email}
+                      onChange={handleChange}
+                    />
+                    <PasswordTextField
+                      fullWidth
+                      error={errors.password}
+                      label={intl.formatMessage(messages.createYourPassword)}
+                      name="password"
+                      value={values.password}
+                      onChange={handleChange}
+                    />
+                    <PasswordTextField
+                      fullWidth
+                      error={errors.passwordConfirm}
+                      label={intl.formatMessage(messages.confirmYourPassword)}
+                      name="passwordConfirm"
+                      value={values.passwordConfirm}
+                      onChange={handleChange}
+                    />
+                    <FormControlLabel
+                      control={
+                        <Checkbox
+                          type="checkbox"
+                          name="isTermsAccepted"
+                          onChange={handleChange}
+                          checked={values.isTermsAccepted}
+                          color="primary"
+                        />
+                      }
+                      label={
+                        <FormattedMessage
+                          {...messages.agreement}
+                          values={{
+                            terms: (
+                              <a
+                                href="https://www.cboard.io/terms-of-use/"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                              >
+                                {intl.formatMessage(
+                                  messages.termsAndConditions
+                                )}
+                              </a>
+                            ),
+                            privacy: (
+                              <a
+                                href="https://www.cboard.io/privacy/"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                              >
+                                {intl.formatMessage(messages.privacy)}
+                              </a>
+                            )
+                          }}
+                        />
+                      }
+                    />
+                    <ErrorMessage
+                      name="isTermsAccepted"
+                      component="p"
+                      className="SignUp__status--error SignUp__termsError"
+                    />
+                  </>
+                )}
+
+                {step === 2 && (
+                  <>
+                    <TextField
+                      fullWidth
+                      select
+                      SelectProps={{
+                        MenuProps: {
+                          getContentAnchorEl: null,
+                          anchorOrigin: {
+                            vertical: 'bottom',
+                            horizontal: 'left'
+                          }
+                        }
                       }}
+                      name="role"
+                      label={intl.formatMessage(messages.role)}
+                      value={values.role}
+                      error={errors.role}
+                      onChange={handleChange}
+                    >
+                      <MenuItem value="AAC User">
+                        {intl.formatMessage(messages.roleAACUser)}
+                      </MenuItem>
+                      <MenuItem value="Educator / Teacher">
+                        {intl.formatMessage(messages.roleEducator)}
+                      </MenuItem>
+                      <MenuItem value="Therapist / SLP">
+                        {intl.formatMessage(messages.roleTherapist)}
+                      </MenuItem>
+                      <MenuItem value="Family Member / Caregiver">
+                        {intl.formatMessage(messages.roleFamily)}
+                      </MenuItem>
+                    </TextField>
+
+                    <TextField
+                      fullWidth
+                      type="number"
+                      name="age"
+                      label={intl.formatMessage(messages.age)}
+                      value={values.age}
+                      error={errors.age}
+                      onChange={handleChange}
                     />
-                  }
-                />
-                <ErrorMessage
-                  name="isTermsAccepted"
-                  component="p"
-                  className="SignUp__status--error SignUp__termsError"
-                />
+
+                    <TextField
+                      fullWidth
+                      select
+                      SelectProps={{
+                        multiple: true,
+                        MenuProps: {
+                          getContentAnchorEl: null,
+                          anchorOrigin: {
+                            vertical: 'bottom',
+                            horizontal: 'left'
+                          }
+                        }
+                      }}
+                      name="pathology"
+                      label={intl.formatMessage(messages.pathology)}
+                      value={values.pathology}
+                      error={errors.pathology}
+                      onChange={handleChange}
+                    >
+                      <MenuItem value="Autism">
+                        {intl.formatMessage(messages.pathologyAutism)}
+                      </MenuItem>
+                      <MenuItem value="Cerebral Palsy">
+                        {intl.formatMessage(messages.pathologyCerebralPalsy)}
+                      </MenuItem>
+                      <MenuItem value="ALS">
+                        {intl.formatMessage(messages.pathologyALS)}
+                      </MenuItem>
+                      <MenuItem value="Aphasia">
+                        {intl.formatMessage(messages.pathologyAphasia)}
+                      </MenuItem>
+                      <MenuItem value="Down Syndrome">
+                        {intl.formatMessage(messages.pathologyDownSyndrome)}
+                      </MenuItem>
+                      <MenuItem value="Other">
+                        {intl.formatMessage(messages.pathologyOther)}
+                      </MenuItem>
+                      <MenuItem value="Prefer not to say">
+                        {intl.formatMessage(messages.pathologyPreferNotToSay)}
+                      </MenuItem>
+                    </TextField>
+                  </>
+                )}
 
                 <DialogActions>
-                  <Button
-                    color="primary"
-                    disabled={isButtonDisabled}
-                    onClick={onClose}
-                  >
-                    <FormattedMessage {...messages.cancel} />
-                  </Button>
-                  <Button
-                    type="submit"
-                    disabled={isButtonDisabled}
-                    variant="contained"
-                    color="primary"
-                  >
-                    {isSigningUp && <LoadingIcon />}
-                    <FormattedMessage {...messages.signMeUp} />
-                  </Button>
+                  {step === 1 && (
+                    <Button
+                      color="primary"
+                      disabled={isButtonDisabled}
+                      onClick={onClose}
+                    >
+                      <FormattedMessage {...messages.cancel} />
+                    </Button>
+                  )}
+                  {step === 2 && (
+                    <Button
+                      color="primary"
+                      disabled={isButtonDisabled}
+                      onClick={() => setStep(1)}
+                    >
+                      <FormattedMessage {...messages.back} />
+                    </Button>
+                  )}
+                  {step === 1 && (
+                    <Button
+                      type="submit"
+                      disabled={isButtonDisabled}
+                      variant="contained"
+                      color="primary"
+                    >
+                      <FormattedMessage {...messages.next} />
+                    </Button>
+                  )}
+                  {step === 2 && (
+                    <Button
+                      type="submit"
+                      disabled={isButtonDisabled}
+                      variant="contained"
+                      color="primary"
+                    >
+                      {isSigningUp && <LoadingIcon />}
+                      <FormattedMessage {...messages.completeSignUp} />
+                    </Button>
+                  )}
                 </DialogActions>
               </form>
             )}

--- a/src/components/Account/SignUp/SignUp.messages.js
+++ b/src/components/Account/SignUp/SignUp.messages.js
@@ -44,5 +44,73 @@ export default defineMessages({
   noConnection: {
     id: 'cboard.components.SignUp.noConnection',
     defaultMessage: 'Unable to connect to the server. Please try again later.'
+  },
+  next: {
+    id: 'cboard.components.SignUp.next',
+    defaultMessage: 'Next'
+  },
+  back: {
+    id: 'cboard.components.SignUp.back',
+    defaultMessage: 'Back'
+  },
+  completeSignUp: {
+    id: 'cboard.components.SignUp.completeSignUp',
+    defaultMessage: 'Complete Sign Up'
+  },
+  role: {
+    id: 'cboard.components.SignUp.role',
+    defaultMessage: 'What is your role?'
+  },
+  roleAACUser: {
+    id: 'cboard.components.SignUp.roleAACUser',
+    defaultMessage: 'AAC User'
+  },
+  roleEducator: {
+    id: 'cboard.components.SignUp.roleEducator',
+    defaultMessage: 'Educator / Teacher'
+  },
+  roleTherapist: {
+    id: 'cboard.components.SignUp.roleTherapist',
+    defaultMessage: 'Therapist / SLP'
+  },
+  roleFamily: {
+    id: 'cboard.components.SignUp.roleFamily',
+    defaultMessage: 'Family Member / Caregiver'
+  },
+  age: {
+    id: 'cboard.components.SignUp.age',
+    defaultMessage: "Communicator's age"
+  },
+  pathology: {
+    id: 'cboard.components.SignUp.pathology',
+    defaultMessage: 'Pathology / diagnosis'
+  },
+  pathologyAutism: {
+    id: 'cboard.components.SignUp.pathologyAutism',
+    defaultMessage: 'Autism'
+  },
+  pathologyCerebralPalsy: {
+    id: 'cboard.components.SignUp.pathologyCerebralPalsy',
+    defaultMessage: 'Cerebral Palsy'
+  },
+  pathologyALS: {
+    id: 'cboard.components.SignUp.pathologyALS',
+    defaultMessage: 'ALS'
+  },
+  pathologyAphasia: {
+    id: 'cboard.components.SignUp.pathologyAphasia',
+    defaultMessage: 'Aphasia'
+  },
+  pathologyDownSyndrome: {
+    id: 'cboard.components.SignUp.pathologyDownSyndrome',
+    defaultMessage: 'Down Syndrome'
+  },
+  pathologyOther: {
+    id: 'cboard.components.SignUp.pathologyOther',
+    defaultMessage: 'Other'
+  },
+  pathologyPreferNotToSay: {
+    id: 'cboard.components.SignUp.pathologyPreferNotToSay',
+    defaultMessage: 'Prefer not to say'
   }
 });

--- a/src/components/Account/SignUp/Signup.component.test.js
+++ b/src/components/Account/SignUp/Signup.component.test.js
@@ -31,6 +31,50 @@ jest.mock('./SignUp.messages', () => {
     signMeUp: {
       id: 'cboard.components.SignUp.signMeUp',
       defaultMessage: 'Sign me up'
+    },
+    next: {
+      id: 'cboard.components.SignUp.next',
+      defaultMessage: 'Next'
+    },
+    back: {
+      id: 'cboard.components.SignUp.back',
+      defaultMessage: 'Back'
+    },
+    completeSignUp: {
+      id: 'cboard.components.SignUp.completeSignUp',
+      defaultMessage: 'Complete Sign Up'
+    },
+    role: { id: 'cboard.components.SignUp.role' },
+    roleAACUser: { id: 'cboard.components.SignUp.roleAACUser' },
+    roleEducator: { id: 'cboard.components.SignUp.roleEducator' },
+    roleTherapist: { id: 'cboard.components.SignUp.roleTherapist' },
+    roleFamily: { id: 'cboard.components.SignUp.roleFamily' },
+    age: { id: 'cboard.components.SignUp.age' },
+    pathology: { id: 'cboard.components.SignUp.pathology' },
+    pathologyAutism: { id: 'cboard.components.SignUp.pathologyAutism' },
+    pathologyCerebralPalsy: {
+      id: 'cboard.components.SignUp.pathologyCerebralPalsy'
+    },
+    pathologyALS: { id: 'cboard.components.SignUp.pathologyALS' },
+    pathologyAphasia: { id: 'cboard.components.SignUp.pathologyAphasia' },
+    pathologyDownSyndrome: {
+      id: 'cboard.components.SignUp.pathologyDownSyndrome'
+    },
+    pathologyOther: { id: 'cboard.components.SignUp.pathologyOther' },
+    pathologyPreferNotToSay: {
+      id: 'cboard.components.SignUp.pathologyPreferNotToSay'
+    },
+    agreement: {
+      id: 'cboard.components.SignUp.agreement',
+      defaultMessage: 'agreement'
+    },
+    termsAndConditions: {
+      id: 'cboard.components.SignUp.termsAndConditions',
+      defaultMessage: 'terms'
+    },
+    privacy: {
+      id: 'cboard.components.SignUp.privacy',
+      defaultMessage: 'privacy'
     }
   };
 });

--- a/src/components/Account/SignUp/validationSchema.js
+++ b/src/components/Account/SignUp/validationSchema.js
@@ -1,6 +1,6 @@
 import * as yup from 'yup';
 
-const validationSchema = yup.object().shape({
+export const validationSchemaStep1 = yup.object().shape({
   password: yup
     .string()
     .required('Required')
@@ -19,4 +19,17 @@ const validationSchema = yup.object().shape({
     .oneOf([true], 'Accept Terms and Policy is required')
 });
 
-export default validationSchema;
+export const validationSchemaStep2 = validationSchemaStep1.shape({
+  role: yup.string().required('Required'),
+  age: yup
+    .number()
+    .nullable()
+    .positive()
+    .integer(),
+  pathology: yup
+    .array()
+    .of(yup.string())
+    .nullable()
+});
+
+export default validationSchemaStep1;


### PR DESCRIPTION
## Description

This PR implements sub-issue #2248 by updating the signup flow to support profile-based onboarding as part of the personalized onboarding experience.

The existing single-step signup flow has been converted into a multi-step flow to collect additional user profile information required for personalized onboarding.

## Changes Made

### Signup Flow Updates
- Converted the existing signup flow into a two-step process
- Step 1 collects:
  - Name
  - Email
  - Password
  - Terms acceptance

- Step 2 collects:
  - User role
  - Age
  - Pathology (multi-select)

### Form Logic
- Added step state management for navigation between signup steps
- Implemented Next / Back navigation actions
- Added submit handling to move from Step 1 → Step 2 before final submission

### Validation Updates
- Split the existing validation schema into:
  - `validationSchemaStep1`
  - `validationSchemaStep2`

- Added validation for:
  - Role selection
  - Age field
  - Pathology selection

### Additional Changes
- Added new `MenuItem` imports for selection fields
- Added i18n messages for:
  - Role field
  - Age field
  - Pathology field
  - Navigation labels

### Testing
- Updated tests to support the new signup flow and added mocks for new messages

## Related Issue

Closes #2248

## Screenshots

<img width="273" height="287" alt="image" src="https://github.com/user-attachments/assets/de379a4a-19da-46b8-8330-fbf90354abae" />
<img width="525" height="349" alt="image" src="https://github.com/user-attachments/assets/af44a81d-ee5b-45c2-acb7-b09c4950b31b" />
