### PR TITLE
fix: use stable keys for FixedGrid rows and cells

### DIFF
--- a/src/components/FixedGrid/GridBase.js
+++ b/src/components/FixedGrid/GridBase.js
@@ -37,13 +37,13 @@ function GridBase(props) {
   return (
     <div className={gridClassName} {...other}>
       {grid.map((row, rowIndex) => (
-        <Row key={rowIndex}>
+        <Row key={utils.getGridRowKey(row, rowIndex)}>
           {row.map((item, columnIndex) => {
             const yPosition = page * rows + rowIndex;
             const idWithPosition = `${columnIndex}-${yPosition}`;
             return (
               <DroppableCell
-                key={columnIndex}
+                key={utils.getGridCellKey(item, rowIndex, columnIndex)}
                 id={idWithPosition}
                 accept={'grid-item'}
                 onDrop={item => {

--- a/src/components/FixedGrid/utils.test.js
+++ b/src/components/FixedGrid/utils.test.js
@@ -1,0 +1,52 @@
+import { getGridRowKey, getGridCellKey } from './utils';
+
+describe('FixedGrid stable key helpers', () => {
+  describe('getGridRowKey', () => {
+    it('derives the key from the first tile id, independent of the row index', () => {
+      const row = [{ id: 'c' }, { id: 'd' }];
+      expect(getGridRowKey(row, 0)).toBe('row-c');
+      // Same content at a different position must produce the same key.
+      expect(getGridRowKey(row, 1)).toBe(getGridRowKey(row, 0));
+    });
+
+    it('keeps a surviving row key constant when an earlier row is removed', () => {
+      // Grid [[a,b],[c,d]] -> the [c,d] row lives at index 1.
+      const before = getGridRowKey([{ id: 'c' }, { id: 'd' }], 1);
+      // After removing the first row, [[c,d]] -> the same row is now at index 0.
+      const after = getGridRowKey([{ id: 'c' }, { id: 'd' }], 0);
+      // Stable: no remount. (Index-based keys would change from 1 to 0.)
+      expect(after).toBe(before);
+    });
+
+    it('uses the first non-empty tile when leading cells are empty', () => {
+      expect(getGridRowKey([null, { id: 'x' }], 3)).toBe('row-x');
+    });
+
+    it('falls back to a unique position key for a fully empty row', () => {
+      expect(getGridRowKey([null, null], 2)).toBe('row-empty-2');
+      expect(getGridRowKey([undefined, undefined], 4)).toBe('row-empty-4');
+    });
+  });
+
+  describe('getGridCellKey', () => {
+    it('derives a stable key from the tile id, independent of position', () => {
+      expect(getGridCellKey({ id: 'a' }, 0, 0)).toBe('cell-a');
+      expect(getGridCellKey({ id: 'a' }, 5, 9)).toBe('cell-a');
+    });
+
+    it('falls back to a unique position key for an empty cell', () => {
+      expect(getGridCellKey(null, 1, 2)).toBe('cell-empty-1-2');
+      expect(getGridCellKey(undefined, 0, 0)).toBe('cell-empty-0-0');
+    });
+  });
+
+  it('produces collision-free keys across a grid mixing tiles and empty cells', () => {
+    const grid = [[{ id: 'a' }, null], [null, { id: 'b' }], [null, null]];
+    const rowKeys = grid.map((row, r) => getGridRowKey(row, r));
+    const cellKeys = grid.flatMap((row, r) =>
+      row.map((cell, c) => getGridCellKey(cell, r, c))
+    );
+    const allKeys = [...rowKeys, ...cellKeys];
+    expect(new Set(allKeys).size).toBe(allKeys.length);
+  });
+});

--- a/src/components/FixedGrid/utils.ts
+++ b/src/components/FixedGrid/utils.ts
@@ -189,3 +189,37 @@ export function getTilesListForNewOrder({
   const tilesListForNewOrder = newPages.flat();
   return tilesListForNewOrder;
 }
+
+type GridCell = { id: string; [key: string]: any } | null | undefined;
+
+/**
+ * Build a stable React key for a grid row.
+ *
+ * A row is keyed by the id of its first non-empty tile, so the key follows the
+ * row's content rather than its position. This keeps the key constant when rows
+ * are inserted, removed or reordered, avoiding needless remounts (and the lost
+ * focus/state that comes with them). Fully empty rows have no content to
+ * preserve, so they fall back to a position-based key, which stays unique.
+ */
+export function getGridRowKey(row: GridCell[], rowIndex: number): string {
+  const firstItem = row.find((cell): cell is { id: string } =>
+    Boolean(cell && cell.id)
+  );
+  return firstItem ? `row-${firstItem.id}` : `row-empty-${rowIndex}`;
+}
+
+/**
+ * Build a stable React key for a grid cell.
+ *
+ * A filled cell is keyed by its tile id (stable across reorder); an empty cell
+ * has nothing to preserve, so it uses a unique position-based key.
+ */
+export function getGridCellKey(
+  cell: GridCell,
+  rowIndex: number,
+  columnIndex: number
+): string {
+  return cell && cell.id
+    ? `cell-${cell.id}`
+    : `cell-empty-${rowIndex}-${columnIndex}`;
+}


### PR DESCRIPTION
### What

`FixedGrid`'s `GridBase` keyed rows by their array index (`key={rowIndex}`) and cells by their column index (`key={columnIndex}`). When a row is inserted, removed or reordered those indices shift, so React remounts the `<Row>` and `<DroppableCell>` wrappers of *unaffected* rows — even though the tiles inside already have stable `id` keys. As #1875 describes, that remounting loses component state and focus and degrades performance while navigating a board (which for many Cboard users is their primary way to communicate).

This keys rows and cells by their tile `id` instead, so a row/cell keeps its identity when its position changes. Empty rows and cells have no state to preserve, so they fall back to a unique position-based key.

### How it's verified

The key derivation is extracted into two pure helpers in `utils.ts` (`getGridRowKey`, `getGridCellKey`) and covered by a new unit test (`utils.test.js`, 7 cases) asserting:

- a row's key is derived from its first tile id and stays constant when its index changes (e.g. survives removing an earlier row) — the core of the bug;
- filled cells key by tile id (stable across position), while empty rows/cells key by position;
- keys never collide across a grid that mixes tiles and empty cells.

The FixedGrid / Board / Communicator test suites pass, and the change only affects key derivation, not rendered output. (For transparency: a few unrelated suites — SpeechProvider, WelcomeScreen/CboardLogo, api, LanguageProvider — also fail on a clean `master` checkout, independent of this change.)

### Disclosure

Implemented with the help of an AI coding assistant (Claude); verified locally with the included unit test.

Fixes #1875
