### PR TITLE
fix(media): preserve recorded audio extensions

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -549,7 +549,8 @@ class API {
     if (isDataURL(tile.sound)) {
       const { url, unrecoverable } = await this.tryUploadDataURL(
         tile.sound,
-        `${tile.id}.mp3`
+        tile.id,
+        true
       );
       return { attempted: true, url, unrecoverable };
     }

--- a/src/api/api.test.js
+++ b/src/api/api.test.js
@@ -318,12 +318,32 @@ describe('Cboard API calls', () => {
       expect(hadFailure).toBe(false);
       expect(API.tryUploadDataURL).toHaveBeenCalledWith(
         'data:audio/mp3;base64,AAAA',
-        't1.mp3'
+        't1',
+        true
       );
       expect(sanitized.tiles[0].sound).toBe(
         'https://cdn.example.com/sound.mp3'
       );
       expect(sanitized.tiles[1].sound).toBe('https://cdn.example.com/keep.mp3');
+    });
+
+    it('uses the sound MIME type for uploaded filenames', async () => {
+      const uploadFile = jest
+        .spyOn(API, 'uploadFile')
+        .mockResolvedValue('https://cdn.example.com/t1.webm');
+      const board = {
+        id: 'b1',
+        tiles: [{ id: 't1', sound: 'data:audio/webm;base64,AAAA' }]
+      };
+
+      const { board: sanitized, hadFailure } = await API.uploadBoardLocalMedia(
+        board
+      );
+
+      expect(hadFailure).toBe(false);
+      expect(uploadFile).toHaveBeenCalledWith(expect.any(Blob), 't1.webm');
+      expect(uploadFile.mock.calls[0][0].type).toBe('audio/webm');
+      expect(sanitized.tiles[0].sound).toBe('https://cdn.example.com/t1.webm');
     });
 
     it('replaces both image and sound on the same tile', async () => {


### PR DESCRIPTION
Recorded tile sounds now use the existing MIME-aware upload path, so the stored filename matches the actual recording format instead of always ending in `.mp3`. The image upload path is unchanged.

- enable extension detection for tile sound data URLs
- add a regression test for an `audio/webm` upload

Tested with:
`set CI=true&& corepack yarn test src/api/api.test.js --watchAll=false --runInBand -t "uses the sound MIME type for uploaded filenames"`

Fixes #2250