### PR TITLE
Skips Apple's 'application' pseudo-receipt

### DIFF
--- a/src/providers/SubscriptionProvider/SubscriptionProvider.container.js
+++ b/src/providers/SubscriptionProvider/SubscriptionProvider.container.js
@@ -110,6 +110,18 @@ export class SubscriptionProvider extends Component {
           ? receipt.transaction
           : transformReceipt(receipt);
 
+        // Apple's "application" pseudo-receipt has no real purchase and its
+        // id is not a valid App Store transaction id. Posting it makes the
+        // API's App Store verification fail with "Invalid transaction id"
+        // (errorCode 4000006), so skip it here.
+        if (isIOS() && transaction?.id === 'appstore.application') {
+          callback({
+            ok: false,
+            message: 'Skipping application pseudo-receipt'
+          });
+          return;
+        }
+
         const res = await API.postTransaction(transaction);
         if (!res.ok) throw res;
         callback({


### PR DESCRIPTION
Prevents an issue where Apple's 'application' pseudo-receipt, which is not a real purchase and has an invalid transaction ID, would be sent to the API.

Sending this type of receipt causes App Store verification to fail with an "Invalid transaction id" error. This change introduces a check on iOS to skip processing these specific pseudo-receipts, ensuring only valid transactions are posted and preventing API errors.