### PR TITLE
Manage missing PayPal subscription status

### DIFF
--- a/src/providers/SubscriptionProvider/SubscriptionProvider.actions.js
+++ b/src/providers/SubscriptionProvider/SubscriptionProvider.actions.js
@@ -22,6 +22,7 @@ import API from '../../api';
 import { isLogged } from '../../components/App/App.selectors';
 import { isAndroid, isIOS } from '../../cordova-util';
 import { formatTitle } from '../../components/Settings/Subscribe/Subscribe.helpers';
+import { normalizeStatus } from './SubscriptionProvider.helpers';
 import { updateNavigationSettings } from '../../components/App/App.actions';
 import { IS_PRODUCTION } from '../../constants';
 
@@ -219,7 +220,7 @@ export function updateIsSubscribed(requestOrigin = 'unkwnown') {
         dispatch(
           updateSubscription({
             ownedProduct,
-            status: status.toLowerCase(),
+            status: normalizeStatus(status),
             isSubscribed,
             expiryDate,
             paypalFixPaymentUrl

--- a/src/providers/SubscriptionProvider/SubscriptionProvider.helpers.js
+++ b/src/providers/SubscriptionProvider/SubscriptionProvider.helpers.js
@@ -1,0 +1,42 @@
+import {
+  ACTIVE,
+  CANCELED,
+  EXPIRED,
+  IN_GRACE_PERIOD,
+  NOT_SUBSCRIBED,
+  ON_HOLD,
+  PAUSED,
+  PROCCESING,
+  SUSPENDED,
+  UNVERIFIED
+} from './SubscriptionProvider.constants';
+
+// Maps status aliases (e.g. from older DB documents or PayPal vocabulary
+// that slipped through without normalization) to canonical constants.
+const STATUS_ALIASES = {
+  cancelled: CANCELED
+};
+
+const KNOWN_STATUSES = [
+  ACTIVE,
+  CANCELED,
+  EXPIRED,
+  IN_GRACE_PERIOD,
+  NOT_SUBSCRIBED,
+  ON_HOLD,
+  PAUSED,
+  PROCCESING,
+  SUSPENDED,
+  UNVERIFIED
+];
+
+/**
+ * Normalizes a subscription status string to a known constant.
+ * Falls back to NOT_SUBSCRIBED for any unrecognized value so the user
+ * is never locked out of purchasing.
+ */
+export const normalizeStatus = status => {
+  const lowered = typeof status === 'string' ? status.toLowerCase() : '';
+  const aliased = STATUS_ALIASES[lowered] || lowered;
+  return KNOWN_STATUSES.includes(aliased) ? aliased : NOT_SUBSCRIBED;
+};

--- a/src/providers/SubscriptionProvider/SubscriptionProvider.reducer.js
+++ b/src/providers/SubscriptionProvider/SubscriptionProvider.reducer.js
@@ -12,6 +12,7 @@ import {
   LOGOUT,
   LOGIN_SUCCESS
 } from '../../components/Account/Login/Login.constants';
+import { normalizeStatus } from './SubscriptionProvider.helpers';
 
 const initialState = {
   subscriberId: '',
@@ -79,7 +80,7 @@ function subscriptionProviderReducer(state = initialState, action) {
       return {
         ...state,
         subscriberId: id,
-        status: status,
+        status: normalizeStatus(status),
         expiryDate: expiry
       };
     case LOGOUT:


### PR DESCRIPTION
Add `normalizeStatus` helper (from `SubscriptionProvider.helpers.js`) that maps status aliases and rejects unknown values, falling back to `NOT_SUBSCRIBED` so users are never locked out of purchasing. 

Applied at two write sites: `SubscriptionProvider.actions.js` (replacing the plain` .toLowerCase()` call) and `SubscriptionProvider.reducer.js` on `LOGIN_SUCCESS` (fixing a bug where statuses from `/user` were stored in uppercase until overwritten by `updateIsSubscribed`).