### PR TITLE
refactor(tests): Improve symbol provider disabling reliability

### DIFF
--- a/tests/page-objects/cboard.js
+++ b/tests/page-objects/cboard.js
@@ -4148,6 +4148,27 @@ export class Cboard {
     await this.arasaacSymbolsCheckbox.click();
   }
 
+  /**
+   * Deterministically turn a provider off. Clicks only when the switch is
+   * currently checked and waits until it is confirmed unchecked, so a click
+   * that fails to register (e.g. during a dialog transition) is self-healed.
+   * @param {import('@playwright/test').Locator} checkbox
+   */
+  async disableProvider(checkbox) {
+    if (await checkbox.isChecked()) {
+      await checkbox.click();
+    }
+    await expect(checkbox).not.toBeChecked();
+  }
+
+  /** Disable all four symbol providers and confirm each is unchecked. */
+  async disableAllProviders() {
+    await this.disableProvider(this.mulberryCheckbox);
+    await this.disableProvider(this.globalSymbolsCheckbox);
+    await this.disableProvider(this.arasaacSymbolsCheckbox);
+    await this.disableProvider(this.cboardSymbolsCheckbox);
+  }
+
   /** Assert all 4 symbol provider checkboxes are visible in the filter bar. */
   async expectAllSymbolProvidersVisible() {
     await expect(this.mulberryCheckbox).toBeVisible();

--- a/tests/unlogged/symbols.spec.js
+++ b/tests/unlogged/symbols.spec.js
@@ -29,13 +29,7 @@ test.describe('Cboard - Symbol Search: Cboard Symbols Provider', () => {
   });
 
   test('should show Cboard Symbols results after re-enabling the provider from an all-disabled state', async () => {
-    await cboard.toggleMulberryProvider();
-    await cboard.waitForTimeout(500);
-    await cboard.toggleGlobalSymbolsProvider();
-    await cboard.waitForTimeout(500);
-    await cboard.toggleArasaacSymbolsProvider();
-    await cboard.waitForTimeout(500);
-    await cboard.toggleCboardSymbolsProvider();
+    await cboard.disableAllProviders();
     await cboard.expectCboardSymbolsDisabled();
     await cboard.waitForTimeout(500);
 


### PR DESCRIPTION
Introduces `disableProvider` to deterministically turn off symbol provider checkboxes, improving test robustness by confirming the unchecked state.

Consolidates repetitive test setup for disabling all providers into `disableAllProviders`, enhancing readability and maintainability of test specs.
