### PR TITLE
fix: use production API in packaged apps instead of invalid file://api. URL

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,14 +1,19 @@
-import { isCordova } from './cordova-util';
-
 let host = window.location.host || '';
 host = host.startsWith('www.') ? host.slice(4) : host;
 const DEV_API_URL = process.env.REACT_APP_DEV_API_URL || null;
 export const ARASAAC_BASE_PATH_API = 'https://api.arasaac.org/api/';
 export const GLOBALSYMBOLS_BASE_PATH_API = 'https://globalsymbols.com/api/v1/';
 
-const RAW_API_URL = isCordova()
-  ? 'https://api.app.cboard.io/'
-  : DEV_API_URL || `${window.location.protocol}//api.${host}`;
+// Only genuine web deployments derive the API from the host; packaged apps
+// (Electron file://, Android https://localhost, iOS app://localhost) use prod.
+const { protocol, hostname } = window.location;
+const isWebHosted =
+  (protocol === 'http:' || protocol === 'https:') &&
+  hostname !== 'localhost' &&
+  hostname !== '';
+const RAW_API_URL =
+  DEV_API_URL ||
+  (isWebHosted ? `${protocol}//api.${host}` : 'https://api.app.cboard.io/');
 const RAW_API_URL_LAST_CHAR = RAW_API_URL.length - 1;
 export const API_URL =
   RAW_API_URL[RAW_API_URL_LAST_CHAR] === '/' ? RAW_API_URL : `${RAW_API_URL}/`;


### PR DESCRIPTION
## Problem

Packaged builds (Electron, Android, iOS) cannot reach the backend. Requests go to invalid URLs such as:

```
GET file://api./board/sync/<email>   net::ERR_FILE_NOT_FOUND
GET file://api./user/<id>            net::ERR_FILE_NOT_FOUND
```
followed by `AxiosError: Network Error`.

## Root cause

`src/constants.js` selects the API base URL with `isCordova()`:

```js
const RAW_API_URL = isCordova()
  ? 'https://api.app.cboard.io/'
  : DEV_API_URL || `${window.location.protocol}//api.${host}`;
```

`isCordova()` is just `!!window.cordova`, but `constants.js` executes at **bundle-evaluation time**, before Cordova has defined `window.cordova`. So in packaged builds `isCordova()` is `false` and the base URL is derived from `window.location`, which for locally-served apps is not a real web host:

- Electron → `file://` (empty host) → `file://api./...`
- Android → `https://localhost`
- iOS → `app://localhost`

All of these produce a broken API URL, so every backend request fails.

## Fix

Choose the API URL from the **actual protocol/hostname** instead of the not-yet-ready `window.cordova`:

- Genuine web deployments (`http:`/`https:` with a real, non-`localhost` hostname) still derive `//api.<host>` — unchanged behavior for `app.cboard.io`, `app.dev.cboard.io`, `app.qa.cboard.io`.
- Everything else (packaged apps) uses `https://api.app.cboard.io/`.
- `REACT_APP_DEV_API_URL` still takes precedence for local/dev overrides.

This removes the dependency on Cordova initialization timing, fixing Electron, Android and iOS builds.

## Testing

- Rebuilt the web bundle and repackaged the Electron app; backend requests now hit `https://api.app.cboard.io/...` and sync/user/subscription calls succeed.
- Web behavior unchanged (still derives `//api.<host>`).