### PR TITLE
Upgrade Swiper to 12.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
         "reselect": "5.1.1",
         "shortid": "^2.2.17",
         "source-map-explorer": "^2.5.3",
-        "swiper": "12.1.4",
+        "swiper": "12.2.0",
         "yup": "^0.32.11"
       },
       "devDependencies": {
@@ -27739,9 +27739,9 @@
       }
     },
     "node_modules/swiper": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/swiper/-/swiper-12.1.4.tgz",
-      "integrity": "sha512-bihiwoKMOQwW8FfdUbo1DgkVH25E+4ZELIq0oopL1KTKBteLuaTMi/wwFjMxtlhTkk45k3XQ89D1Fvv0spSqBA==",
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-12.2.0.tgz",
+      "integrity": "sha512-K8uXsBZU6ME97Ia3xbBge8IRCnR1lOmIILzvY/jGVic7dSTQ530s3uO8RvXbPUtkkXLWIwmZLRPbtDxRWVAFdg==",
       "funding": [
         {
           "type": "custom",

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
         "reselect": "5.1.1",
         "shortid": "^2.2.17",
         "source-map-explorer": "^2.5.3",
-        "swiper": "12.1.2",
+        "swiper": "12.1.4",
         "yup": "^0.32.11"
       },
       "devDependencies": {
@@ -27739,17 +27739,17 @@
       }
     },
     "node_modules/swiper": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/swiper/-/swiper-12.1.2.tgz",
-      "integrity": "sha512-4gILrI3vXZqoZh71I1PALqukCFgk+gpOwe1tOvz5uE9kHtl2gTDzmYflYCwWvR4LOvCrJi6UEEU+gnuW5BtkgQ==",
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-12.1.4.tgz",
+      "integrity": "sha512-bihiwoKMOQwW8FfdUbo1DgkVH25E+4ZELIq0oopL1KTKBteLuaTMi/wwFjMxtlhTkk45k3XQ89D1Fvv0spSqBA==",
       "funding": [
         {
-          "type": "patreon",
-          "url": "https://www.patreon.com/swiperjs"
+          "type": "custom",
+          "url": "https://sponsors.nolimits4web.com"
         },
         {
-          "type": "open_collective",
-          "url": "http://opencollective.com/swiper"
+          "type": "github",
+          "url": "https://github.com/sponsors/nolimits4web"
         }
       ],
       "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
         "reselect": "5.1.1",
         "shortid": "^2.2.17",
         "source-map-explorer": "^2.5.3",
-        "swiper": "^6.8.4",
+        "swiper": "12.1.2",
         "yup": "^0.32.11"
       },
       "devDependencies": {
@@ -11028,15 +11028,6 @@
       },
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/dom7": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/dom7/-/dom7-3.0.0.tgz",
-      "integrity": "sha512-oNlcUdHsC4zb7Msx7JN3K0Nro1dzJ48knvBOnDPKJ2GV9wl1i5vydJZUSyOfrkKFDZEud/jBsTk92S/VGSAe/g==",
-      "license": "MIT",
-      "dependencies": {
-        "ssr-window": "^3.0.0-alpha.1"
       }
     },
     "node_modules/domain-browser": {
@@ -26369,12 +26360,6 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/ssr-window": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-3.0.0.tgz",
-      "integrity": "sha512-q+8UfWDg9Itrg0yWK7oe5p/XRCJpJF9OBtXfOPgSJl+u3Xd5KI328RUEvUqSMVM9CiQUEf1QdBzJMkYGErj9QA==",
-      "license": "MIT"
-    },
     "node_modules/stable": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
