### PR TITLE
fix(sync): exclude non-onboardable boards from untracked telemetry count

### DIFF
--- a/src/components/Board/Board.actions.js
+++ b/src/components/Board/Board.actions.js
@@ -921,6 +921,7 @@ export function syncBoards(remoteBoards) {
     dispatch(syncBoardsStarted());
 
     const startedAt = Date.now();
+    const userEmail = getState().app?.userData?.email;
     const { boards: localBoards, syncMeta } = getState().board;
     const pendingBefore = countPendingBoards(syncMeta);
 
@@ -935,7 +936,11 @@ export function syncBoards(remoteBoards) {
           manifestSize: remoteBoards.length,
           localBoards: localBoards.length,
           localServerBoards,
-          untrackedBefore: countUntrackedBoards(localBoards, syncMeta)
+          untrackedBefore: countUntrackedBoards(
+            localBoards,
+            syncMeta,
+            userEmail
+          )
         }
       });
 
@@ -1002,7 +1007,8 @@ export function syncBoards(remoteBoards) {
           pendingAfter: countPendingBoards(successState.syncMeta),
           untrackedAfter: countUntrackedBoards(
             successState.boards,
-            successState.syncMeta
+            successState.syncMeta,
+            userEmail
           )
         }
       });
@@ -1019,7 +1025,8 @@ export function syncBoards(remoteBoards) {
           pendingAfter: countPendingBoards(failureState.syncMeta),
           untrackedAfter: countUntrackedBoards(
             failureState.boards,
-            failureState.syncMeta
+            failureState.syncMeta,
+            userEmail
           )
         }
       });

--- a/src/components/Board/Board.sync.analytics.js
+++ b/src/components/Board/Board.sync.analytics.js
@@ -1,5 +1,6 @@
 import { appInsights } from '../../appInsights';
 import { SYNC_STATUS } from './Board.constants';
+import { isUnloggedCreatedBoard } from './Board.utils';
 
 // All sync telemetry carries `feature: "sync"` so customEvents and exceptions
 // join cleanly in Kusto. appInsights auto-disables in development.
@@ -44,9 +45,20 @@ export function countPendingBoards(syncMeta = {}) {
   ).length;
 }
 
