### PR TITLE
refactor(util): Determine isCordova reliably at module load time

### DIFF
--- a/src/components/Account/Login/Login.actions.test.js
+++ b/src/components/Account/Login/Login.actions.test.js
@@ -15,7 +15,16 @@ jest.mock('../../../appInsights', () => ({
   }
 }));
 
+// isCordova is now derived from the URL protocol at module load, so window.cordova
+// no longer toggles it. Mock the util to drive the packaged-app branches in tests.
+jest.mock('../../../cordova-util', () => ({
+  ...jest.requireActual('../../../cordova-util'),
+  isCordova: jest.fn(() => false),
+  isElectron: jest.fn(() => false)
+}));
+
 const { appInsights } = require('../../../appInsights');
+const cordovaUtil = require('../../../cordova-util');
 
 const mockBoard = {
   name: 'tewt',
@@ -385,8 +394,8 @@ it('should set google analytics user id after login - WEB', async () => {
 });
 
 it('should set google analytics user id after login - ANDROID IOS', async () => {
-  window.cordova = jest.fn(() => true);
-  window.cordova.platformId = 'notElectron';
+  cordovaUtil.isCordova.mockReturnValue(true);
+  cordovaUtil.isElectron.mockReturnValue(false);
   window.FirebasePlugin = {
     setUserId: jest.fn(),
     logEvent: jest.fn()
@@ -397,6 +406,8 @@ it('should set google analytics user id after login - ANDROID IOS', async () => 
 
   await store.dispatch(actions.login(user, 'local'));
   expect(window.FirebasePlugin.setUserId).toHaveBeenCalledWith(userData.id);
+
+  cordovaUtil.isCordova.mockReturnValue(false);
 });
 
 it('should set App Insights authenticated user context with the user id on login', async () => {

--- a/src/cordova-util.js
+++ b/src/cordova-util.js
@@ -4,7 +4,9 @@
 export const isPackagedApp = () =>
   window.location.protocol !== 'http:' && window.location.protocol !== 'https:';
 
-export const isCordova = isPackagedApp();
+const IS_PACKAGED_APP = isPackagedApp();
+
+export const isCordova = () => IS_PACKAGED_APP;
 
 export const isAndroid = () =>
   isCordova() && window.cordova.platformId === 'android';

--- a/src/cordova-util.js
+++ b/src/cordova-util.js
@@ -1,4 +1,10 @@
-export const isCordova = () => !!window.cordova;
+// Reliable at module-load time.
+// Packaged apps are served over a non-web scheme (Electron and
+// Android file://, iOS app://localhost).
+export const isPackagedApp = () =>
+  window.location.protocol !== 'http:' && window.location.protocol !== 'https:';
+
+export const isCordova = isPackagedApp();
 
 export const isAndroid = () =>
   isCordova() && window.cordova.platformId === 'android';
@@ -7,12 +13,6 @@ export const isElectron = () =>
   isCordova() && window.cordova.platformId === 'electron';
 
 export const isIOS = () => isCordova() && window.cordova.platformId === 'ios';
-
-// Reliable at module-load time (unlike isCordova, which needs window.cordova to
-// be set first): packaged apps are served over a non-web scheme (Electron and
-// Android file://, iOS app://localhost).
-export const isPackagedApp = () =>
-  window.location.protocol !== 'http:' && window.location.protocol !== 'https:';
 
 export const onCordovaReady = (onReady) =>
   document.addEventListener('deviceready', onReady, false);

--- a/src/cordova-util.js
+++ b/src/cordova-util.js
@@ -8,13 +8,15 @@ const IS_PACKAGED_APP = isPackagedApp();
 
 export const isCordova = () => IS_PACKAGED_APP;
 
+// window.cordova may not be set yet even when isCordova() is true (before
+// deviceready), so guard the platformId access.
 export const isAndroid = () =>
-  isCordova() && window.cordova.platformId === 'android';
+  isCordova() && window.cordova?.platformId === 'android';
 
 export const isElectron = () =>
-  isCordova() && window.cordova.platformId === 'electron';
+  isCordova() && window.cordova?.platformId === 'electron';
 
-export const isIOS = () => isCordova() && window.cordova.platformId === 'ios';
+export const isIOS = () => isCordova() && window.cordova?.platformId === 'ios';
 
 export const onCordovaReady = (onReady) =>
   document.addEventListener('deviceready', onReady, false);


### PR DESCRIPTION
Previously, `isCordova` was a function that relied on `window.cordova` being available, which might not be the case immediately at module load time.

By setting `isCordova` as a constant derived from `isPackagedApp()`, its value is now reliably available the moment the module loads, leveraging the `window.location.protocol` check.
