### PR TITLE
fix(import): stop logged-out board imports from getting stuck in PENDING

### DIFF
--- a/src/components/Settings/Import/Import.container.js
+++ b/src/components/Settings/Import/Import.container.js
@@ -135,6 +135,10 @@ export class ImportContainer extends PureComponent {
       boardWithNewId.prevId = boardWithNewId.id;
     }
     boardWithNewId.id = shortid.generate();
+    // Clear any imported or foreign email so the board is treated as locally
+    // owned. Otherwise classifyBoardsForPush skips it during sync and it stays
+    // PENDING forever, never reaching the user's account (mirrors the copy flow).
+    boardWithNewId.email = '';
     return boardWithNewId;
   }
 

--- a/src/components/Settings/Import/Import.container.test.js
+++ b/src/components/Settings/Import/Import.container.test.js
@@ -1,0 +1,34 @@
+import { ImportContainer } from './Import.container';
+
+// prepareLocalBoard is a pure instance method (it does not read this.props),
+// so it can be exercised on a bare instance without a Redux store or render.
+const makeInstance = () => new ImportContainer({});
+
+describe('ImportContainer.prepareLocalBoard', () => {
+  test('assigns a fresh id and remembers the original as prevId', () => {
+    const instance = makeInstance();
+    const result = instance.prepareLocalBoard({
+      id: 'original-id',
+      name: 'My board'
+    });
+
+    expect(result.id).toBeDefined();
+    expect(result.id).not.toBe('original-id');
+    expect(result.prevId).toBe('original-id');
+    expect(result.name).toBe('My board');
+  });
+
+  test('clears a foreign email so the board is not left stuck PENDING on sync (issue #2231)', () => {
+    const instance = makeInstance();
+    const result = instance.prepareLocalBoard({
+      id: 'imported-id',
+      name: 'Imported board',
+      email: 'previous-owner@example.com'
+    });
+
+    // A foreign email makes classifyBoardsForPush skip the board during sync,
+    // leaving it PENDING forever. Normalizing to an empty string marks it as
+    // locally owned so it graduates to the current user on the next sync.
+    expect(result.email).toBe('');
+  });
+});


### PR DESCRIPTION
Fixes #2231.

## Problem

When a board is imported while logged out, `prepareLocalBoard` in `src/components/Settings/Import/Import.container.js` gives the board a fresh id but keeps whatever `email` was stored in the imported file. If that email belongs to another user, the board never syncs.

On the next sync, `classifyBoardsForPush` only queues a `PENDING` board when `hasDefaultOrNoEmail(board)` is true or `board.email === userEmail`. A foreign email fails both checks, so the imported board stays `PENDING` forever and never reaches the user's account or their other devices.

Steps to reproduce (from the issue):
1. Log out.
2. Import a board file that contains another user's email.
3. Log in and let sync run.
4. The imported board stays `PENDING` and never uploads.

## Fix

Clear the email to an empty string inside `prepareLocalBoard`, mirroring what the copy-board flow already does in `Board.container.js`. An empty email makes `hasDefaultOrNoEmail` return true, so the board is treated as locally owned and graduates to the current user on the next sync (`transformBoardForUser` reassigns ownership when the board is pushed).

`prepareLocalBoard` has two callers, and both stay correct:
- Logged-out import (the bug): the foreign email is cleared, so the board syncs.
- Logged-in fallback when a server create fails: the board previously carried the user's own email, which was already pushable. Clearing it to an empty string keeps it pushable, and it is reassigned to the user on push. Same end result.

## Test

Adds `Import.container.test.js`:
- asserts `prepareLocalBoard` clears a foreign email (regression test for this issue),
- keeps a test for the existing id / prevId behaviour.

`prepareLocalBoard` does not read `this.props`, so it runs on a bare instance with no store.

```
yarn test --testPathPattern "Settings/Import"
```

Both suites pass (5 tests).
