### PR TITLE
fix(telemetry): enable App Insights correlation for cboard-io APIs

### DIFF
--- a/src/appInsights.js
+++ b/src/appInsights.js
@@ -20,7 +20,8 @@ export const appInsights = new ApplicationInsights({
       '*.doubleclick.net',
       'pagead2.googlesyndication.com',
       'eastus.tts.speech.microsoft.com',
-      '*.cboard.io'
+      'cbuilder.cboard.io',
+      'cbuilder.qa.cboard.io'
     ]
   }
 });


### PR DESCRIPTION
## What

Replace the blanket `'*.cboard.io'` entry in `correlationHeaderExcludedDomains` (`src/appInsights.js`) with the specific cbuilder hosts:

```diff
-      '*.cboard.io'
+      'cbuilder.cboard.io',
+      'cbuilder.qa.cboard.io'
```

## Why

`'*.cboard.io'` was added to silence CORS errors, but the wildcard also stripped App Insights correlation headers from requests to our **own** API (`app.api.cboard.io` / `app.qa.api.cboard.io`), which runs the App Insights SDK. That broke end-to-end distributed tracing between the web app and the Cboard API.

Narrowing the exclusion:
- **API** now receives correlation headers → dependencies stitch to server telemetry. Safe because the API's `cors()` reflects requested headers (no CORS regression).
- **cbuilder** stays excluded → no App Insights and no CORS handling for these headers, so it must not receive them (avoids reintroducing the original CORS failures).

## Related

- Closes #2272
- API-side counterpart (adds `exposedHeaders: ['Request-Context']`): cboard-org/cboard-api#472

## Notes

nginx (`cboard-nginx`) verified as a clean pass-through — no CORS handling, no header stripping — so no infra changes needed.

## Testing

Verify preflight/response headers through nginx to the API:

```bash
curl -i https://app.api.cboard.io/<endpoint> -H "Origin: https://app.cboard.io"
# expect: Request-Context: appId=cid-v1:...
#         Access-Control-Expose-Headers: Request-Context   (after API PR #472)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)