### PR TITLE
fix: resolve tile & board-thumbnail image paths in packaged apps (relative under file://)

### DIFF
--- a/src/components/Board/Symbol/Symbol.js
+++ b/src/components/Board/Symbol/Symbol.js
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { isCordova } from '../../../cordova-util';
+import { isPackagedApp } from '../../../cordova-util';
 import OutlinedInput from '@material-ui/core/OutlinedInput';
 import messages from '../Board.messages';
 
@@ -26,7 +26,7 @@ const propTypes = {
 };
 
 function formatSrc(src) {
-  return isCordova() && src?.startsWith('/') ? `.${src}` : src;
+  return isPackagedApp() && src?.startsWith('/') ? `.${src}` : src;
 }
 
 function Symbol(props) {

--- a/src/components/Communicator/CommunicatorDialog/CommunicatorDialogBoardItem.component.js
+++ b/src/components/Communicator/CommunicatorDialog/CommunicatorDialogBoardItem.component.js
@@ -36,7 +36,7 @@ import LanguageIcon from '@material-ui/icons/Language';
 import IconButton from '../../UI/IconButton';
 import { TAB_INDEXES } from './CommunicatorDialog.constants';
 import messages from './CommunicatorDialog.messages';
-import { isCordova } from '../../../cordova-util';
+import { isCordova, isPackagedApp } from '../../../cordova-util';
 import InputImage from '../../UI/InputImage';
 import SymbolSearch from '../../Board/SymbolSearch';
 import PremiumFeature from '../../PremiumFeature';
@@ -374,11 +374,11 @@ class CommunicatorDialogBoardItem extends React.Component {
       (selectedTab === TAB_INDEXES.COMMUNICATOR_BOARDS && !!userData.authToken);
     // Cordova path cannot be absolute
     const boardCaption =
-      isCordova() && board.caption && board.caption.search('/') === 0
+      isPackagedApp() && board.caption && board.caption.search('/') === 0
         ? `.${board.caption}`
         : board.caption;
     const imageBoard =
-      isCordova() &&
+      isPackagedApp() &&
       this.state.imageBoard &&
       this.state.imageBoard.search('/') === 0
         ? `.${this.state.imageBoard}`

--- a/src/components/Communicator/CommunicatorToolbar/CommunicatorToolbar.component.js
+++ b/src/components/Communicator/CommunicatorToolbar/CommunicatorToolbar.component.js
@@ -17,7 +17,7 @@ import AddCircleIcon from '@material-ui/icons/AddCircle';
 import FormDialog from '../../UI/FormDialog';
 import messages from './CommunicatorToolbar.messages';
 import './CommunicatorToolbar.css';
-import { isCordova } from '../../../cordova-util';
+import { isPackagedApp } from '../../../cordova-util';
 import DefaultBoardSelector from './DefaultBoardSelector';
 import SyncButton from './SyncButton';
 
@@ -96,7 +96,7 @@ class CommunicatorToolbar extends React.Component {
 
   boardCaption = (board) => {
     // Cordova path cannot be absolute
-    if (isCordova() && board.caption && board.caption.search('/') === 0) {
+    if (isPackagedApp() && board.caption && board.caption.search('/') === 0) {
       return `.${board.caption}`;
     } else {
       return board.caption;

--- a/src/components/Communicator/CommunicatorToolbar/DefaultBoardSelector/DefaultBoardOption.js
+++ b/src/components/Communicator/CommunicatorToolbar/DefaultBoardSelector/DefaultBoardOption.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { CardContent } from '@material-ui/core';
 import { Card, CardMedia, Typography } from '@material-ui/core';
 
-import { isCordova } from '../../../../cordova-util';
+import { isPackagedApp } from '../../../../cordova-util';
 import styles from './DefaultBoardSelector.module.css';
 
 import messages from '../CommunicatorToolbar.messages';
@@ -15,7 +15,7 @@ const DefaultBoardOption = ({ rootBoard, onClick, intl }) => {
 
   // Cordova path cannot be absolute
   const image =
-    isCordova() && rootBoard.caption && rootBoard.caption.search('/') === 0
+    isPackagedApp() && rootBoard.caption && rootBoard.caption.search('/') === 0
       ? `.${rootBoard.caption}`
       : rootBoard.caption;
 


### PR DESCRIPTION
## Problem

In the packaged apps (Electron/iOS/Android), some images don't render because they use **absolute** paths. Under `file://`, an absolute path resolves to the filesystem root instead of the app bundle:

```
GET file:///C:/symbols/mulberry/forwards.svg net::ERR_FILE_NOT_FOUND
```

This affected:
- **Tile symbol images** (`/symbols/…`)
- **Board caption / thumbnail images** in the Communicator (folder tiles, default-board selector)

## Root cause

The helpers that prefix absolute `/…` paths with `.` (so they resolve relative to the bundle) keyed off `isCordova()` (`!!window.cordova`), which is unreliable in packaged apps — `window.cordova` isn't guaranteed to be set when these render (e.g. `Symbol.formatSrc` runs in the component's initial `useState`). So the `.` isn't added and the absolute path 404s.

## Fix

Use `isPackagedApp()` (protocol-based, reliable at any time — introduced in #2322) for the image-path decisions:

| File | Change |
|---|---|
| `Board/Symbol/Symbol.js` | `formatSrc` → `isPackagedApp()` (tile symbols) |
| `Communicator/CommunicatorDialog/CommunicatorDialogBoardItem.component.js` | board caption + image thumbnails → `isPackagedApp()` |
| `Communicator/CommunicatorToolbar/CommunicatorToolbar.component.js` | board caption → `isPackagedApp()` |
| `Communicator/CommunicatorToolbar/DefaultBoardSelector/DefaultBoardOption.js` | root board caption → `isPackagedApp()` |

Runtime UI gates (e.g. `!isCordova()` to hide a control on native) are left on `isCordova()` — those correctly evaluate after `deviceready`.

## Behavior

- Packaged apps (`file://`, `app://localhost`): absolute symbol/caption paths become relative → images and thumbnails load.
- Web (`http`/`https`): unchanged — paths stay absolute.

## Related

Follow-up to #2322 (same `isCordova()`-timing class of bug, applied to image paths).