### PR TITLE
chore: ignore Prettier baseline in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Prettier 3 repository-wide mechanical formatting baseline (PR #2316)
+05843a0412c3ee0809587a13c8780f8169955ce7


### PR DESCRIPTION
## Summary

- add `.git-blame-ignore-revs` at the repository root
- ignore only the full SHA for PR #2316's mechanical Prettier formatting baseline
- keep the PR merge commit and substantive tooling/CI commits visible to blame

## Why

The repository-wide Prettier 3 baseline mechanically changed many lines, obscuring the substantive history shown by `git blame`. Ignoring that one formatting revision restores attribution to the earlier commits without hiding functional changes.

## Impact

Developers can pass `.git-blame-ignore-revs` to `git blame` and see the pre-formatting authorship for mechanically changed lines. Runtime behavior is unchanged.

## Validation

- `git diff --check origin/master...HEAD`
- `git blame --ignore-revs-file .git-blame-ignore-revs src/components/Board/Board.container.js`
- the formatting commit attributed 70 lines in ordinary blame and 0 lines when the ignore file was applied
- sampled lines 246 and 249 moved from `05843a041...` to the earlier substantive commit `e4f1071e0...`