### PR TITLE
refactor: add isPackagedApp() helper; fix history + broken images in packaged apps

### DIFF
--- a/src/components/Settings/About/About.component.js
+++ b/src/components/Settings/About/About.component.js
@@ -11,16 +11,16 @@ import FullScreenDialog, {
 } from '../../UI/FullScreenDialog';
 import CboardLogo from '../../WelcomeScreen/CboardLogo';
 import './About.css';
-import { isCordova } from '../../../cordova-util';
+import { isPackagedApp } from '../../../cordova-util';
 
 const itemData = [
   {
-    img: (isCordova() ? '.' : '') + '/images/sponsers/unicef.png',
+    img: (isPackagedApp() ? '.' : '') + '/images/sponsers/unicef.png',
     title: 'UNICEF',
     author: 'UNICEF'
   },
   {
-    img: (isCordova() ? '.' : '') + '/images/sponsers/microsoft.png',
+    img: (isPackagedApp() ? '.' : '') + '/images/sponsers/microsoft.png',
     title: 'Microsoft',
     author: 'Microsoft'
   }

--- a/src/components/WelcomeScreen/CboardLogo/CboardLogo.component.js
+++ b/src/components/WelcomeScreen/CboardLogo/CboardLogo.component.js
@@ -2,16 +2,16 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { CSSTransition } from 'react-transition-group';
 
-import { isCordova } from '../../../cordova-util';
+import { isPackagedApp } from '../../../cordova-util';
 
 import './CboardLogo.css';
 
-// Cordova path cannot be absolute
-const imageWhite = isCordova()
+// Packaged-app asset paths must be relative (served over file://).
+const imageWhite = isPackagedApp()
   ? './images/logo-white-slogan.png'
   : '/images/logo-white-slogan.png';
 
-const imageViolet = isCordova()
+const imageViolet = isPackagedApp()
   ? './images/logo-violet.svg'
   : '/images/logo-violet.svg';
 

--- a/src/components/WelcomeScreen/WelcomeScreen.container.js
+++ b/src/components/WelcomeScreen/WelcomeScreen.container.js
@@ -22,10 +22,10 @@ import CboardLogo from './CboardLogo/CboardLogo.component';
 import './WelcomeScreen.css';
 import { API_URL, GOOGLE_FIREBASE_WEB_CLIENT_ID } from '../../constants';
 import {
-  isCordova,
   isAndroid,
   isElectron,
   isIOS,
+  isPackagedApp,
   manageKeyboardEvents
 } from '../../cordova-util';
 
@@ -33,8 +33,8 @@ const SocialBtnStyle = {
   borderRadius: '15px'
 };
 
-// Cordova path cannot be absolute
-const backgroundImage = isCordova()
+// Packaged-app asset paths must be relative (served over file://).
+const backgroundImage = isPackagedApp()
   ? './images/bg/waves.png'
   : '/images/bg/waves.png';
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,19 +1,18 @@
+import { isPackagedApp } from './cordova-util';
+
 let host = window.location.host || '';
 host = host.startsWith('www.') ? host.slice(4) : host;
 const DEV_API_URL = process.env.REACT_APP_DEV_API_URL || null;
 export const ARASAAC_BASE_PATH_API = 'https://api.arasaac.org/api/';
 export const GLOBALSYMBOLS_BASE_PATH_API = 'https://globalsymbols.com/api/v1/';
 
-// Only genuine web deployments derive the API from the host; packaged apps
-// (Electron file://, Android https://localhost, iOS app://localhost) use prod.
-const { protocol, hostname } = window.location;
-const isWebHosted =
-  (protocol === 'http:' || protocol === 'https:') &&
-  hostname !== 'localhost' &&
-  hostname !== '';
+// Packaged apps (Electron/Android file://, iOS app://localhost) use the prod
+// API; genuine web deployments derive it from the current host.
 const RAW_API_URL =
   DEV_API_URL ||
-  (isWebHosted ? `${protocol}//api.${host}` : 'https://api.app.cboard.io/');
+  (isPackagedApp()
+    ? 'https://api.app.cboard.io/'
+    : `${window.location.protocol}//api.${host}`);
 const RAW_API_URL_LAST_CHAR = RAW_API_URL.length - 1;
 export const API_URL =
   RAW_API_URL[RAW_API_URL_LAST_CHAR] === '/' ? RAW_API_URL : `${RAW_API_URL}/`;

--- a/src/cordova-util.js
+++ b/src/cordova-util.js
@@ -8,6 +8,13 @@ export const isElectron = () =>
 
 export const isIOS = () => isCordova() && window.cordova.platformId === 'ios';
 
+// Reliable at module-load time (unlike isCordova, which needs window.cordova to
+// be set first): packaged apps are served over a non-web scheme (Electron and
+// Android file://, iOS app://localhost).
+export const isPackagedApp = () =>
+  window.location.protocol !== 'http:' &&
+  window.location.protocol !== 'https:';
+
 export const onCordovaReady = (onReady) =>
   document.addEventListener('deviceready', onReady, false);
 

--- a/src/cordova-util.js
+++ b/src/cordova-util.js
@@ -12,8 +12,7 @@ export const isIOS = () => isCordova() && window.cordova.platformId === 'ios';
 // be set first): packaged apps are served over a non-web scheme (Electron and
 // Android file://, iOS app://localhost).
 export const isPackagedApp = () =>
-  window.location.protocol !== 'http:' &&
-  window.location.protocol !== 'https:';
+  window.location.protocol !== 'http:' && window.location.protocol !== 'https:';
 
 export const onCordovaReady = (onReady) =>
   document.addEventListener('deviceready', onReady, false);

--- a/src/history.js
+++ b/src/history.js
@@ -1,9 +1,7 @@
 import { createBrowserHistory, createHashHistory } from 'history';
+import { isPackagedApp } from './cordova-util';
 
-// window.cordova isn't set at module-eval time, so detect packaged apps by
-// their non-web scheme (Electron/Android file://, iOS app://localhost) and use
-// hash history there; genuine web (http/https) uses browser history.
-const isWebHosted =
-  window.location.protocol === 'http:' || window.location.protocol === 'https:';
-const history = isWebHosted ? createBrowserHistory() : createHashHistory();
+// Packaged apps (Electron/Android file://, iOS app://localhost) need hash
+// history; HTML5 path history doesn't resolve there. Web uses browser history.
+const history = isPackagedApp() ? createHashHistory() : createBrowserHistory();
 export default history;


### PR DESCRIPTION
## Summary

Introduces a shared `isPackagedApp()` helper and routes all **load-time** platform checks through it, fixing a family of bugs where packaged apps (Electron, iOS, Android) behaved like the web build.

## Background

`isCordova()` is `!!window.cordova`, but `window.cordova` is **not defined at module-evaluation time**. Any top-level constant computed with `isCordova()` therefore gets the wrong (web) value in packaged builds, which are served over non-web schemes: Electron/Android `file://`, iOS `app://localhost`.

This caused a series of issues:
- **API base URL** → `file://api./…` (fixed in #2320)
- **Router** → `createBrowserHistory()` → **404 page after splash** (was #2321, superseded here)
- **Images** → absolute `/images/…` → **broken Cboard logo, welcome background, and About sponsor logos**

## Change

New helper in `src/cordova-util.js`:

```js
// Reliable at module-load time (unlike isCordova, which needs window.cordova):
export const isPackagedApp = () =>
  window.location.protocol !== 'http:' &&
  window.location.protocol !== 'https:';
```

Routed through it:
| File | Was | Now |
|---|---|---|
| `constants.js` | inline protocol check | `isPackagedApp()` → prod API |
| `history.js` | `isCordova()` | `isPackagedApp()` → hash history |
| `WelcomeScreen/CboardLogo/CboardLogo.component.js` | `isCordova()` | `isPackagedApp()` → relative logo paths |
| `WelcomeScreen/WelcomeScreen.container.js` | `isCordova()` | `isPackagedApp()` → relative background path |
| `Settings/About/About.component.js` | `isCordova()` | `isPackagedApp()` → relative sponsor paths |

`isCordova()` (and `isAndroid`/`isElectron`/`isIOS`) remain for **runtime** plugin/platform checks, which correctly run after `deviceready`.

## Behavior

- **Web (production/dev/qa)** — unchanged: `http`/`https` still derive `//api.<host>`, use browser history, and absolute asset paths.
- **Local web dev (`http://localhost`)** — unchanged: browser history + host-derived API (`REACT_APP_DEV_API_URL` still respected).
- **Packaged apps** — prod API, hash history, and relative asset paths, so logo/background/sponsor images load.

## Testing

- Repackaged Electron: loads past splash (no 404), backend reachable, logo/background/sponsor images render.
- Web bundle unchanged in behavior.

## Related

- Follow-up to #2320.
- **Supersedes #2321** (that history-only fix is included here, refactored onto the shared helper).