### PR TITLE
fix(sync): make sync guards survive AppContainer remounts

### DIFF
--- a/src/__test__/reducers.test.js
+++ b/src/__test__/reducers.test.js
@@ -1,6 +1,7 @@
 import createReducer, {
   createMigratingStorage,
-  boardMigrations
+  boardMigrations,
+  boardSyncTransform
 } from '../reducers';
 
 describe('reducers', () => {
@@ -108,6 +109,38 @@ describe('createMigratingStorage', () => {
       expect(newStorage.removeItem).toHaveBeenCalledWith('persist:root');
       expect(oldStorage.removeItem).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('boardSyncTransform', () => {
+  it('resets a persisted isSyncing flag on rehydrate', () => {
+    const persistedBoard = {
+      isSyncing: true,
+      boards: [{ id: 'board-1' }],
+      syncMeta: { 'board-1': { status: 'SYNCED' } }
+    };
+
+    const result = boardSyncTransform.out(persistedBoard, 'board');
+
+    expect(result.isSyncing).toBe(false);
+    expect(result.boards).toEqual(persistedBoard.boards);
+    expect(result.syncMeta).toEqual(persistedBoard.syncMeta);
+  });
+
+  it('leaves other state slices untouched on rehydrate', () => {
+    const persistedApp = { userData: { id: 'user-1' } };
+
+    const result = boardSyncTransform.out(persistedApp, 'app');
+
+    expect(result).toBe(persistedApp);
+  });
+
+  it('persists board state unchanged on write', () => {
+    const boardState = { isSyncing: true, boards: [] };
+
+    const result = boardSyncTransform.in(boardState, 'board');
+
+    expect(result).toBe(boardState);
   });
 });
 

--- a/src/components/App/App.container.js
+++ b/src/components/App/App.container.js
@@ -9,7 +9,6 @@ import { isFirstVisit, isLogged } from './App.selectors';
 import messages from './App.messages';
 import App from './App.component';
 import { DISPLAY_SIZE_STANDARD } from '../Settings/Display/Display.constants';
-import { hasPendingSyncBoards } from '../Board/Board.selectors';
 
 import {
   updateUserDataFromAPI,
@@ -17,7 +16,7 @@ import {
   updateUnloggedUserLocation,
   updateConnectivity
 } from '../App/App.actions';
-import { getApiObjects, clearSync } from '../Board/Board.actions';
+import { getApiObjects } from '../Board/Board.actions';
 import {
   isCordova,
   isElectron,
@@ -25,6 +24,14 @@ import {
   cleanUpCvaOnResume
 } from '../../cordova-util';
 import { appInsights } from '../../appInsights';
+
+// Module-scoped so the sync throttle survives AppContainer remounts but still
+// resets on a real app launch.
+let lastSyncTime = null;
+
+export const resetSyncThrottle = () => {
+  lastSyncTime = null;
+};
 
 export class AppContainer extends Component {
   static propTypes = {
@@ -56,14 +63,8 @@ export class AppContainer extends Component {
     /**
      * Get API objects (boards and communicators)
      */
-    getApiObjects: PropTypes.func.isRequired,
-    /**
-     * Clear a stale isSyncing flag rehydrated from a previous session
-     */
-    clearSync: PropTypes.func.isRequired
+    getApiObjects: PropTypes.func.isRequired
   };
-
-  lastSyncTime = null;
 
   componentDidMount() {
     const localizeUser = () => {
@@ -142,7 +143,6 @@ export class AppContainer extends Component {
       this.handleWebVisibilityChange
     );
 
-    this.props.clearSync();
     this.handleDataRefresh('App started');
   }
 
@@ -158,11 +158,11 @@ export class AppContainer extends Component {
 
   isSyncRecentlyExecuted = () => {
     const THROTTLE_MS = 1000 * 30;
-    return this.lastSyncTime && Date.now() - this.lastSyncTime < THROTTLE_MS;
+    return lastSyncTime && Date.now() - lastSyncTime < THROTTLE_MS;
   };
 
   handleDataRefresh = (source = 'Unknown') => {
-    const { isLogged, hasPendingSyncBoards } = this.props;
+    const { isLogged } = this.props;
 
     if (!isLogged) {
       return;
@@ -173,12 +173,12 @@ export class AppContainer extends Component {
       return;
     }
 
-    if (this.isSyncRecentlyExecuted() && !hasPendingSyncBoards) {
+    if (this.isSyncRecentlyExecuted()) {
       console.log(`Sync skipped - throttled (${source})`);
       return;
     }
 
-    this.lastSyncTime = Date.now();
+    lastSyncTime = Date.now();
     this.props.getApiObjects(source);
   };
 
@@ -259,8 +259,7 @@ const mapStateToProps = state => ({
   lang: state.language.lang,
   displaySettings: state.app.displaySettings,
   isDownloadingLang: state.language.downloadingLang.isdownloading,
-  userId: state.app.userData.id,
-  hasPendingSyncBoards: hasPendingSyncBoards(state)
+  userId: state.app.userData.id
 });
 
 const mapDispatchToProps = {
@@ -269,8 +268,7 @@ const mapDispatchToProps = {
   updateLoggedUserLocation,
   updateUnloggedUserLocation,
   updateConnectivity,
-  getApiObjects,
-  clearSync
+  getApiObjects
 };
 
 export default connect(

--- a/src/components/App/__tests__/App.container.test.js
+++ b/src/components/App/__tests__/App.container.test.js
@@ -1,4 +1,4 @@
-import { AppContainer } from '../App.container';
+import { AppContainer, resetSyncThrottle } from '../App.container';
 
 jest.mock('../App.component', () => () => null);
 
@@ -7,7 +7,6 @@ describe('AppContainer.handleDataRefresh', () => {
     const instance = new AppContainer();
     instance.props = {
       isLogged: true,
-      hasPendingSyncBoards: false,
       getApiObjects: jest.fn(() => Promise.resolve()),
       ...props
     };
@@ -17,6 +16,7 @@ describe('AppContainer.handleDataRefresh', () => {
   const originalOnLine = window.navigator.onLine;
 
   beforeEach(() => {
+    resetSyncThrottle();
     Object.defineProperty(window.navigator, 'onLine', {
       value: true,
       configurable: true
@@ -32,30 +32,34 @@ describe('AppContainer.handleDataRefresh', () => {
     jest.restoreAllMocks();
   });
 
-  it('dispatches a sync when pending boards bypass the throttle', () => {
+  it('dispatches a sync when the throttle window has not started', () => {
     const getApiObjects = jest.fn(() => Promise.resolve());
-    const instance = buildInstance({
-      hasPendingSyncBoards: true,
-      getApiObjects
-    });
-    instance.lastSyncTime = Date.now();
+    const instance = buildInstance({ getApiObjects });
 
     instance.handleDataRefresh('App started');
 
     expect(getApiObjects).toHaveBeenCalledTimes(1);
   });
 
-  it('skips sync when throttled and no boards are pending', () => {
+  it('skips sync when throttled', () => {
     const getApiObjects = jest.fn(() => Promise.resolve());
-    const instance = buildInstance({
-      hasPendingSyncBoards: false,
-      getApiObjects
-    });
-    instance.lastSyncTime = Date.now();
+    const instance = buildInstance({ getApiObjects });
 
+    instance.handleDataRefresh('App started');
     instance.handleDataRefresh('Tab focused');
 
-    expect(getApiObjects).not.toHaveBeenCalled();
+    expect(getApiObjects).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the throttle across a remount (new instance)', () => {
+    const getApiObjects = jest.fn(() => Promise.resolve());
+    const firstMount = buildInstance({ getApiObjects });
+    firstMount.handleDataRefresh('App started');
+
+    const secondMount = buildInstance({ getApiObjects });
+    secondMount.handleDataRefresh('App started');
+
+    expect(getApiObjects).toHaveBeenCalledTimes(1);
   });
 
   it('skips sync when offline', () => {

--- a/src/components/Board/Board.actions.js
+++ b/src/components/Board/Board.actions.js
@@ -46,7 +46,6 @@ import {
   SYNC_BOARDS_FAILURE,
   SYNC_STARTED,
   SYNC_FINISHED,
-  CLEAR_SYNC,
   MARK_BOARDS_SYNCED,
   SYNC_STATUS,
   SET_IS_SAVING
@@ -588,10 +587,6 @@ export function syncStarted() {
 
 export function syncFinished() {
   return { type: SYNC_FINISHED };
-}
-
-export function clearSync() {
-  return { type: CLEAR_SYNC };
 }
 
 /**

--- a/src/components/Board/Board.constants.js
+++ b/src/components/Board/Board.constants.js
@@ -45,7 +45,6 @@ export const SYNC_BOARDS_SUCCESS = 'cboard/Board/SYNC_BOARDS_SUCCESS';
 export const SYNC_BOARDS_FAILURE = 'cboard/Board/SYNC_BOARDS_FAILURE';
 export const SYNC_STARTED = 'cboard/Board/SYNC_STARTED';
 export const SYNC_FINISHED = 'cboard/Board/SYNC_FINISHED';
-export const CLEAR_SYNC = 'cboard/Board/CLEAR_SYNC';
 export const MARK_BOARDS_SYNCED = 'cboard/Board/MARK_BOARDS_SYNCED';
 export const SET_IS_SAVING = 'cboard/Board/SET_IS_SAVING';
 

--- a/src/components/Board/Board.reducer.js
+++ b/src/components/Board/Board.reducer.js
@@ -47,7 +47,6 @@ import {
   SYNC_BOARDS_FAILURE,
   SYNC_STARTED,
   SYNC_FINISHED,
-  CLEAR_SYNC,
   MARK_BOARDS_SYNCED,
   SYNC_STATUS,
   SET_IS_SAVING
@@ -612,11 +611,6 @@ function boardReducer(state = initialState, action) {
         isSyncing: true
       };
     case SYNC_FINISHED:
-      return {
-        ...state,
-        isSyncing: false
-      };
-    case CLEAR_SYNC:
       return {
         ...state,
         isSyncing: false

--- a/src/components/Board/__tests__/Board.actions.test.js
+++ b/src/components/Board/__tests__/Board.actions.test.js
@@ -529,12 +529,6 @@ describe('syncFinished', () => {
   });
 });
 
-describe('clearSync', () => {
-  it('should create an action to CLEAR_SYNC', () => {
-    expect(actions.clearSync()).toEqual({ type: types.CLEAR_SYNC });
-  });
-});
-
 describe('getApiObjects concurrency guard', () => {
   const buildState = isSyncing => ({
     ...initialState,

--- a/src/components/Board/__tests__/Board.reducer.test.js
+++ b/src/components/Board/__tests__/Board.reducer.test.js
@@ -34,7 +34,6 @@ import {
   SYNC_BOARDS_FAILURE,
   SYNC_STARTED,
   SYNC_FINISHED,
-  CLEAR_SYNC,
   SYNC_STATUS
 } from '../Board.constants';
 import { LOGOUT, LOGIN_SUCCESS } from '../../Account/Login/Login.constants';
@@ -622,17 +621,6 @@ describe('reducer', () => {
     };
     expect(
       boardReducer({ ...initialState, isSyncing: true }, syncFinished)
-    ).toEqual({
-      ...initialState,
-      isSyncing: false
-    });
-  });
-  it('should handle clearSync', () => {
-    const clearSync = {
-      type: CLEAR_SYNC
-    };
-    expect(
-      boardReducer({ ...initialState, isSyncing: true }, clearSync)
     ).toEqual({
       ...initialState,
       isSyncing: false

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -1,7 +1,8 @@
 import {
   persistCombineReducers,
   persistReducer,
-  createMigrate
+  createMigrate,
+  createTransform
 } from 'redux-persist';
 
 import localForage from 'localforage';
@@ -130,12 +131,21 @@ export const boardMigrations = {
   })
 };
 
+// isSyncing describes a sync in flight in the current JS process, so a
+// rehydrated value is stale by definition and must never come back as true.
+export const boardSyncTransform = createTransform(
+  null,
+  outboundState => ({ ...outboundState, isSyncing: false }),
+  { whitelist: ['board'] }
+);
+
 const config = {
   key: 'root',
   storage: migratingStorage,
   blacklist: ['language'],
   version: 1,
-  migrate: createMigrate(boardMigrations, { debug: false })
+  migrate: createMigrate(boardMigrations, { debug: false }),
+  transforms: [boardSyncTransform]
 };
 
 const languagePersistConfig = {


### PR DESCRIPTION
## Summary

Fixes #2266 — on startup the sync engine could run a full sync **twice, concurrently**, both with `source: "App started"`. A `LanguageProvider`-driven remount of `AppContainer` defeated both sync guards:

1. `clearSync()` fires on every mount and cannot tell a *stale rehydrated* `isSyncing` flag from a *live in-session* sync, so the second mount wiped the guard of the sync still running from the first mount.
2. The 30s throttle (`lastSyncTime`) was an instance field, so the remounted instance started with a fresh throttle.

Per the investigation on the issue, the `LanguageProvider` remount itself is load-bearing for i18n correctness on react-intl v2 + react-redux v5, so this PR hardens the guards instead of touching the provider.

## Changes

- **Never rehydrate `isSyncing`**: a redux-persist outbound transform (`boardSyncTransform`) forces `isSyncing: false` on the `board` slice during rehydration. This solves the stale-flag problem at the persistence boundary, so `clearSync()` / `CLEAR_SYNC` are deleted entirely. It also fixes a latent race where a `REHYDRATE` landing *after* `clearSync()` re-introduced the stale `true` and blocked all syncs. Resulting invariant: `isSyncing` is true only while `getApiObjects` is executing in the current JS process.
- **Module-scoped throttle**: `lastSyncTime` is hoisted from an instance field to module scope in `App.container.js` — survives remounts, resets on a real app launch. Deliberately not Redux: the `board` slice is persisted, so a persisted timestamp would skip the startup sync after a quick app restart.
- **Uniform throttle**: the `hasPendingSyncBoards` bypass is removed — all sync triggers are throttled equally. The selector itself stays (used by `SyncButton`). fixes #2263

## Tests

- New: `boardSyncTransform` resets a persisted `isSyncing: true` on rehydrate, leaves other slices untouched, and persists writes unchanged.
- New: throttle survives a remount (two `AppContainer` instances → one `getApiObjects` call).
- Removed: `CLEAR_SYNC` action/reducer tests and the pending-boards throttle-bypass test (behaviors removed).

## Test plan

- [ ] `yarn test src/__test__/reducers.test.js src/components/App/__tests__/App.container.test.js src/components/Board`
- [ ] Repro from #2266: log out → change app language ≠ user default → log in → console shows one `Sync dispatched - App started` and a `Sync skipped` line, and App Insights shows a single `Sync_FullRun`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)