### PR TITLE
feat(cordova): Support eye control in packaged apps

### DIFF
--- a/src/cordova-util.js
+++ b/src/cordova-util.js
@@ -347,6 +347,34 @@ export const requestCvaWritePermissions = () => {
   }
 };
 
+// getUserMedia video inside the Android WebView is denied unless the app holds
+// the runtime CAMERA permission, and unlike the browser it never shows a native
+// prompt on its own. Request it explicitly before starting eye control.
+// Resolves to true when the camera may be used (web/iOS handle their own prompt).
+export const requestCvaCameraPermission = async () => {
+  if (!isAndroid()) return true;
+
+  const permissions = window.cordova?.plugins?.permissions;
+  if (!permissions) return true;
+
+  const hasCameraPermission = await new Promise((resolve) => {
+    permissions.checkPermission(
+      permissions.CAMERA,
+      (status) => resolve(!!status.hasPermission),
+      () => resolve(false)
+    );
+  });
+  if (hasCameraPermission) return true;
+
+  return new Promise((resolve) => {
+    permissions.requestPermission(
+      permissions.CAMERA,
+      (status) => resolve(!!status.hasPermission),
+      () => resolve(false)
+    );
+  });
+};
+
 export const requestCvaPermissions = async () => {
   if (isAndroid()) {
     var permissions = window.cordova.plugins.permissions;

--- a/src/providers/GazeSwitchProvider/GazeController.js
+++ b/src/providers/GazeSwitchProvider/GazeController.js
@@ -12,6 +12,7 @@
  */
 
 import { FaceLandmarker, FilesetResolver } from '@mediapipe/tasks-vision';
+import { isPackagedApp } from '../../cordova-util';
 
 // WASM runtime and model are self-hosted under public/mediapipe so the feature
 // works offline and inside the Cordova-packaged app (no CDN, no cross-origin
@@ -19,6 +20,28 @@ import { FaceLandmarker, FilesetResolver } from '@mediapipe/tasks-vision';
 const ASSET_BASE = `${process.env.PUBLIC_URL || ''}/mediapipe`;
 const WASM_BASE_URL = `${ASSET_BASE}/wasm`;
 const FACE_MODEL_URL = `${ASSET_BASE}/face_landmarker.task`;
+
+// Packaged apps serve assets over file:// (Android) or other non-web schemes
+// that the Fetch API refuses, so MediaPipe's default fetch-based asset loading
+// fails. XMLHttpRequest can still read the bundled files, so load them as
+// ArrayBuffers and hand MediaPipe a blob URL / in-memory buffer instead.
+function loadArrayBuffer(url) {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open('GET', url, true);
+    xhr.responseType = 'arraybuffer';
+    xhr.onload = () => {
+      // file:// responses report status 0 on success.
+      if (xhr.status === 0 || (xhr.status >= 200 && xhr.status < 300)) {
+        resolve(xhr.response);
+      } else {
+        reject(new Error(`Failed to load ${url} (status ${xhr.status})`));
+      }
+    };
+    xhr.onerror = () => reject(new Error(`Failed to load ${url}`));
+    xhr.send();
+  });
+}
 
 export const GAZE_STATUS = {
   IDLE: 'idle',
@@ -50,6 +73,8 @@ export default class GazeController {
     this.faceLandmarker = null;
     this.rafId = null;
     this.lastVideoTime = -1;
+    this.modelAssetBuffer = null;
+    this._blobUrls = [];
 
     this.status = GAZE_STATUS.IDLE;
     this.eyesClosedSince = null;
@@ -82,6 +107,18 @@ export default class GazeController {
       const filesetResolver =
         await FilesetResolver.forVisionTasks(WASM_BASE_URL);
 
+      if (isPackagedApp()) {
+        filesetResolver.wasmBinaryPath = await this._toBlobUrl(
+          filesetResolver.wasmBinaryPath,
+          'application/wasm'
+        );
+        if (!this.modelAssetBuffer) {
+          this.modelAssetBuffer = new Uint8Array(
+            await loadArrayBuffer(FACE_MODEL_URL)
+          );
+        }
+      }
+
       this.faceLandmarker = await this._createLandmarker(filesetResolver);
 
       this.stream = await navigator.mediaDevices.getUserMedia({
@@ -102,8 +139,11 @@ export default class GazeController {
   // Prefer the GPU (WebGL) delegate; fall back to CPU where GPU is unavailable
   // (some packaged WebViews), so init doesn't hard-fail.
   async _createLandmarker(filesetResolver) {
+    const modelAsset = this.modelAssetBuffer
+      ? { modelAssetBuffer: this.modelAssetBuffer }
+      : { modelAssetPath: FACE_MODEL_URL };
     const options = (delegate) => ({
-      baseOptions: { modelAssetPath: FACE_MODEL_URL, delegate },
+      baseOptions: { ...modelAsset, delegate },
       outputFaceBlendshapes: true,
       runningMode: 'VIDEO',
       numFaces: 1
@@ -117,6 +157,13 @@ export default class GazeController {
     } catch (gpuErr) {
       return FaceLandmarker.createFromOptions(filesetResolver, options('CPU'));
     }
+  }
+
+  async _toBlobUrl(url, type) {
+    const buffer = await loadArrayBuffer(url);
+    const blobUrl = URL.createObjectURL(new Blob([buffer], { type }));
+    this._blobUrls.push(blobUrl);
+    return blobUrl;
   }
 
   stop() {
@@ -139,6 +186,8 @@ export default class GazeController {
     if (this.video) {
       this.video.srcObject = null;
     }
+    this._blobUrls.forEach((blobUrl) => URL.revokeObjectURL(blobUrl));
+    this._blobUrls = [];
     this.eyesClosedSince = null;
     this.triggeredThisClosure = false;
     this.lastVideoTime = -1;

--- a/src/providers/GazeSwitchProvider/GazeSwitchProvider.component.js
+++ b/src/providers/GazeSwitchProvider/GazeSwitchProvider.component.js
@@ -96,8 +96,13 @@ class GazeSwitchProvider extends React.Component {
   async startController() {
     if (this.videoRef.current) {
       // Android WebView needs the runtime CAMERA permission before getUserMedia;
-      // it never prompts on its own like the browser does.
-      await requestCvaCameraPermission();
+      // it never prompts on its own like the browser does. Skip the expensive
+      // MediaPipe init when permission is denied, since getUserMedia would fail.
+      const hasCameraPermission = await requestCvaCameraPermission();
+      if (!hasCameraPermission) {
+        this.setState({ status: GAZE_STATUS.ERROR });
+        return;
+      }
       this.controller.start(this.videoRef.current);
     }
   }

--- a/src/providers/GazeSwitchProvider/GazeSwitchProvider.component.js
+++ b/src/providers/GazeSwitchProvider/GazeSwitchProvider.component.js
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import { FormattedMessage } from 'react-intl';
 
 import GazeController, { GAZE_STATUS } from './GazeController';
+import { requestCvaCameraPermission } from '../../cordova-util';
 import messages from './GazeSwitchProvider.messages';
 import './GazeSwitchProvider.css';
 
@@ -92,8 +93,11 @@ class GazeSwitchProvider extends React.Component {
     return { blinkThreshold, dwellMs, cooldownMs };
   }
 
-  startController() {
+  async startController() {
     if (this.videoRef.current) {
+      // Android WebView needs the runtime CAMERA permission before getUserMedia;
+      // it never prompts on its own like the browser does.
+      await requestCvaCameraPermission();
       this.controller.start(this.videoRef.current);
     }
   }


### PR DESCRIPTION
MediaPipe's WebAssembly and model assets fail to load in Cordova-packaged applications due to their use of file:// or other non-HTTP schemes, which prevent the Fetch API from working. This change switches to XMLHttpRequest and blob URLs for asset loading in packaged environments.

Additionally, Android WebViews do not automatically prompt for CAMERA permission, which getUserMedia requires for video access. Explicitly request this permission before starting eye control.