-/** Count boards with no syncMeta entry (untracked, see docs/sync-engine.md §7). */
-export function countUntrackedBoards(boards = [], syncMeta = {}) {
-  return boards.filter(board => syncMeta[board.id] == null).length;
+/**
+ * Count boards with no syncMeta entry that the sync engine would actually
+ * onboard (untracked, see docs/sync-engine.md §7). Mirrors the eligibility
+ * predicate in classifyBoardsForPush (Board.actions.js): an untracked board is
+ * only tracked when it belongs to the current user or was created while
+ * unlogged. Boards owned by another/default email are never onboarded, so they
+ * stay untracked by design and are excluded here to avoid inflating the metric.
+ */
+export function countUntrackedBoards(boards = [], syncMeta = {}, userEmail) {
+  return boards.filter(
+    board =>
+      syncMeta[board.id] == null &&
+      (board.email === userEmail || isUnloggedCreatedBoard(board))
+  ).length;
 }
 
 /**

--- a/src/components/Board/__tests__/Board.sync.analytics.test.js
+++ b/src/components/Board/__tests__/Board.sync.analytics.test.js
@@ -1,7 +1,8 @@
 import {
   trackSyncEvent,
   trackSyncException,
-  getManifestWatermark
+  getManifestWatermark,
+  countUntrackedBoards
 } from '../Board.sync.analytics';
 import { appInsights } from '../../../appInsights';
 
@@ -54,6 +55,56 @@ describe('getManifestWatermark', () => {
   it('returns null for a missing or non-array manifest', () => {
     expect(getManifestWatermark()).toBeNull();
     expect(getManifestWatermark(null)).toBeNull();
+  });
+});
+
+describe('countUntrackedBoards', () => {
+  const USER_EMAIL = 'user@example.com';
+
+  it('counts untracked boards owned by the current user', () => {
+    const boards = [{ id: 'aaaaaaaaaaaaaaaa', email: USER_EMAIL }];
+
+    expect(countUntrackedBoards(boards, {}, USER_EMAIL)).toBe(1);
+  });
+
+  it('counts untracked boards created while unlogged (no email)', () => {
+    const boards = [{ id: 'aaaaaaaaaaaaaaaa', email: '' }];
+
+    expect(countUntrackedBoards(boards, {}, USER_EMAIL)).toBe(1);
+  });
+
+  it('excludes shipped default boards owned by the default email', () => {
+    // `root` is a real default board id; still owned by support@cboard.io it is
+    // never onboarded by the sync engine, so it must not count as untracked.
+    const boards = [{ id: 'root', email: 'support@cboard.io' }];
+
+    expect(countUntrackedBoards(boards, {}, USER_EMAIL)).toBe(0);
+  });
+
+  it("excludes untracked boards owned by another user's email", () => {
+    const boards = [{ id: 'aaaaaaaaaaaaaaaa', email: 'someone@else.com' }];
+
+    expect(countUntrackedBoards(boards, {}, USER_EMAIL)).toBe(0);
+  });
+
+  it('excludes boards that already have a syncMeta entry', () => {
+    const boards = [{ id: 'aaaaaaaaaaaaaaaa', email: USER_EMAIL }];
+    const syncMeta = { aaaaaaaaaaaaaaaa: { status: 'SYNCED' } };
+
+    expect(countUntrackedBoards(boards, syncMeta, USER_EMAIL)).toBe(0);
+  });
+
+  it('counts only the eligible untracked boards in a mixed list', () => {
+    const boards = [
+      { id: 'aaaaaaaaaaaaaaaa', email: USER_EMAIL }, // untracked, user-owned
+      { id: 'bbbbbbbbbbbbbbbb', email: '' }, // untracked, unlogged
+      { id: 'root', email: 'support@cboard.io' }, // default, excluded
+      { id: 'cccccccccccccccc', email: 'other@x.com' }, // other user, excluded
+      { id: 'dddddddddddddddd', email: USER_EMAIL } // tracked, excluded
+    ];
+    const syncMeta = { dddddddddddddddd: { status: 'SYNCED' } };
+
+    expect(countUntrackedBoards(boards, syncMeta, USER_EMAIL)).toBe(2);
   });
 });
 


### PR DESCRIPTION
## What & why

`countUntrackedBoards` (`src/components/Board/Board.sync.analytics.js`) counted every board with no `syncMeta` entry. That overcounts: shipped **default boards** (still owned by `support@cboard.io`) and boards owned by another user's email are never onboarded by the sync engine, so they stay untracked *by design* and permanently inflate the `untrackedBefore` / `untrackedAfter` measurements on `Sync_BoardsStarted` and `Sync_Completed`.

The push classifier `classifyBoardsForPush` (`Board.actions.js`) only onboards an untracked board when:

```js
board.email === userEmail || isUnloggedCreatedBoard(board)
```

The telemetry counter now mirrors that predicate exactly, so the metric reflects only the boards the engine would actually track.

## Changes

- `countUntrackedBoards` takes a `userEmail` argument and filters with the classifier's eligibility predicate.
- Threaded `userEmail` (read once from `getState().app?.userData?.email`) through the three call sites in `syncBoards`.
- Added 6 unit tests covering user-owned, unlogged, default-board, foreign-email, already-tracked, and mixed-list cases.

## Testing

`react-scripts test Board.sync.analytics` — 15/15 pass (6 new).

## Notes

- Telemetry-only change; no user-facing behavior is affected.
- When unauthenticated, `userEmail` is `undefined` and only `isUnloggedCreatedBoard` boards count — consistent with the push loop, which bails when there's no email.

Closes #2279

🤖 Generated with [Claude Code](https://claude.com/claude-code)