### PR TITLE
Handle PayPal suspended subscription with fix-payment flow

### DIFF
--- a/src/components/Settings/Subscribe/Subscribe.messages.js
+++ b/src/components/Settings/Subscribe/Subscribe.messages.js
@@ -85,6 +85,15 @@ export default defineMessages({
     id: 'cboard.components.Settings.Subscribe.on_hold',
     defaultMessage: 'Your subscription expired on: {e}'
   },
+  suspended: {
+    id: 'cboard.components.Settings.Subscribe.suspended',
+    defaultMessage:
+      'Your PayPal subscription was suspended due to failed payments. Fix your payment on PayPal to reactivate it.'
+  },
+  fixPaymentOnPaypal: {
+    id: 'cboard.components.Settings.Subscribe.fixPaymentOnPaypal',
+    defaultMessage: 'Fix Payment on PayPal'
+  },
   not_subscribed: {
     id: 'cboard.components.Settings.Subscribe.not_subscribed',
     defaultMessage: 'You are not subscribed. '

--- a/src/components/Settings/Subscribe/SubscriptionPlans.js
+++ b/src/components/Settings/Subscribe/SubscriptionPlans.js
@@ -27,6 +27,7 @@ import {
   NOT_SUBSCRIBED,
   PROCCESING,
   ON_HOLD,
+  SUSPENDED,
   UNVERIFIED
 } from '../../../providers/SubscriptionProvider/SubscriptionProvider.constants';
 import Button from '@material-ui/core/Button';
@@ -77,7 +78,8 @@ const SubscriptionPlans = ({
     error,
     isOnTrialPeriod,
     isSubscribed,
-    products
+    products,
+    paypalFixPaymentUrl
   } = subscription;
 
   let plans = [];
@@ -117,7 +119,8 @@ const SubscriptionPlans = ({
 
     on_hold: 'warning', //TODO
     paused: 'info', //TODO
-    expired: 'warning' //TODO
+    expired: 'warning', //TODO
+    suspended: 'error'
   };
 
   const paypalButtonsStyle = {
@@ -276,7 +279,23 @@ const SubscriptionPlans = ({
                       <FormattedMessage {...messages.subscribe} />
                     </Button>
                   )}
-                  {!isCordova() && isLogged && (
+                  {!isCordova() && isLogged && status === SUSPENDED && (
+                    <Button
+                      variant="contained"
+                      fullWidth={true}
+                      color="primary"
+                      component="a"
+                      href={
+                        paypalFixPaymentUrl ||
+                        'https://www.paypal.com/myaccount/autopay/'
+                      }
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <FormattedMessage {...messages.fixPaymentOnPaypal} />
+                    </Button>
+                  )}
+                  {!isCordova() && isLogged && status !== SUSPENDED && (
                     <PayPalButtons
                       style={paypalButtonsStyle}
                       disabled={!canPurchase}

--- a/src/components/Settings/Subscribe/SubscriptionPlans.js
+++ b/src/components/Settings/Subscribe/SubscriptionPlans.js
@@ -192,175 +192,182 @@ const SubscriptionPlans = ({
           values={{ e: `${expiryDateFormated}` }}
         />
       </Alert>
+      {!isCordova() && isLogged && status === SUSPENDED && (
+        <Grid
+          container
+          spacing={0}
+          alignItems="center"
+          justifyContent="center"
+          style={{ padding: '16px' }}
+        >
+          <Button
+            variant="contained"
+            color="primary"
+            component="a"
+            href={
+              paypalFixPaymentUrl || 'https://www.paypal.com/myaccount/autopay/'
+            }
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <FormattedMessage {...messages.fixPaymentOnPaypal} />
+          </Button>
+        </Grid>
+      )}
       <Grid
         container
         spacing={0}
         alignItems="center"
         justifyContent="space-around"
       >
-        {plans.map(product => {
-          return [
-            <Grid
-              key={product.id}
-              item
-              xs={12}
-              sm={6}
-              style={{ padding: '5px', maxWidth: 328 }}
-            >
-              <Card style={{ minWidth: 275 }} variant="outlined">
-                <CardContent>
-                  <Typography
-                    color="secondary"
-                    gutterBottom
-                    className={classes.titles}
-                  >
-                    {formatTitle(product.title)}
-                  </Typography>
-                  <Box
-                    sx={{
-                      display: 'flex',
-                      justifyContent: 'center',
-                      alignItems: 'baseline',
-                      mb: 2
-                    }}
-                  >
+        {status !== SUSPENDED &&
+          plans.map(product => {
+            return [
+              <Grid
+                key={product.id}
+                item
+                xs={12}
+                sm={6}
+                style={{ padding: '5px', maxWidth: 328 }}
+              >
+                <Card style={{ minWidth: 275 }} variant="outlined">
+                  <CardContent>
                     <Typography
-                      component="h2"
-                      variant="h3"
-                      color="text.primary"
+                      color="secondary"
+                      gutterBottom
+                      className={classes.titles}
                     >
-                      {product.price.currencyCode} {product.price.units}
+                      {formatTitle(product.title)}
                     </Typography>
-                    <Typography variant="h6" color="text.secondary">
-                      /{formatDuration(product.billingPeriod)}
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        justifyContent: 'center',
+                        alignItems: 'baseline',
+                        mb: 2
+                      }}
+                    >
+                      <Typography
+                        component="h2"
+                        variant="h3"
+                        color="text.primary"
+                      >
+                        {product.price.currencyCode} {product.price.units}
+                      </Typography>
+                      <Typography variant="h6" color="text.secondary">
+                        /{formatDuration(product.billingPeriod)}
+                      </Typography>
+                    </Box>
+                    {(isAndroid() || isIOS()) && (
+                      <Button
+                        variant="contained"
+                        fullWidth={true}
+                        color="primary"
+                        {...(!isLogged
+                          ? { component: Link, to: '/login-signup' }
+                          : {
+                              onClick: function() {
+                                onSubscribe(product);
+                              }
+                            })}
+                        disabled={!canPurchase}
+                      >
+                        <FormattedMessage {...messages.subscribe} />
+                      </Button>
+                    )}
+                    {isElectron() && (
+                      <Button
+                        variant="contained"
+                        fullWidth={true}
+                        color="primary"
+                        onClick={function() {
+                          window.cordova.plugins.DefaultBrowser.open(
+                            'https://app.cboard.io/settings/subscribe'
+                          );
+                        }}
+                        disabled={!canPurchase}
+                      >
+                        <FormattedMessage {...messages.subscribe} />
+                      </Button>
+                    )}
+                    {!isCordova() && !isLogged && (
+                      <Button
+                        variant="contained"
+                        fullWidth={true}
+                        color="primary"
+                        component={Link}
+                        to="/login-signup"
+                        disabled={!canPurchase}
+                      >
+                        <FormattedMessage {...messages.subscribe} />
+                      </Button>
+                    )}
+                    {!isCordova() && isLogged && (
+                      <PayPalButtons
+                        style={paypalButtonsStyle}
+                        disabled={!canPurchase}
+                        fundingSource={undefined}
+                        createSubscription={(data, actions) => {
+                          return actions.subscription.create({
+                            plan_id: product.paypalId
+                          });
+                        }}
+                        onClick={function(data, actions) {
+                          onPaypalAction('onClick', product, data);
+                        }}
+                        onApprove={function(data, actions) {
+                          // In theory we could get transaction details doing:
+                          // actions.subscription.get().then(details=>{
+                          //   console.log(details);
+                          // });
+                          // but doesn't work because of an issue with the
+                          // paypal react library.
+                          // See https://stackoverflow.com/questions/59609198/how-to-get-user-information-after-subscription
+                          onPaypalAction('onApprove', product, data);
+                        }}
+                        onCancel={function(data, actions) {
+                          onPaypalAction('onCancel', product, data);
+                        }}
+                        onError={function(data, actions) {
+                          onPaypalAction('onError', product, data);
+                        }}
+                      />
+                    )}
+                    <Typography color="secondary">
+                      <br />
+                      <br />
+                      <FormattedMessage {...messages.includedFeatures} />
                     </Typography>
-                  </Box>
-                  {(isAndroid() || isIOS()) && (
-                    <Button
-                      variant="contained"
-                      fullWidth={true}
-                      color="primary"
-                      {...(!isLogged
-                        ? { component: Link, to: '/login-signup' }
-                        : {
-                            onClick: function() {
-                              onSubscribe(product);
-                            }
-                          })}
-                      disabled={!canPurchase}
-                    >
-                      <FormattedMessage {...messages.subscribe} />
-                    </Button>
-                  )}
-                  {isElectron() && (
-                    <Button
-                      variant="contained"
-                      fullWidth={true}
-                      color="primary"
-                      onClick={function() {
-                        window.cordova.plugins.DefaultBrowser.open(
-                          'https://app.cboard.io/settings/subscribe'
-                        );
-                      }}
-                      disabled={!canPurchase}
-                    >
-                      <FormattedMessage {...messages.subscribe} />
-                    </Button>
-                  )}
-                  {!isCordova() && !isLogged && (
-                    <Button
-                      variant="contained"
-                      fullWidth={true}
-                      color="primary"
-                      component={Link}
-                      to="/login-signup"
-                      disabled={!canPurchase}
-                    >
-                      <FormattedMessage {...messages.subscribe} />
-                    </Button>
-                  )}
-                  {!isCordova() && isLogged && status === SUSPENDED && (
-                    <Button
-                      variant="contained"
-                      fullWidth={true}
-                      color="primary"
-                      component="a"
-                      href={
-                        paypalFixPaymentUrl ||
-                        'https://www.paypal.com/myaccount/autopay/'
-                      }
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      <FormattedMessage {...messages.fixPaymentOnPaypal} />
-                    </Button>
-                  )}
-                  {!isCordova() && isLogged && status !== SUSPENDED && (
-                    <PayPalButtons
-                      style={paypalButtonsStyle}
-                      disabled={!canPurchase}
-                      fundingSource={undefined}
-                      createSubscription={(data, actions) => {
-                        return actions.subscription.create({
-                          plan_id: product.paypalId
-                        });
-                      }}
-                      onClick={function(data, actions) {
-                        onPaypalAction('onClick', product, data);
-                      }}
-                      onApprove={function(data, actions) {
-                        // In theory we could get transaction details doing:
-                        // actions.subscription.get().then(details=>{
-                        //   console.log(details);
-                        // });
-                        // but doesn't work because of an issue with the
-                        // paypal react library.
-                        // See https://stackoverflow.com/questions/59609198/how-to-get-user-information-after-subscription
-                        onPaypalAction('onApprove', product, data);
-                      }}
-                      onCancel={function(data, actions) {
-                        onPaypalAction('onCancel', product, data);
-                      }}
-                      onError={function(data, actions) {
-                        onPaypalAction('onError', product, data);
-                      }}
-                    />
-                  )}
-                  <Typography color="secondary">
-                    <br />
-                    <br />
-                    <FormattedMessage {...messages.includedFeatures} />
-                  </Typography>
-                  <List disablePadding style={{ padding: '5px' }}>
-                    {INCLUDED_FEATURES.map(feature => {
-                      return [
-                        <ListItem key={feature}>
-                          <ListItemIcon className={classes.icon}>
-                            <CheckCircleIcon />
-                          </ListItemIcon>
-                          <ListItemText
-                            primary={
-                              <FormattedMessage
-                                {...messages[feature] || {
-                                  ...messages.fallback
-                                }}
-                              />
-                            }
-                            secondary={null}
-                          />
-                        </ListItem>
-                      ];
-                    })}
-                  </List>
-                </CardContent>
-                {/*  //TODO
+                    <List disablePadding style={{ padding: '5px' }}>
+                      {INCLUDED_FEATURES.map(feature => {
+                        return [
+                          <ListItem key={feature}>
+                            <ListItemIcon className={classes.icon}>
+                              <CheckCircleIcon />
+                            </ListItemIcon>
+                            <ListItemText
+                              primary={
+                                <FormattedMessage
+                                  {...messages[feature] || {
+                                    ...messages.fallback
+                                  }}
+                                />
+                              }
+                              secondary={null}
+                            />
+                          </ListItem>
+                        ];
+                      })}
+                    </List>
+                  </CardContent>
+                  {/*  //TODO
                   <CardActions>
                     <Button size="small">Learn More</Button>
                   </CardActions> */}
-              </Card>
-            </Grid>
-          ];
-        })}
+                </Card>
+              </Grid>
+            ];
+          })}
       </Grid>
     </>
   );

--- a/src/providers/SubscriptionProvider/SubscriptionProvider.actions.js
+++ b/src/providers/SubscriptionProvider/SubscriptionProvider.actions.js
@@ -15,6 +15,7 @@ import {
   SHOW_LOGIN_REQUIRED,
   HIDE_LOGIN_REQUIRED,
   UNVERIFIED,
+  SUSPENDED,
   DAYS_TO_TRY
 } from './SubscriptionProvider.constants';
 import API from '../../api';
@@ -210,12 +211,18 @@ export function updateIsSubscribed(requestOrigin = 'unkwnown') {
         if (transaction?.expiryDate) {
           expiryDate = transaction.expiryDate;
         }
+        const paypalFixPaymentUrl =
+          status.toLowerCase() === SUSPENDED
+            ? transaction?.nativePurchase?.links?.find(l => l.rel === 'approve')
+                ?.href || null
+            : null;
         dispatch(
           updateSubscription({
             ownedProduct,
             status: status.toLowerCase(),
             isSubscribed,
-            expiryDate
+            expiryDate,
+            paypalFixPaymentUrl
           })
         );
       }

--- a/src/providers/SubscriptionProvider/SubscriptionProvider.constants.js
+++ b/src/providers/SubscriptionProvider/SubscriptionProvider.constants.js
@@ -18,6 +18,7 @@ export const IN_GRACE_PERIOD = 'in_grace_period';
 export const PAUSED = 'paused';
 export const EXPIRED = 'expired';
 export const ON_HOLD = 'on_hold';
+export const SUSPENDED = 'suspended';
 export const UNVERIFIED = 'unverified';
 
 export const DAYS_TO_TRY = 15;


### PR DESCRIPTION
When a PayPal subscription was suspended, the Subscribe screen showed "Wait please..." (fallback message) and all buttons were disabled. The user had no way to act from within the app.

**Changes**
- `SubscriptionProvider.constants.js`: Added SUSPENDED = 'suspended' constant
- `SubscriptionProvider.actions.js`: When status is suspended, extracts the PayPal approve link from `transaction.nativePurchase.links` and dispatches it as `paypalFixPaymentUrl` in subscription state
- `Subscribe.messages.js`: Added suspended message explaining the payment failure, and `fixPaymentOnPaypal` button label
- `SubscriptionPlans.js`: When status is suspended, hides plan cards and shows a single "Fix Payment on PayPal" button that links to PayPal's hosted payment update page (using the approve link from the subscription, falling back to paypal.com/myaccount/autopay/)

**User flow after fix**
1. User opens Settings → Subscribe and sees a red alert: "Your PayPal subscription was suspended due to failed payments. Fix your payment on PayPal to reactivate it."
2. Clicks "Fix Payment on PayPal" → taken to PayPal's hosted page to update their payment method
3. PayPal collects outstanding balance and reactivates the subscription
4. User returns, clicks the refresh button in the alert → status updates to active