### PR TITLE
fix(sync): upload base64 board caption as media to prevent 409 poison pill

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -588,6 +588,17 @@ class API {
     const tileUpdates = {};
     let hadFailure = false;
 
+    const applyMedia = (result, apply) => {
+      if (!result.attempted) return;
+      if (result.url) apply(result.url);
+      else if (result.unrecoverable) apply('');
+      else hadFailure = true;
+    };
+
+    const captionPromise = captionIsTarget
+      ? this.uploadBoardCaptionMedia(board)
+      : null;
+
     const uploadTarget = async tile => {
       try {
         const [image, sound] = await Promise.all([
@@ -596,25 +607,8 @@ class API {
         ]);
 
         const update = {};
-        if (image.attempted) {
-          if (image.url) {
-            update.image = image.url;
-          } else if (image.unrecoverable) {
-            update.image = '';
-          } else {
-            hadFailure = true;
-          }
-        }
-
-        if (sound.attempted) {
-          if (sound.url) {
-            update.sound = sound.url;
-          } else if (sound.unrecoverable) {
-            update.sound = '';
-          } else {
-            hadFailure = true;
-          }
-        }
+        applyMedia(image, url => (update.image = url));
+        applyMedia(sound, url => (update.sound = url));
 
         if (Object.keys(update).length) {
           tileUpdates[tile.id] = update;
@@ -637,17 +631,8 @@ class API {
       })
     };
 
-    if (captionIsTarget) {
-      const caption = await this.uploadBoardCaptionMedia(board);
-      if (caption.attempted) {
-        if (caption.url) {
-          sanitizedBoard.caption = caption.url;
-        } else if (caption.unrecoverable) {
-          sanitizedBoard.caption = '';
-        } else {
-          hadFailure = true;
-        }
-      }
+    if (captionPromise) {
+      applyMedia(await captionPromise, url => (sanitizedBoard.caption = url));
     }
 
     return { board: sanitizedBoard, hadFailure };

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -557,6 +557,19 @@ class API {
     return { attempted: false, url: null, unrecoverable: false };
   }
 
+  async uploadBoardCaptionMedia(board) {
+    if (isDataURL(board?.caption)) {
+      const { url, unrecoverable } = await this.tryUploadDataURL(
+        board.caption,
+        board.id,
+        true
+      );
+      return { attempted: true, url, unrecoverable };
+    }
+
+    return { attempted: false, url: null, unrecoverable: false };
+  }
+
   async uploadBoardLocalMedia(board) {
     const tiles = board?.tiles || [];
     const targets = tiles.filter(
@@ -566,7 +579,9 @@ class API {
         isDataURL(tile?.sound)
     );
 
-    if (!targets.length) {
+    const captionIsTarget = isDataURL(board?.caption);
+
+    if (!targets.length && !captionIsTarget) {
       return { board, hadFailure: false };
     }
 
@@ -621,6 +636,19 @@ class API {
         return update ? { ...tile, ...update } : tile;
       })
     };
+
+    if (captionIsTarget) {
+      const caption = await this.uploadBoardCaptionMedia(board);
+      if (caption.attempted) {
+        if (caption.url) {
+          sanitizedBoard.caption = caption.url;
+        } else if (caption.unrecoverable) {
+          sanitizedBoard.caption = '';
+        } else {
+          hadFailure = true;
+        }
+      }
+    }
 
     return { board: sanitizedBoard, hadFailure };
   }

--- a/src/api/api.test.js
+++ b/src/api/api.test.js
@@ -488,6 +488,72 @@ describe('Cboard API calls', () => {
       expect(tryUploadDataURL).not.toHaveBeenCalled();
       expect(sanitized.caption).toBe('https://cdn.example.com/existing.png');
     });
+
+    it('clears a caption and does not flag failure when it is unrecoverable', async () => {
+      jest
+        .spyOn(API, 'tryUploadDataURL')
+        .mockResolvedValue({ url: null, unrecoverable: true });
+
+      const board = {
+        id: 'b1',
+        tiles: [],
+        caption: 'data:image/png;base64,@@@'
+      };
+
+      const { board: sanitized, hadFailure } = await API.uploadBoardLocalMedia(
+        board
+      );
+
+      expect(hadFailure).toBe(false);
+      expect(sanitized.caption).toBe('');
+    });
+
+    it('keeps the caption and flags hadFailure on a transient caption upload failure', async () => {
+      jest
+        .spyOn(API, 'tryUploadDataURL')
+        .mockResolvedValue({ url: null, unrecoverable: false });
+
+      const board = {
+        id: 'b1',
+        tiles: [],
+        caption: 'data:image/png;base64,AAAA'
+      };
+
+      const { board: sanitized, hadFailure } = await API.uploadBoardLocalMedia(
+        board
+      );
+
+      expect(hadFailure).toBe(true);
+      expect(sanitized.caption).toBe('data:image/png;base64,AAAA');
+    });
+
+    it('uploads both a base64 tile image and a base64 caption', async () => {
+      jest
+        .spyOn(API, 'tryUploadDataURL')
+        .mockResolvedValueOnce({
+          url: 'https://cdn.example.com/tile.png',
+          unrecoverable: false
+        })
+        .mockResolvedValueOnce({
+          url: 'https://cdn.example.com/caption.png',
+          unrecoverable: false
+        });
+
+      const board = {
+        id: 'b1',
+        tiles: [{ id: 't1', image: 'data:image/png;base64,AAAA' }],
+        caption: 'data:image/png;base64,BBBB'
+      };
+
+      const { board: sanitized, hadFailure } = await API.uploadBoardLocalMedia(
+        board
+      );
+
+      expect(hadFailure).toBe(false);
+      expect(API.tryUploadDataURL).toHaveBeenCalledTimes(2);
+      expect(sanitized.tiles[0].image).toBe('https://cdn.example.com/tile.png');
+      expect(sanitized.caption).toBe('https://cdn.example.com/caption.png');
+    });
   });
 
   it('fetches results from unauthorized api', () => {

--- a/src/api/api.test.js
+++ b/src/api/api.test.js
@@ -443,6 +443,51 @@ describe('Cboard API calls', () => {
         'file:///storage/emulated/0/img.png'
       );
     });
+
+    it('uploads a base64 caption and rewrites it to the url on success', async () => {
+      jest.spyOn(API, 'tryUploadDataURL').mockResolvedValue({
+        url: 'https://cdn.example.com/caption.png',
+        unrecoverable: false
+      });
+
+      const board = {
+        id: 'b1',
+        tiles: [],
+        caption: 'data:image/png;base64,iVBORw0KGgo='
+      };
+
+      const { board: sanitized, hadFailure } = await API.uploadBoardLocalMedia(
+        board
+      );
+
+      expect(hadFailure).toBe(false);
+      expect(API.tryUploadDataURL).toHaveBeenCalledWith(
+        'data:image/png;base64,iVBORw0KGgo=',
+        'b1',
+        true
+      );
+      expect(sanitized.caption).toBe('https://cdn.example.com/caption.png');
+    });
+
+    it('leaves a non-data-url caption untouched and does not upload', async () => {
+      const uploadFile = jest.spyOn(API, 'uploadFile');
+      const tryUploadDataURL = jest.spyOn(API, 'tryUploadDataURL');
+
+      const board = {
+        id: 'b1',
+        tiles: [],
+        caption: 'https://cdn.example.com/existing.png'
+      };
+
+      const { board: sanitized, hadFailure } = await API.uploadBoardLocalMedia(
+        board
+      );
+
+      expect(hadFailure).toBe(false);
+      expect(uploadFile).not.toHaveBeenCalled();
+      expect(tryUploadDataURL).not.toHaveBeenCalled();
+      expect(sanitized.caption).toBe('https://cdn.example.com/existing.png');
+    });
   });
 
   it('fetches results from unauthorized api', () => {

--- a/src/api/api.test.js
+++ b/src/api/api.test.js
@@ -528,16 +528,13 @@ describe('Cboard API calls', () => {
     });
 
     it('uploads both a base64 tile image and a base64 caption', async () => {
-      jest
-        .spyOn(API, 'tryUploadDataURL')
-        .mockResolvedValueOnce({
-          url: 'https://cdn.example.com/tile.png',
-          unrecoverable: false
-        })
-        .mockResolvedValueOnce({
-          url: 'https://cdn.example.com/caption.png',
-          unrecoverable: false
-        });
+      jest.spyOn(API, 'tryUploadDataURL').mockImplementation(async dataURL => ({
+        url:
+          dataURL === 'data:image/png;base64,AAAA'
+            ? 'https://cdn.example.com/tile.png'
+            : 'https://cdn.example.com/caption.png',
+        unrecoverable: false
+      }));
 
       const board = {
         id: 'b1',


### PR DESCRIPTION
Fixes #2277

## Summary

- A board's `caption` can hold a large `data:image/png;base64,...` string. It was sent verbatim to `POST /board`; MongoDB rejects the over-1024-byte index key, surfaced as **HTTP 409**, and the board retries every sync cycle forever (poison pill).
- `uploadBoardLocalMedia` (`src/api/api.js`) only sanitized `board.tiles` and early-returned when `tiles` was empty — so a folder tile's child board (`tiles: []`, `caption: <base64>`) skipped sanitization entirely.
- This PR treats `board.caption` as an uploadable media field: a new `uploadBoardCaptionMedia` helper uploads the data URL and rewrites `caption` to the returned URL, folded into the existing `hadFailure` guard so a base64 caption is never POSTed. The empty-tiles early-return now also accounts for the caption.

## Behavior

- **Success** → `caption` rewritten to the uploaded URL (short key, no 409).
- **Unrecoverable** (blob gone/corrupt) → `caption` cleared to `''` (mirrors the tile-image path), board still syncs.
- **Transient failure** → `hadFailure = true`, so `sanitizeBoardMedia` throws and the board is **not** POSTed with base64; it stays pending and retries a sanitizable payload next cycle.

Existing poison-pill boards self-heal on their next push — they route through the same `uploadBoardLocalMedia`. No change to the push loop, `sanitizeBoardMedia`, `createApiBoard`/`updateApiBoard`, or `TileEditor`.

### Known tradeoff
For a folder tile, the parent board's `tile.image` and the child board's `caption` hold the same base64 but live on different boards, so the image is uploaded twice on first sync. This is a one-time, self-healing cost (both become URLs afterward) and is accepted here; cross-board upload dedup is out of scope.

## Test Plan

- [x] `uploadBoardLocalMedia` uploads a base64 caption and rewrites it to the URL
- [x] Non-data-URL caption left untouched, no upload attempted
- [x] Unrecoverable caption → cleared to `''`, `hadFailure` false
- [x] Transient caption failure → caption unchanged, `hadFailure` true
- [x] Board with both a base64 tile image and a base64 caption → both uploaded
- [x] `Board.actions` consumer tests unaffected (113/113)

🤖 Generated with [Claude Code](https://claude.com/claude-code)