@@ -27754,25 +27739,20 @@
       }
     },
     "node_modules/swiper": {
-      "version": "6.8.4",
-      "resolved": "https://registry.npmjs.org/swiper/-/swiper-6.8.4.tgz",
-      "integrity": "sha512-O+buF9Q+sMA0H7luMS8R59hCaJKlpo8PXhQ6ZYu6Rn2v9OsFd4d1jmrv14QvxtQpKAvL/ZiovEeANI/uDGet7g==",
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-12.1.2.tgz",
+      "integrity": "sha512-4gILrI3vXZqoZh71I1PALqukCFgk+gpOwe1tOvz5uE9kHtl2gTDzmYflYCwWvR4LOvCrJi6UEEU+gnuW5BtkgQ==",
       "funding": [
         {
           "type": "patreon",
-          "url": "https://www.patreon.com/vladimirkharlampidi"
+          "url": "https://www.patreon.com/swiperjs"
         },
         {
           "type": "open_collective",
           "url": "http://opencollective.com/swiper"
         }
       ],
-      "hasInstallScript": true,
       "license": "MIT",
-      "dependencies": {
-        "dom7": "^3.0.0",
-        "ssr-window": "^3.0.0"
-      },
       "engines": {
         "node": ">= 4.7.0"
       }

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "reselect": "5.1.1",
     "shortid": "^2.2.17",
     "source-map-explorer": "^2.5.3",
-    "swiper": "12.1.4",
+    "swiper": "12.2.0",
     "yup": "^0.32.11"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "reselect": "5.1.1",
     "shortid": "^2.2.17",
     "source-map-explorer": "^2.5.3",
-    "swiper": "^6.8.4",
+    "swiper": "12.1.2",
     "yup": "^0.32.11"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "reselect": "5.1.1",
     "shortid": "^2.2.17",
     "source-map-explorer": "^2.5.3",
-    "swiper": "12.1.2",
+    "swiper": "12.1.4",
     "yup": "^0.32.11"
   },
   "devDependencies": {

--- a/src/components/Board/SymbolSearch/SymbolSearchTour.component.js
+++ b/src/components/Board/SymbolSearch/SymbolSearchTour.component.js
@@ -3,14 +3,8 @@ import PropTypes from 'prop-types';
 import Joyride, { STATUS } from 'react-joyride';
 import messages from './SymbolSearch.messages';
 import { FormattedMessage, intlShape } from 'react-intl';
-import SwiperCore, { Navigation, Pagination, Autoplay } from 'swiper/core';
-import 'swiper/swiper.min.css';
-import 'swiper/components/navigation/navigation.min.css';
-import 'swiper/components/pagination/pagination.min.css';
 
 import './SymbolSearch.css';
-
-SwiperCore.use([Navigation, Pagination, Autoplay]);
 
 const propTypes = {
   isSymbolSearchTourEnabled: PropTypes.bool.isRequired,

--- a/src/components/Settings/Settings.css
+++ b/src/components/Settings/Settings.css
@@ -90,7 +90,7 @@
   left: 50%;
 }
 
-.swiper-container {
+.swiper {
   width: 100%;
   height: 100%;
 }

--- a/src/components/Settings/SettingsTour.component.js
+++ b/src/components/Settings/SettingsTour.component.js
@@ -4,15 +4,15 @@ import Joyride, { STATUS } from 'react-joyride';
 import messages from './Settings.messages';
 import { FormattedMessage, intlShape } from 'react-intl';
 import { Swiper, SwiperSlide } from 'swiper/react';
-import SwiperCore, { Navigation, Pagination, Autoplay } from 'swiper/core';
-import 'swiper/swiper.min.css';
-import 'swiper/components/navigation/navigation.min.css';
-import 'swiper/components/pagination/pagination.min.css';
+import { Navigation, Pagination, Autoplay } from 'swiper/modules';
+import 'swiper/css';
+import 'swiper/css/navigation';
+import 'swiper/css/pagination';
 
 import './Settings.css';
 import { isCordova } from '../../cordova-util';
 
-SwiperCore.use([Navigation, Pagination, Autoplay]);
+const swiperModules = [Navigation, Pagination, Autoplay];
 
 const propTypes = {
   isSettingsTourEnabled: PropTypes.bool.isRequired,
@@ -180,6 +180,7 @@ function SettingsTour({ intl, disableTour, isSettingsTourEnabled }) {
             {tooltipSwiperText.title}
           </h2>
           <Swiper
+            modules={swiperModules}
             navigation={true}
             pagination={true}
             autoplay={{
@@ -219,6 +220,7 @@ function SettingsTour({ intl, disableTour, isSettingsTourEnabled }) {
             {tooltipSwiperText.title}
           </h2>
           <Swiper
+            modules={swiperModules}
             watchOverflow={true}
             onSlideChange={(swiper) => {
               handleOnSlideChange('scanning', swiper.realIndex);
@@ -255,6 +257,7 @@ function SettingsTour({ intl, disableTour, isSettingsTourEnabled }) {
             {tooltipSwiperText.title}
           </h2>
           <Swiper
+            modules={swiperModules}
             navigation={true}
             pagination={true}
             autoplay={{

--- a/tests/unlogged/settings/tour.spec.js
+++ b/tests/unlogged/settings/tour.spec.js
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Cboard - Settings Tour', () => {
+  test('should render and navigate every settings carousel', async ({
+    page
+  }) => {
+    const pageErrors = [];
+    page.on('pageerror', (error) => pageErrors.push(error.message));
+
+    await page.goto('/settings', { waitUntil: 'domcontentloaded' });
+
+    await expect(
+      page.getByRole('heading', { name: 'Welcome to the settings!' })
+    ).toBeVisible();
+
+    const nextTourStep = page.locator('[data-test-id="button-primary"]');
+    for (let step = 0; step < 5; step += 1) {
+      await nextTourStep.click();
+    }
+
+    const activeSwiper = page.locator('.swiper:visible');
+    await expect(activeSwiper).toHaveClass(/swiper-initialized/);
+    await expect(activeSwiper).toHaveCSS('width', /[1-9]\d*(\.\d+)?px/);
+    await expect(activeSwiper.locator('.swiper-slide')).toHaveCount(5);
+    await expect(activeSwiper.locator('.swiper-slide-active')).toHaveCount(1);
+    await expect(activeSwiper.locator('.swiper-pagination-bullet')).toHaveCount(
+      5
+    );
+    await expect(activeSwiper.locator('.swiper-button-next svg')).toBeVisible();
+
+    const firstImageAlt = await activeSwiper
+      .locator('.swiper-slide-active img')
+      .getAttribute('alt');
+    await expect
+      .poll(
+        () =>
+          activeSwiper.locator('.swiper-slide-active img').getAttribute('alt'),
+        { timeout: 6000 }
+      )
+      .not.toBe(firstImageAlt);
+
+    await nextTourStep.click();
+    await expect(activeSwiper.locator('.swiper-slide')).toHaveCount(1);
+    await expect(activeSwiper.locator('.swiper-slide-active')).toHaveCount(1);
+
+    await nextTourStep.click();
+    await expect(activeSwiper.locator('.swiper-slide')).toHaveCount(4);
+    await expect(activeSwiper.locator('.swiper-pagination-bullet')).toHaveCount(
+      4
+    );
+    await expect(activeSwiper.locator('.swiper-button-next svg')).toBeVisible();
+
+    const firstNavigationImageAlt = await activeSwiper
+      .locator('.swiper-slide-active img')
+      .getAttribute('alt');
+    await activeSwiper.locator('.swiper-button-next').click();
+    await expect
+      .poll(() =>
+        activeSwiper.locator('.swiper-slide-active img').getAttribute('alt')
+      )
+      .not.toBe(firstNavigationImageAlt);
+
+    expect(pageErrors).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

Upgrade Swiper 6.8.4 → 12.1.2 and apply only the required React module, CSS import, and container-class migrations. Remove dead Swiper setup from `SymbolSearchTour` and add focused carousel coverage.

## Why

Moves Cboard off the vulnerable v6 line. Cboard only uses Navigation, Pagination, and Autoplay—no loop, virtual, lazy, or Swiper Element APIs—so the migration stays intentionally narrow.

## Confidence

High: production and Cordova builds pass; Settings tests pass (19/19); the new tour test passes on Chromium and Pixel 5, covering initialization, layout, pagination, SVG navigation, autoplay, callbacks, and runtime errors. Browser CI remains the final cross-browser signal; Swiper 10+ targets iOS 15+.